### PR TITLE
Async RPC call of Android Binder

### DIFF
--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteAniTorrentEngine.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteAniTorrentEngine.aidl
@@ -2,9 +2,9 @@
 package me.him188.ani.app.domain.torrent;
 
 import me.him188.ani.app.domain.torrent.IRemoteTorrentDownloader;
-import me.him188.ani.app.domain.torrent.IAnitorrentConfigCollector;
-import me.him188.ani.app.domain.torrent.IProxySettingsCollector;
-import me.him188.ani.app.domain.torrent.ITorrentPeerConfigCollector;
+import me.him188.ani.app.domain.torrent.collector.IAnitorrentConfigCollector;
+import me.him188.ani.app.domain.torrent.collector.IProxySettingsCollector;
+import me.him188.ani.app.domain.torrent.collector.ITorrentPeerConfigCollector;
 
 // Declare any non-default types here with import statements
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentDownloader.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentDownloader.aidl
@@ -2,6 +2,8 @@
 package me.him188.ani.app.domain.torrent;
 
 import me.him188.ani.app.domain.torrent.callback.ITorrentDownloaderStatsCallback;
+import me.him188.ani.app.domain.torrent.cont.ContTorrentDownloaderFetchTorrent;
+import me.him188.ani.app.domain.torrent.cont.ContTorrentDownloaderStartDownload;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;
 import me.him188.ani.app.domain.torrent.parcel.PTorrentLibInfo;
@@ -14,9 +16,9 @@ interface IRemoteTorrentDownloader {
     
     PTorrentLibInfo getVendor();
     
-    PEncodedTorrentInfo fetchTorrent(in String uri, int timeoutSeconds);
+    IDisposableHandle fetchTorrent(in String uri, int timeoutSeconds, in ContTorrentDownloaderFetchTorrent cont);
     
-    IRemoteTorrentSession startDownload(in PEncodedTorrentInfo data, in String overrideSaveDir);
+    IDisposableHandle startDownload(in PEncodedTorrentInfo data, in String overrideSaveDir, in ContTorrentDownloaderStartDownload cont);
     
     String getSaveDirForTorrent(in PEncodedTorrentInfo data);
     

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentDownloader.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentDownloader.aidl
@@ -1,7 +1,7 @@
 // IRemoteTorrentDownloader.aidl
 package me.him188.ani.app.domain.torrent;
 
-import me.him188.ani.app.domain.torrent.ITorrentDownloaderStatsCallback;
+import me.him188.ani.app.domain.torrent.callback.ITorrentDownloaderStatsCallback;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;
 import me.him188.ani.app.domain.torrent.parcel.PTorrentLibInfo;

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentFileEntry.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentFileEntry.aidl
@@ -1,7 +1,7 @@
 // IRemoteTorrentFileEntry.aidl
 package me.him188.ani.app.domain.torrent;
 
-import me.him188.ani.app.domain.torrent.ITorrentFileEntryStatsCallback;
+import me.him188.ani.app.domain.torrent.callback.ITorrentFileEntryStatsCallback;
 import me.him188.ani.app.domain.torrent.IRemotePieceList;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentFileEntry.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentFileEntry.aidl
@@ -2,6 +2,8 @@
 package me.him188.ani.app.domain.torrent;
 
 import me.him188.ani.app.domain.torrent.callback.ITorrentFileEntryStatsCallback;
+import me.him188.ani.app.domain.torrent.cont.ContTorrentFileEntryGetInputParams;
+import me.him188.ani.app.domain.torrent.cont.ContTorrentFileEntryResolveFile;
 import me.him188.ani.app.domain.torrent.IRemotePieceList;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;
@@ -22,11 +24,11 @@ interface IRemoteTorrentFileEntry {
 	
 	IRemoteTorrentFileHandle createHandle();
 	
-	String resolveFile();
+	IDisposableHandle resolveFile(in ContTorrentFileEntryResolveFile cont);
 	
 	String resolveFileMaybeEmptyOrNull();
 	
-	PTorrentInputParameter getTorrentInputParams();
+	IDisposableHandle getTorrentInputParams(in ContTorrentFileEntryGetInputParams cont);
 	
 	void torrentInputOnWait(int pieceIndex);
 }

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentSession.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentSession.aidl
@@ -2,6 +2,7 @@
 package me.him188.ani.app.domain.torrent;
 
 import me.him188.ani.app.domain.torrent.callback.ITorrentSessionStatsCallback;
+import me.him188.ani.app.domain.torrent.cont.ContTorrentSessionGetFiles;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList;
 import me.him188.ani.app.domain.torrent.parcel.PPeerInfo;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;
@@ -13,7 +14,7 @@ interface IRemoteTorrentSession {
     
     String getName();
     
-    IRemoteTorrentFileEntryList getFiles();
+    IDisposableHandle getFiles(in ContTorrentSessionGetFiles cont);
     
     PPeerInfo[] getPeers();
     

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentSession.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/IRemoteTorrentSession.aidl
@@ -1,7 +1,7 @@
 // IRemoteTorrentSession.aidl
 package me.him188.ani.app.domain.torrent;
 
-import me.him188.ani.app.domain.torrent.ITorrentSessionStatsCallback;
+import me.him188.ani.app.domain.torrent.callback.ITorrentSessionStatsCallback;
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList;
 import me.him188.ani.app.domain.torrent.parcel.PPeerInfo;
 import me.him188.ani.app.domain.torrent.IDisposableHandle;

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentDownloaderStatsCallback.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentDownloaderStatsCallback.aidl
@@ -1,5 +1,5 @@
 // ITorrentDownloaderStatsCallback.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.callback;
 
 import me.him188.ani.app.domain.torrent.parcel.PTorrentDownloaderStats;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentFileEntryStatsCallback.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentFileEntryStatsCallback.aidl
@@ -1,5 +1,5 @@
 // ITorrentFileEntryStatsCallback.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.callback;
 
 import me.him188.ani.app.domain.torrent.parcel.PTorrentFileEntryStats;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentSessionStatsCallback.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/callback/ITorrentSessionStatsCallback.aidl
@@ -1,5 +1,5 @@
 // ITorrentSessionStatsCallback.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.callback;
 
 import me.him188.ani.app.domain.torrent.parcel.PTorrentSessionStats;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/IAnitorrentConfigCollector.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/IAnitorrentConfigCollector.aidl
@@ -1,5 +1,5 @@
 // IAnitorrentConfigCollector.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.collector;
 
 import me.him188.ani.app.domain.torrent.parcel.PAnitorrentConfig;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/IProxySettingsCollector.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/IProxySettingsCollector.aidl
@@ -1,5 +1,5 @@
 // IProxySettingsCollector.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.collector;
 
 import me.him188.ani.app.domain.torrent.parcel.PProxySettings;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/ITorrentPeerConfigCollector.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/collector/ITorrentPeerConfigCollector.aidl
@@ -1,5 +1,5 @@
 // ITorrentPeerConfigCollector.aidl
-package me.him188.ani.app.domain.torrent;
+package me.him188.ani.app.domain.torrent.collector;
 
 import me.him188.ani.app.domain.torrent.parcel.PTorrentPeerConfig;
 

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentDownloaderFetchTorrent.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentDownloaderFetchTorrent.aidl
@@ -1,0 +1,12 @@
+// ContTorrentDownloaderFetchTorrent.aidl
+package me.him188.ani.app.domain.torrent.cont;
+
+import me.him188.ani.app.domain.torrent.parcel.PEncodedTorrentInfo;
+import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException;
+
+// Declare any non-default types here with import statements
+
+interface ContTorrentDownloaderFetchTorrent {
+    void resume(in PEncodedTorrentInfo value);
+    void resumeWithException(in RemoteContinuationException exception);
+}

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentDownloaderStartDownload.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentDownloaderStartDownload.aidl
@@ -1,0 +1,12 @@
+// ContTorrentDownloaderStartDownload.aidl
+package me.him188.ani.app.domain.torrent.cont;
+
+import me.him188.ani.app.domain.torrent.IRemoteTorrentSession;
+import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException;
+
+// Declare any non-default types here with import statements
+
+interface ContTorrentDownloaderStartDownload {
+    void resume(in IRemoteTorrentSession value);
+    void resumeWithException(in RemoteContinuationException exception);
+}

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentFileEntryGetInputParams.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentFileEntryGetInputParams.aidl
@@ -1,0 +1,12 @@
+// ContTorrentFileEntryGetInputParams.aidl
+package me.him188.ani.app.domain.torrent.cont;
+
+import me.him188.ani.app.domain.torrent.parcel.PTorrentInputParameter;
+import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException;
+
+// Declare any non-default types here with import statements
+
+interface ContTorrentFileEntryGetInputParams {
+    void resume(in PTorrentInputParameter value);
+    void resumeWithException(in RemoteContinuationException exception);
+}

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentFileEntryResolveFile.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentFileEntryResolveFile.aidl
@@ -1,0 +1,12 @@
+// ContTorrentFileEntryResolveFile.aidl
+package me.him188.ani.app.domain.torrent.cont;
+
+import me.him188.ani.app.domain.torrent.parcel.PTorrentInputParameter;
+import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException;
+
+// Declare any non-default types here with import statements
+
+interface ContTorrentFileEntryResolveFile {
+    void resume(in String value);
+    void resumeWithException(in RemoteContinuationException exception);
+}

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentSessionGetFiles.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/cont/ContTorrentSessionGetFiles.aidl
@@ -1,0 +1,12 @@
+// ContTorrentSessionGetFiles.aidl
+package me.him188.ani.app.domain.torrent.cont;
+
+import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList;
+import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException;
+
+// Declare any non-default types here with import statements
+
+interface ContTorrentSessionGetFiles {
+    void resume(in IRemoteTorrentFileEntryList value);
+    void resumeWithException(in RemoteContinuationException exception);
+}

--- a/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/parcel/RemoteContinuationException.aidl
+++ b/app/shared/app-data/src/androidMain/aidl/me/him188/ani/app/domain/torrent/parcel/RemoteContinuationException.aidl
@@ -1,0 +1,4 @@
+// RemoteContinuationException.aidl
+package me.him188.ani.app.domain.torrent.parcel;
+
+parcelable RemoteContinuationException;

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
@@ -98,7 +98,7 @@ class RemoteAnitorrentEngine(
     }
     
     override suspend fun getDownloader(): TorrentDownloader {
-        return RemoteTorrentDownloader(childScope, connectivityAware) {
+        return RemoteTorrentDownloader(connectivityAware) {
             runBlocking { getBinderOrFail() }.downlaoder
         }
     }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
@@ -98,7 +98,7 @@ class RemoteAnitorrentEngine(
     }
     
     override suspend fun getDownloader(): TorrentDownloader {
-        return RemoteTorrentDownloader(connectivityAware) {
+        return RemoteTorrentDownloader(childScope, connectivityAware) {
             runBlocking { getBinderOrFail() }.downlaoder
         }
     }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
@@ -107,7 +107,7 @@ class RemoteAnitorrentEngine(
     override suspend fun getDownloader(): TorrentDownloader {
         return RemoteTorrentDownloader(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) { getBinderOrFail().downlaoder },
+            RetryRemoteObject(fetchRemoteScope) { getBinderOrFail().downlaoder },
             connectivityAware,
         )
     }
@@ -127,7 +127,7 @@ class RemoteAnitorrentEngine(
         crossinline transact: I.(String) -> Unit
     ) = scope.launch {
         val stateFlow = settingsFlow.stateIn(this)
-        val remoteCall = RetryRemoteCall(fetchRemoteScope) { getBinder() }
+        val remoteCall = RetryRemoteObject(fetchRemoteScope) { getBinder() }
 
         connection.connected
             .filter { it }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
@@ -105,7 +105,11 @@ class RemoteAnitorrentEngine(
     }
     
     override suspend fun getDownloader(): TorrentDownloader {
-        return RemoteTorrentDownloader(fetchRemoteScope, connectivityAware) { getBinderOrFail().downlaoder }
+        return RemoteTorrentDownloader(
+            fetchRemoteScope,
+            RetryRemoteCall(fetchRemoteScope) { getBinderOrFail().downlaoder },
+            connectivityAware,
+        )
     }
 
     private suspend fun getBinderOrFail(): IRemoteAniTorrentEngine {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteAnitorrentEngine.kt
@@ -12,6 +12,8 @@ package me.him188.ani.app.domain.torrent.client
 import android.os.Build
 import android.os.IInterface
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -20,7 +22,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
 import me.him188.ani.app.data.models.preference.ProxySettings
@@ -34,6 +35,7 @@ import me.him188.ani.app.domain.torrent.parcel.PTorrentPeerConfig
 import me.him188.ani.app.domain.torrent.service.TorrentServiceConnection
 import me.him188.ani.app.torrent.api.TorrentDownloader
 import me.him188.ani.datasources.api.source.MediaSourceLocation
+import me.him188.ani.utils.coroutines.IO_
 import me.him188.ani.utils.coroutines.childScope
 import me.him188.ani.utils.coroutines.onReplacement
 import me.him188.ani.utils.io.SystemPath
@@ -50,8 +52,13 @@ class RemoteAnitorrentEngine(
     saveDir: SystemPath,
     parentCoroutineContext: CoroutineContext,
 ) : TorrentEngine {
-    private val childScope = parentCoroutineContext.childScope()
     private val logger = logger<RemoteAnitorrentEngine>()
+
+    private val scope = parentCoroutineContext.childScope()
+    private val fetchRemoteScope = parentCoroutineContext.childScope(
+        CoroutineName("RemoteAnitorrentEngineFetchRemote") + Dispatchers.IO_,
+    )
+    
     private val connectivityAware = DefaultConnectivityAware(
         parentCoroutineContext.childScope(),
         connection.connected,
@@ -98,9 +105,7 @@ class RemoteAnitorrentEngine(
     }
     
     override suspend fun getDownloader(): TorrentDownloader {
-        return RemoteTorrentDownloader(connectivityAware) {
-            runBlocking { getBinderOrFail() }.downlaoder
-        }
+        return RemoteTorrentDownloader(fetchRemoteScope, connectivityAware) { getBinderOrFail().downlaoder }
     }
 
     private suspend fun getBinderOrFail(): IRemoteAniTorrentEngine {
@@ -108,16 +113,17 @@ class RemoteAnitorrentEngine(
     }
 
     override fun close() {
-        childScope.cancel()
+        scope.cancel()
+        fetchRemoteScope.cancel()
     }
 
     private inline fun <I : IInterface> collectSettingsToRemote(
         settingsFlow: Flow<String>,
         noinline getBinder: suspend () -> I,
         crossinline transact: I.(String) -> Unit
-    ) = childScope.launch {
+    ) = scope.launch {
         val stateFlow = settingsFlow.stateIn(this)
-        val remoteCall = RetryRemoteCall { runBlocking { getBinder() } }
+        val remoteCall = RetryRemoteCall(fetchRemoteScope) { getBinder() }
 
         connection.connected
             .filter { it }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteCall.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteCall.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.DeadObjectException
 import android.os.IInterface
+import android.os.RemoteException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -21,7 +22,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException
-import me.him188.ani.utils.coroutines.CancellationException
 import me.him188.ani.utils.coroutines.update
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.logging.warn
@@ -99,7 +99,7 @@ suspend inline fun <I : IInterface, T : Any> RemoteCall<I>.callSuspendCancellabl
             object : RemoteContinuation<T> {
                 override fun resume(value: T?) {
                     if (value == null) {
-                        cont.resumeWithException(CancellationException("Remote resume a null value."))
+                        cont.resumeWithException(RemoteException("Remote resume a null value."))
                     } else {
                         cont.resume(value)
                     }
@@ -107,7 +107,7 @@ suspend inline fun <I : IInterface, T : Any> RemoteCall<I>.callSuspendCancellabl
 
                 override fun resumeWithException(e: RemoteContinuationException?) {
                     cont.resumeWithException(
-                        e?.smartCast() ?: Exception("Remote resume a null exception."),
+                        e?.smartCast() ?: RemoteException("Remote resume a null exception."),
                     )
                 }
             },
@@ -122,7 +122,7 @@ suspend inline fun <I : IInterface, T : Any> RemoteCall<I>.callSuspendCancellabl
             }
         }
     } else {
-        cont.resumeWithException(CancellationException("Remote disposable is null."))
+        cont.resumeWithException(RemoteException("Remote disposable is null."))
     }
 }
 

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteCall.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteCall.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.sync.withLock
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.parcel.RemoteContinuationException
 import me.him188.ani.utils.coroutines.CancellationException
+import me.him188.ani.utils.coroutines.update
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.logging.warn
 import kotlin.coroutines.resume
@@ -51,7 +52,7 @@ class RetryRemoteCall<I : IInterface>(
         if (currentRemote != null) return@async currentRemote
 
         val newRemote = getRemote()
-        while (!remote.compareAndSet(null, newRemote));
+        remote.update { newRemote }
         newRemote
     }
 

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteObject.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteObject.kt
@@ -31,17 +31,17 @@ import kotlin.coroutines.resumeWithException
 /**
  * Wrapper for remote call
  */
-interface RemoteCall<I : IInterface> {
+interface RemoteObject<I : IInterface> {
     fun <R : Any?> call(block: I.() -> R): R
 }
 
 /**
  * Impl for remote call safely with retry mechanism.
  */
-class RetryRemoteCall<I : IInterface>(
+class RetryRemoteObject<I : IInterface>(
     private val scope: CoroutineScope,
     private val getRemote: suspend () -> I
-) : RemoteCall<I> {
+) : RemoteObject<I> {
     private val logger = logger(this::class)
 
     private val remote: MutableStateFlow<I?> = MutableStateFlow(null)
@@ -91,7 +91,7 @@ class RetryRemoteCall<I : IInterface>(
  *
  * [IDisposableHandle] takes responsibility to pass cancellation to server.
  */
-suspend inline fun <I : IInterface, T : Any> RemoteCall<I>.callSuspendCancellable(
+suspend inline fun <I : IInterface, T : Any> RemoteObject<I>.callSuspendCancellable(
     crossinline transact: I.(RemoteContinuation<T>) -> IDisposableHandle?,
 ): T = suspendCancellableCoroutine { cont ->
     val disposable = call {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentDownloader
-import me.him188.ani.app.domain.torrent.ITorrentDownloaderStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentDownloaderStatsCallback
 import me.him188.ani.app.domain.torrent.parcel.PTorrentDownloaderStats
 import me.him188.ani.app.domain.torrent.parcel.toParceled
 import me.him188.ani.app.torrent.api.TorrentDownloader

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
@@ -11,7 +11,6 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -37,7 +36,6 @@ import kotlin.coroutines.CoroutineContext
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentDownloader(
-    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentDownloader
 ) : TorrentDownloader,
@@ -85,9 +83,8 @@ class RemoteTorrentDownloader(
         parentCoroutineContext: CoroutineContext,
         overrideSaveDir: SystemPath?
     ): TorrentSession {
-        return RemoteTorrentSession(scope, this@RemoteTorrentDownloader) {
+        return RemoteTorrentSession(this@RemoteTorrentDownloader) {
             callSuspendCancellableAsFuture(
-                scope = scope,
                 transact = { resolve, reject ->
                     startDownload(
                         data.toParceled(),

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentDownloader.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentDownloader(
     private val fetchRemoteScope: CoroutineScope,
-    private val remote: RemoteCall<IRemoteTorrentDownloader>,
+    private val remote: RemoteObject<IRemoteTorrentDownloader>,
     private val connectivityAware: ConnectivityAware
 ) : TorrentDownloader {
     override val totalStats: Flow<TorrentDownloader.Stats> = callbackFlow {
@@ -94,7 +94,7 @@ class RemoteTorrentDownloader(
     ): TorrentSession {
         return RemoteTorrentSession(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) {
+            RetryRemoteObject(fetchRemoteScope) {
                 remote.callSuspendCancellable { cont ->
                     startDownload(
                         data.toParceled(),

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntry
-import me.him188.ani.app.domain.torrent.ITorrentFileEntryStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentFileEntryStatsCallback
 import me.him188.ani.app.domain.torrent.parcel.PTorrentFileEntryStats
 import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 import me.him188.ani.app.torrent.api.files.TorrentFileHandle

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
@@ -41,7 +41,7 @@ import java.io.RandomAccessFile
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntry(
     private val fetchRemoteScope: CoroutineScope,
-    private val remote: RemoteCall<IRemoteTorrentFileEntry>,
+    private val remote: RemoteObject<IRemoteTorrentFileEntry>,
     private val connectivityAware: ConnectivityAware
 ) : TorrentFileEntry {
     override val fileStats: Flow<TorrentFileEntry.Stats> = callbackFlow {
@@ -82,7 +82,7 @@ class RemoteTorrentFileEntry(
     override fun createHandle(): TorrentFileHandle {
         return RemoteTorrentFileHandle(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) { remote.call { createHandle() } },
+            RetryRemoteObject(fetchRemoteScope) { remote.call { createHandle() } },
             connectivityAware,
         )
     }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntry.kt
@@ -11,7 +11,6 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +38,6 @@ import java.io.RandomAccessFile
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntry(
-    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentFileEntry
 ) : TorrentFileEntry,
@@ -75,7 +73,7 @@ class RemoteTorrentFileEntry(
     override val supportsStreaming: Boolean get() = call { supportsStreaming }
 
     override fun createHandle(): TorrentFileHandle {
-        return RemoteTorrentFileHandle(scope, this) { call { createHandle() } }
+        return RemoteTorrentFileHandle(this) { call { createHandle() } }
     }
 
     override suspend fun resolveFile(): SystemPath =

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
@@ -18,7 +18,7 @@ import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntryList(
     private val fetchRemoteScope: CoroutineScope,
-    private val remote: RemoteCall<IRemoteTorrentFileEntryList>,
+    private val remote: RemoteObject<IRemoteTorrentFileEntryList>,
     private val connectivityAware: ConnectivityAware
 ) : AbstractList<TorrentFileEntry>() {
     override val size: Int get() = remote.call { size }
@@ -26,7 +26,7 @@ class RemoteTorrentFileEntryList(
     override fun get(index: Int): TorrentFileEntry {
         return RemoteTorrentFileEntry(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) { remote.call { get(index) } },
+            RetryRemoteObject(fetchRemoteScope) { remote.call { get(index) } },
             connectivityAware,
         )
     }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
@@ -11,13 +11,11 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CoroutineScope
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList
 import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntryList(
-    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentFileEntryList
 ) : AbstractList<TorrentFileEntry>(),
@@ -26,6 +24,6 @@ class RemoteTorrentFileEntryList(
     override val size: Int get() = call { size }
 
     override fun get(index: Int): TorrentFileEntry {
-        return RemoteTorrentFileEntry(scope, this) { call { get(index) } }
+        return RemoteTorrentFileEntry(this) { call { get(index) } }
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
@@ -11,11 +11,13 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList
 import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntryList(
+    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentFileEntryList
 ) : AbstractList<TorrentFileEntry>(),
@@ -24,6 +26,6 @@ class RemoteTorrentFileEntryList(
     override val size: Int get() = call { size }
 
     override fun get(index: Int): TorrentFileEntry {
-        return RemoteTorrentFileEntry(this) { call { get(index) } }
+        return RemoteTorrentFileEntry(scope, this) { call { get(index) } }
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
@@ -11,19 +11,21 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList
 import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntryList(
+    private val fetchRemoteScope: CoroutineScope,
     connectivityAware: ConnectivityAware,
-    getRemote: () -> IRemoteTorrentFileEntryList
+    getRemote: suspend () -> IRemoteTorrentFileEntryList
 ) : AbstractList<TorrentFileEntry>(),
-    RemoteCall<IRemoteTorrentFileEntryList> by RetryRemoteCall(getRemote),
+    RemoteCall<IRemoteTorrentFileEntryList> by RetryRemoteCall(fetchRemoteScope, getRemote),
     ConnectivityAware by connectivityAware {
     override val size: Int get() = call { size }
 
     override fun get(index: Int): TorrentFileEntry {
-        return RemoteTorrentFileEntry(this) { call { get(index) } }
+        return RemoteTorrentFileEntry(fetchRemoteScope, this) { call { get(index) } }
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileEntryList.kt
@@ -18,14 +18,16 @@ import me.him188.ani.app.torrent.api.files.TorrentFileEntry
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileEntryList(
     private val fetchRemoteScope: CoroutineScope,
-    connectivityAware: ConnectivityAware,
-    getRemote: suspend () -> IRemoteTorrentFileEntryList
-) : AbstractList<TorrentFileEntry>(),
-    RemoteCall<IRemoteTorrentFileEntryList> by RetryRemoteCall(fetchRemoteScope, getRemote),
-    ConnectivityAware by connectivityAware {
-    override val size: Int get() = call { size }
+    private val remote: RemoteCall<IRemoteTorrentFileEntryList>,
+    private val connectivityAware: ConnectivityAware
+) : AbstractList<TorrentFileEntry>() {
+    override val size: Int get() = remote.call { size }
 
     override fun get(index: Int): TorrentFileEntry {
-        return RemoteTorrentFileEntry(fetchRemoteScope, this) { call { get(index) } }
+        return RemoteTorrentFileEntry(
+            fetchRemoteScope,
+            RetryRemoteCall(fetchRemoteScope) { remote.call { get(index) } },
+            connectivityAware,
+        )
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle
@@ -21,13 +22,14 @@ import me.him188.ani.utils.coroutines.IO_
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileHandle(
+    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentFileHandle
 ) : TorrentFileHandle,
     RemoteCall<IRemoteTorrentFileHandle> by RetryRemoteCall(getRemote),
     ConnectivityAware by connectivityAware {
     override val entry: TorrentFileEntry
-        get() = RemoteTorrentFileEntry(this) { call { torrentFileEntry } }
+        get() = RemoteTorrentFileEntry(scope, this) { call { torrentFileEntry } }
     
     override fun resume(priority: FilePriority) {
         call { resume(priority.ordinal) }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle
@@ -21,13 +22,14 @@ import me.him188.ani.utils.coroutines.IO_
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileHandle(
+    private val fetchRemoteScope: CoroutineScope,
     connectivityAware: ConnectivityAware,
-    getRemote: () -> IRemoteTorrentFileHandle
+    getRemote: suspend () -> IRemoteTorrentFileHandle
 ) : TorrentFileHandle,
-    RemoteCall<IRemoteTorrentFileHandle> by RetryRemoteCall(getRemote),
+    RemoteCall<IRemoteTorrentFileHandle> by RetryRemoteCall(fetchRemoteScope, getRemote),
     ConnectivityAware by connectivityAware {
     override val entry: TorrentFileEntry
-        get() = RemoteTorrentFileEntry(this) { call { torrentFileEntry } }
+        get() = RemoteTorrentFileEntry(fetchRemoteScope, this) { call { torrentFileEntry } }
     
     override fun resume(priority: FilePriority) {
         call { resume(priority.ordinal) }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
@@ -11,7 +11,6 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle
@@ -22,14 +21,13 @@ import me.him188.ani.utils.coroutines.IO_
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileHandle(
-    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentFileHandle
 ) : TorrentFileHandle,
     RemoteCall<IRemoteTorrentFileHandle> by RetryRemoteCall(getRemote),
     ConnectivityAware by connectivityAware {
     override val entry: TorrentFileEntry
-        get() = RemoteTorrentFileEntry(scope, this) { call { torrentFileEntry } }
+        get() = RemoteTorrentFileEntry(this) { call { torrentFileEntry } }
     
     override fun resume(priority: FilePriority) {
         call { resume(priority.ordinal) }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentFileHandle.kt
@@ -23,13 +23,13 @@ import me.him188.ani.utils.coroutines.IO_
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentFileHandle(
     private val fetchRemoteScope: CoroutineScope,
-    private val remote: RemoteCall<IRemoteTorrentFileHandle>,
+    private val remote: RemoteObject<IRemoteTorrentFileHandle>,
     private val connectivityAware: ConnectivityAware
 ) : TorrentFileHandle {
     override val entry: TorrentFileEntry
         get() = RemoteTorrentFileEntry(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) { remote.call { torrentFileEntry } },
+            RetryRemoteObject(fetchRemoteScope) { remote.call { torrentFileEntry } },
             connectivityAware,
         )
     

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
@@ -11,7 +11,6 @@ package me.him188.ani.app.domain.torrent.client
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -31,7 +30,6 @@ import me.him188.ani.utils.coroutines.IO_
 
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentSession(
-    private val scope: CoroutineScope,
     connectivityAware: ConnectivityAware,
     getRemote: () -> IRemoteTorrentSession
 ) : TorrentSession,
@@ -63,9 +61,8 @@ class RemoteTorrentSession(
     }
 
     override suspend fun getFiles(): List<TorrentFileEntry> {
-        return RemoteTorrentFileEntryList(scope, this@RemoteTorrentSession) {
+        return RemoteTorrentFileEntryList(this@RemoteTorrentSession) {
             callSuspendCancellableAsFuture(
-                scope = scope,
                 transact = { resolve, reject ->
                     getFiles(
                         object : ContTorrentSessionGetFiles.Stub() {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
@@ -62,18 +62,15 @@ class RemoteTorrentSession(
 
     override suspend fun getFiles(): List<TorrentFileEntry> {
         return RemoteTorrentFileEntryList(this@RemoteTorrentSession) {
-            callSuspendCancellableAsFuture(
-                transact = { resolve, reject ->
-                    getFiles(
-                        object : ContTorrentSessionGetFiles.Stub() {
-                            override fun resume(value: IRemoteTorrentFileEntryList?) = resolve(value)
-                            override fun resumeWithException(exception: RemoteContinuationException?) =
-                                reject(exception)
-                        },
-                    )
-                },
-                convert = { it },
-            ).get()
+            callSuspendCancellableAsFuture { resolve, reject ->
+                getFiles(
+                    object : ContTorrentSessionGetFiles.Stub() {
+                        override fun resume(value: IRemoteTorrentFileEntryList?) = resolve(value)
+                        override fun resumeWithException(exception: RemoteContinuationException?) =
+                            reject(exception)
+                    },
+                )
+            }.get()
         }
     }
 

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
@@ -71,12 +71,16 @@ class RemoteTorrentSession(
         return RemoteTorrentFileEntryList(
             fetchRemoteScope,
             RetryRemoteCall(fetchRemoteScope) {
-                remote.callSuspendCancellable { resolve, reject ->
+                remote.callSuspendCancellable { cont ->
                     getFiles(
                         object : ContTorrentSessionGetFiles.Stub() {
-                            override fun resume(value: IRemoteTorrentFileEntryList?) = resolve(value)
-                            override fun resumeWithException(exception: RemoteContinuationException?) =
-                                reject(exception)
+                            override fun resume(value: IRemoteTorrentFileEntryList?) {
+                                cont.resume(value)
+                            }
+
+                            override fun resumeWithException(exception: RemoteContinuationException?) {
+                                cont.resumeWithException(exception)
+                            }
                         },
                     )
                 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession
-import me.him188.ani.app.domain.torrent.ITorrentSessionStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentSessionStatsCallback
 import me.him188.ani.app.domain.torrent.parcel.PTorrentSessionStats
 import me.him188.ani.app.torrent.api.TorrentSession
 import me.him188.ani.app.torrent.api.files.TorrentFileEntry

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/client/RemoteTorrentSession.kt
@@ -33,7 +33,7 @@ import me.him188.ani.utils.coroutines.IO_
 @RequiresApi(Build.VERSION_CODES.O_MR1)
 class RemoteTorrentSession(
     private val fetchRemoteScope: CoroutineScope,
-    private val remote: RemoteCall<IRemoteTorrentSession>,
+    private val remote: RemoteObject<IRemoteTorrentSession>,
     private val connectivityAware: ConnectivityAware
 ) : TorrentSession {
     override val sessionStats: Flow<TorrentSession.Stats?> = callbackFlow {
@@ -70,7 +70,7 @@ class RemoteTorrentSession(
     override suspend fun getFiles(): List<TorrentFileEntry> {
         return RemoteTorrentFileEntryList(
             fetchRemoteScope,
-            RetryRemoteCall(fetchRemoteScope) {
+            RetryRemoteObject(fetchRemoteScope) {
                 remote.callSuspendCancellable { cont ->
                     getFiles(
                         object : ContTorrentSessionGetFiles.Stub() {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/parcel/RemoteContinuationException.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/parcel/RemoteContinuationException.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.torrent.parcel
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import me.him188.ani.utils.coroutines.CancellationException
+import java.io.OutputStream
+import java.io.PrintStream
+
+@Suppress("MemberVisibilityCanBePrivate", "CanBeParameter")
+@Parcelize
+class RemoteContinuationException(
+    val throwableName: String,
+    override val message: String?,
+    val serializedCause: String?,
+) : Parcelable, Exception(
+    "$throwableName: $message",
+    serializedCause?.let { RemoteContinuationException("Exception", it, null) },
+) {
+    fun smartCast(): Exception {
+        return if (throwableName.contains("CancellationException")) {
+            CancellationException(message, cause)
+        } else {
+            this
+        }
+    }
+}
+
+private fun Throwable.toFullString(): String = buildString {
+    printStackTrace(
+        PrintStream(
+            object : OutputStream() {
+                override fun write(b: Int) {
+                    append(b.toByte())
+                }
+            },
+        ),
+    )
+}
+
+internal fun Throwable.toRemoteContinuationException() =
+    RemoteContinuationException(javaClass.name, message, cause?.toFullString())

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/parcel/RemoteContinuationException.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/parcel/RemoteContinuationException.kt
@@ -15,6 +15,9 @@ import me.him188.ani.utils.coroutines.CancellationException
 import java.io.OutputStream
 import java.io.PrintStream
 
+/**
+ * Exception which can be parceled and transact in async remote call.
+ */
 @Suppress("MemberVisibilityCanBePrivate", "CanBeParameter")
 @Parcelize
 class RemoteContinuationException(

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/AniTorrentService.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/AniTorrentService.kt
@@ -51,9 +51,8 @@ import kotlin.coroutines.CoroutineContext
 
 class AniTorrentService : LifecycleService(), CoroutineScope {
     private val logger = logger(this::class)
-    override val coroutineContext: CoroutineContext
-        get() = lifecycleScope.coroutineContext +
-                CoroutineName("AniTorrentService") +
+    override val coroutineContext: CoroutineContext =
+        Dispatchers.Default + CoroutineName("AniTorrentService") + 
                 SupervisorJob(lifecycleScope.coroutineContext[Job])
     
     // config flow for constructing torrent engine.

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentDownloaderProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentDownloaderProxy.kt
@@ -20,7 +20,7 @@ import kotlinx.io.files.Path
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentDownloader
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession
-import me.him188.ani.app.domain.torrent.ITorrentDownloaderStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentDownloaderStatsCallback
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
 import me.him188.ani.app.domain.torrent.parcel.PEncodedTorrentInfo
 import me.him188.ani.app.domain.torrent.parcel.PTorrentDownloaderStats

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentDownloaderProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentDownloaderProxy.kt
@@ -12,20 +12,22 @@ package me.him188.ani.app.domain.torrent.service.proxy
 import android.os.Build
 import android.os.DeadObjectException
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentDownloader
-import me.him188.ani.app.domain.torrent.IRemoteTorrentSession
 import me.him188.ani.app.domain.torrent.callback.ITorrentDownloaderStatsCallback
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
+import me.him188.ani.app.domain.torrent.cont.ContTorrentDownloaderFetchTorrent
+import me.him188.ani.app.domain.torrent.cont.ContTorrentDownloaderStartDownload
 import me.him188.ani.app.domain.torrent.parcel.PEncodedTorrentInfo
 import me.him188.ani.app.domain.torrent.parcel.PTorrentDownloaderStats
 import me.him188.ani.app.domain.torrent.parcel.PTorrentLibInfo
 import me.him188.ani.app.domain.torrent.parcel.toParceled
+import me.him188.ani.app.domain.torrent.parcel.toRemoteContinuationException
 import me.him188.ani.app.torrent.api.TorrentDownloader
 import me.him188.ani.utils.coroutines.CancellationException
 import me.him188.ani.utils.coroutines.IO_
@@ -79,24 +81,52 @@ class TorrentDownloaderProxy(
     }
 
     @RequiresApi(Build.VERSION_CODES.O_MR1)
-    override fun fetchTorrent(uri: String?, timeoutSeconds: Int): PEncodedTorrentInfo? {
+    override fun fetchTorrent(
+        uri: String?,
+        timeoutSeconds: Int,
+        cont: ContTorrentDownloaderFetchTorrent?
+    ): IDisposableHandle? {
         if (uri == null) return null
-        
-        val fetched = runBlocking { delegate.fetchTorrent(uri, timeoutSeconds) }
-        return fetched.toParceled()
+        if (cont == null) return null
+
+        val job = scope.launch(
+            CoroutineExceptionHandler { _, throwable ->
+                if (!isConnected) return@CoroutineExceptionHandler
+                cont.resumeWithException(throwable.toRemoteContinuationException())
+            } + Dispatchers.IO_,
+        ) {
+            val result = delegate.fetchTorrent(uri, timeoutSeconds)
+            if (!isConnected) return@launch
+            cont.resume(result.toParceled())
+        }
+
+        return DisposableHandleProxy { job.cancel() }
     }
 
     @RequiresApi(Build.VERSION_CODES.O_MR1)
-    override fun startDownload(data: PEncodedTorrentInfo?, overrideSaveDir: String?): IRemoteTorrentSession? {
+    override fun startDownload(
+        data: PEncodedTorrentInfo?,
+        overrideSaveDir: String?,
+        cont: ContTorrentDownloaderStartDownload?
+    ): IDisposableHandle? {
         if (data == null) return null
-        
-        val session = runBlocking { 
-            delegate.startDownload(
+        if (cont == null) return null
+
+        val job = scope.launch(
+            CoroutineExceptionHandler { _, throwable ->
+                if (!isConnected) return@CoroutineExceptionHandler
+                cont.resumeWithException(throwable.toRemoteContinuationException())
+            } + Dispatchers.IO_,
+        ) {
+            val result = delegate.startDownload(
                 withContext(Dispatchers.IO_) { data.toEncodedTorrentInfo() },
                 overrideSaveDir = overrideSaveDir?.run { Path(this).inSystem },
-            ) 
+            )
+            if (!isConnected) return@launch
+            cont.resume(TorrentSessionProxy(result, this@TorrentDownloaderProxy, scope.coroutineContext))
         }
-        return TorrentSessionProxy(session, this, scope.coroutineContext)
+
+        return DisposableHandleProxy { job.cancel() }
     }
 
     @RequiresApi(Build.VERSION_CODES.O_MR1)

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentEngineProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentEngineProxy.kt
@@ -24,12 +24,12 @@ import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
 import me.him188.ani.app.data.models.preference.ProxySettings
 import me.him188.ani.app.data.models.preference.TorrentPeerConfig
-import me.him188.ani.app.domain.torrent.IAnitorrentConfigCollector
-import me.him188.ani.app.domain.torrent.IProxySettingsCollector
 import me.him188.ani.app.domain.torrent.IRemoteAniTorrentEngine
 import me.him188.ani.app.domain.torrent.IRemoteTorrentDownloader
-import me.him188.ani.app.domain.torrent.ITorrentPeerConfigCollector
 import me.him188.ani.app.domain.torrent.client.DefaultConnectivityAware
+import me.him188.ani.app.domain.torrent.collector.IAnitorrentConfigCollector
+import me.him188.ani.app.domain.torrent.collector.IProxySettingsCollector
+import me.him188.ani.app.domain.torrent.collector.ITorrentPeerConfigCollector
 import me.him188.ani.app.domain.torrent.engines.AnitorrentEngine
 import me.him188.ani.app.domain.torrent.parcel.PAnitorrentConfig
 import me.him188.ani.app.domain.torrent.parcel.PProxySettings

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileEntryListProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileEntryListProxy.kt
@@ -18,13 +18,13 @@ import kotlin.coroutines.CoroutineContext
 
 class TorrentFileEntryListProxy(
     val delegate: List<TorrentFileEntry>,
-    connectivityAware: ConnectivityAware,
+    private val connectivityAware: ConnectivityAware,
     context: CoroutineContext
-) : IRemoteTorrentFileEntryList.Stub(), ConnectivityAware by connectivityAware {
+) : IRemoteTorrentFileEntryList.Stub() {
     private val scope = context.childScope()
     
     override fun get(index: Int): IRemoteTorrentFileEntry {
-        return TorrentFileEntryProxy(delegate[index], this, scope.coroutineContext)
+        return TorrentFileEntryProxy(delegate[index], connectivityAware, scope.coroutineContext)
     }
 
     override fun getSize(): Int {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileEntryProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileEntryProxy.kt
@@ -19,7 +19,7 @@ import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemotePieceList
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntry
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle
-import me.him188.ani.app.domain.torrent.ITorrentFileEntryStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentFileEntryStatsCallback
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
 import me.him188.ani.app.domain.torrent.parcel.PTorrentFileEntryStats
 import me.him188.ani.app.domain.torrent.parcel.PTorrentInputParameter

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileHandleProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileHandleProxy.kt
@@ -20,13 +20,13 @@ import kotlin.coroutines.CoroutineContext
 
 class TorrentFileHandleProxy(
     private val delegate: TorrentFileHandle,
-    connectivityAware: ConnectivityAware,
+    private val connectivityAware: ConnectivityAware,
     context: CoroutineContext
-) : IRemoteTorrentFileHandle.Stub(), ConnectivityAware by connectivityAware {
+) : IRemoteTorrentFileHandle.Stub() {
     private val scope = context.childScope()
 
     override fun getTorrentFileEntry(): IRemoteTorrentFileEntry {
-        return TorrentFileEntryProxy(delegate.entry, this, scope.coroutineContext)
+        return TorrentFileEntryProxy(delegate.entry, connectivityAware, scope.coroutineContext)
     }
 
     override fun resume(priorityEnum: Int) {

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileHandleProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentFileHandleProxy.kt
@@ -9,7 +9,7 @@
 
 package me.him188.ani.app.domain.torrent.service.proxy
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntry
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileHandle
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
@@ -38,10 +38,14 @@ class TorrentFileHandleProxy(
     }
 
     override fun close() {
-        runBlocking { delegate.close() }
+        scope.launch {
+            delegate.close()
+        }
     }
 
     override fun closeAndDelete() {
-        runBlocking { delegate.closeAndDelete() }
+        scope.launch {
+            delegate.closeAndDelete()
+        }
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.domain.torrent.IDisposableHandle
 import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession
-import me.him188.ani.app.domain.torrent.ITorrentSessionStatsCallback
+import me.him188.ani.app.domain.torrent.callback.ITorrentSessionStatsCallback
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
 import me.him188.ani.app.domain.torrent.parcel.PPeerInfo
 import me.him188.ani.app.domain.torrent.parcel.PTorrentSessionStats

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
@@ -103,10 +103,14 @@ class TorrentSessionProxy(
     }
 
     override fun close() {
-        return runBlocking { delegate.close() }
+        scope.launch {
+            delegate.close()
+        }
     }
 
     override fun closeIfNotInUse() {
-        return runBlocking { delegate.closeIfNotInUse() }
+        scope.launch {
+            delegate.closeIfNotInUse()
+        }
     }
 }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/TorrentSessionProxy.kt
@@ -10,16 +10,18 @@
 package me.him188.ani.app.domain.torrent.service.proxy
 
 import android.os.DeadObjectException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.domain.torrent.IDisposableHandle
-import me.him188.ani.app.domain.torrent.IRemoteTorrentFileEntryList
 import me.him188.ani.app.domain.torrent.IRemoteTorrentSession
 import me.him188.ani.app.domain.torrent.callback.ITorrentSessionStatsCallback
 import me.him188.ani.app.domain.torrent.client.ConnectivityAware
+import me.him188.ani.app.domain.torrent.cont.ContTorrentSessionGetFiles
 import me.him188.ani.app.domain.torrent.parcel.PPeerInfo
 import me.him188.ani.app.domain.torrent.parcel.PTorrentSessionStats
+import me.him188.ani.app.domain.torrent.parcel.toRemoteContinuationException
 import me.him188.ani.app.torrent.api.TorrentSession
 import me.him188.ani.utils.coroutines.CancellationException
 import me.him188.ani.utils.coroutines.IO_
@@ -65,28 +67,39 @@ class TorrentSessionProxy(
         return runBlocking { delegate.getName() }
     }
 
-    override fun getFiles(): IRemoteTorrentFileEntryList {
-        val list = runBlocking { delegate.getFiles() }
+    override fun getFiles(cont: ContTorrentSessionGetFiles?): IDisposableHandle? {
+        if (cont == null) return null
 
-        return TorrentFileEntryListProxy(list, this, scope.coroutineContext)
+        val job = scope.launch(
+            CoroutineExceptionHandler { _, throwable ->
+                if (!isConnected) return@CoroutineExceptionHandler
+                cont.resumeWithException(throwable.toRemoteContinuationException())
+            } + Dispatchers.IO_,
+        ) {
+            val result = delegate.getFiles()
+            if (!isConnected) return@launch
+            cont.resume(
+                TorrentFileEntryListProxy(result, this@TorrentSessionProxy, scope.coroutineContext),
+            )
+        }
+
+        return DisposableHandleProxy { job.cancel() }
     }
 
     override fun getPeers(): Array<PPeerInfo> {
-        return runBlocking { 
-            delegate.getPeers().map { 
-                PPeerInfo(
-                    it.handle,
-                    it.id,
-                    it.client,
-                    it.ipAddr,
-                    it.ipPort,
-                    it.progress,
-                    it.totalDownload.inBytes,
-                    it.totalUpload.inBytes,
-                    it.flags
-                ) 
-            }.toTypedArray()
-        }
+        return delegate.getPeers().map {
+            PPeerInfo(
+                it.handle,
+                it.id,
+                it.client,
+                it.ipAddr,
+                it.ipPort,
+                it.progress,
+                it.totalDownload.inBytes,
+                it.totalUpload.inBytes,
+                it.flags,
+            )
+        }.toTypedArray()
     }
 
     override fun close() {


### PR DESCRIPTION
此 PR 旨在消除 service proxy 的 `runBlocking`，提高 service 吞吐量

### 目前问题

例如，`IRemoteTorrentDownloader.aidl` 中的 `startRemoteDownload` 接口为

```aidl
IRemoteTorrentSession startRemoteDownload(in PEncodedTorrentInfo data, in String overrideSaveDir);
```

这个接口对应了 `TorrentDownloader` 的 `startDownload` 函数，是一个 suspend 函数

```kotlin
suspend fun startDownload(
    data: EncodedTorrentInfo,
    parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
    overrideSaveDir: SystemPath? = null,
): TorrentSession
```

目前在 client 的调用实现为

```kotlin
override suspend fun startDownload(
    data: EncodedTorrentInfo,
    parentCoroutineContext: CoroutineContext,
    overrideSaveDir: SystemPath?
): TorrentSession {
    return remote.startRemoteDownload(data.toParceled(), overrideSaveDir?.absolutePath)
}
```

在 service 的实现为

```kotlin
override fun startRemoteDownload(data: PEncodedTorrentInfo?, overrideSaveDir: String?): IRemoteTorrentSession? {
    val session = runBlocking { 
        actualServiceTorrentDownloader.startDownload(
            withContext(Dispatchers.IO_) { data.toEncodedTorrentInfo() },
            overrideSaveDir = overrideSaveDir?.run { Path(this).inSystem },
        ) 
    }
    return TorrentSessionProxy(session, this, scope.coroutineContext)
}
```

client 调用 `startRemoteDownload` 时需要等待 service 实现中的 `runBlocking` 执行完成才会返回结果，如果 `runBlocking` 执行了很长时间，那 client 调用端会一直等待结果而阻塞，service 实现也会因为 `runBlocking` 而不能使用当前的 binder 线程继续处理其他 client 调用

## 新变化

此 PR 将 `startRemoteDownload` AIDL 接口改为如下回调形式

```aidl
IDisposableHandle startRemoteDownload(in PEncodedTorrentInfo data, in String overrideSaveDir, in RemoteContinuation cont);
```

```aidl
interface RemoteContinuation {
    void resume(in IRemoteTorrentSession value);
    void resumeWithException(in RemoteContinuationException exception);
}
```

其中，`IDisposableHandle` 用于处理 service 取消协程的动作，client 取消协程后通过 `IDisposableHandle` 通知 service 同样取消对应处理协程，`RemoteContinuation` 用于回调结果

如此而来，client 通过 `suspendCancellableCoroutine` 就可以比较轻易地实现回调 API 的挂起

```kotlin
override suspend fun startDownload(
    data: EncodedTorrentInfo,
    parentCoroutineContext: CoroutineContext,
    overrideSaveDir: SystemPath?
): TorrentSession = suspendCancellableCoroutine { cont ->
    val disposable = remote.startRemoteDownload(
        data.toParceled(), 
        overrideSaveDir?.absolutePath,
        object : ContTorrentDownloaderStartDownload.Stub() {
            override fun resume(value: IRemoteTorrentSession?) {
                cont.resume(value)
            }   

            override fun resumeWithException(exception: RemoteContinuationException?) {
                cont.resumeWithException(exception)
            }

        }
    )
    
    cont.invokeOnCancellation { disposable.dispose() }
```

service 也可以去除 `runBlocking`，并且快速返回结果

```kotlin
override fun startRemoteDownload(
    data: PEncodedTorrentInfo?,
    overrideSaveDir: String?,
    cont: RemoteContinuation?
): IDisposableHandle? {
    if (data == null) return null
    if (cont == null) return null

    val job = scope.launch(
        CoroutineExceptionHandler { _, throwable ->
            cont.resumeWithException(throwable.toRemoteContinuationException())
        } + Dispatchers.IO_,
    ) {
        val result = delegate.startDownload(
            withContext(Dispatchers.IO_) { data.toEncodedTorrentInfo() },
            overrideSaveDir = overrideSaveDir?.run { Path(this).inSystem },
        )
        cont.resume(TorrentSessionProxy(result, this@TorrentDownloaderProxy, scope.coroutineContext))
    }

    return DisposableHandleProxy { job.cancel() }
}
```