### PR TITLE
修复全屏显示状态栏

### DIFF
--- a/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/layout/Fullscreen.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/layout/Fullscreen.android.kt
@@ -146,6 +146,7 @@ actual fun Context.setSystemBarVisible(visible: Boolean) {
                         or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN // Hide the nav bar and status bar
                         or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                         or View.SYSTEM_UI_FLAG_FULLSCREEN)
+            this.window.addFlags(android.view.WindowManager.LayoutParams.FLAG_FULLSCREEN)
         }
     }
 }


### PR DESCRIPTION
fix #1074 , fix #570

work on 4.14.116 HarmonyOs(Android 10), Android 8