### PR TITLE
添加禁用字幕选项

### DIFF
--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/SubtitleSwitcher.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/SubtitleSwitcher.kt
@@ -90,7 +90,7 @@ fun PlayerControllerDefaults.SubtitleSwitcher(
         optionsProvider = { options },
         renderValue = {
             if (it == null) {
-                Text("自动")
+                Text("关闭")
             } else {
                 Text(it.displayName, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }

--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -451,6 +451,7 @@ class VlcjVideoPlayerState(parentCoroutineContext: CoroutineContext) : PlayerSta
                     listOf(Label(null, it.description())),
                 )
             }
+        subtitleTracks.current.value = subtitleTracks.candidates.value.firstOrNull()
     }
 
     private fun reloadAudioTracks() {


### PR DESCRIPTION
resolve #1107 

将 `自动` 选项改成 `关闭` 选项
自动选取字幕列表的首个字幕