### PR TITLE
Refactor SelectorTestState to avoid compose state usage in background

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/rss/RssMediaSource.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/rss/RssMediaSource.kt
@@ -145,7 +145,6 @@ class RssMediaSource(
             if (!usePaging && page != 0) return@PageBasedPagedSource null
 
             val result = engine.search(searchConfig, query, page, mediaSourceId)
-                .getOrThrow()
 
             // 404 Not Found
             val channel = result.channel ?: return@PageBasedPagedSource null

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/MatchTag.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/MatchTag.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.test
+
+import androidx.compose.runtime.Immutable
+
+
+@Immutable
+class MatchTag(
+    val value: String,
+    /**
+     * 该标签表示一个缺失的项目. 例如缺失 EP.
+     */
+    val isMissing: Boolean = false,
+    /**
+     * 该标签是否匹配了用户的搜索条件.
+     * - `true`: 满足了一个条件. UI 显示为紫色的 check
+     * - `false`: 不满足条件. UI 显示为红色的 close
+     * - `null`: 这不是一个搜索条件. UI 不会特别高亮此标签.
+     */
+    val isMatch: Boolean? = null,
+)
+
+class MatchTagsBuilder
+@PublishedApi
+internal constructor() {
+    private val list = mutableListOf<MatchTag>()
+
+    fun emit(value: String, isMissing: Boolean = false, isMatch: Boolean? = null) {
+        list.add(MatchTag(value, isMissing, isMatch))
+    }
+
+    @PublishedApi
+    internal fun build(): List<MatchTag> = list
+}
+
+inline fun buildMatchTags(builder: MatchTagsBuilder.() -> Unit): List<MatchTag> =
+    MatchTagsBuilder().apply(builder).build()

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/RefreshResult.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/RefreshResult.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.test
+
+import me.him188.ani.app.data.repository.RepositoryException
+
+/**
+ * 标记接口, 表示一个通用的刷新结果.
+ */
+interface RefreshResult {
+    /**
+     * 刷新成功, 不会显示错误按钮.
+     */
+    interface Success : RefreshResult
+
+    interface InProgress : RefreshResult
+
+    /**
+     * 刷新失败, 会显示错误按钮.
+     */
+    sealed interface Failed : RefreshResult
+
+    /**
+     * 一个已知类型的 API 错误
+     */
+    interface ApiError : Failed {
+        val exception: RepositoryException
+    }
+
+    /**
+     * 配置有误, 例如测试 RSS 数据源. UI 只会显示 "配置不完整". 你需要让你的编辑框自己显示 error.
+     */
+    interface InvalidConfig : Failed
+
+    /**
+     * 一个任意类型异常. 这属于不期望遇到的错误 (bug).
+     */
+    interface UnknownError : Failed {
+        val exception: Throwable
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/rss/RssItemInfo.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/rss/RssItemInfo.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.test.rss
+
+import androidx.compose.runtime.Immutable
+import me.him188.ani.app.domain.mediasource.MediaListFilter
+import me.him188.ani.app.domain.mediasource.rss.RssSearchConfig
+import me.him188.ani.app.domain.mediasource.rss.RssSearchQuery
+import me.him188.ani.app.domain.mediasource.rss.toFilterContext
+import me.him188.ani.app.domain.mediasource.test.MatchTag
+import me.him188.ani.app.domain.mediasource.test.buildMatchTags
+import me.him188.ani.app.domain.rss.RssItem
+import me.him188.ani.app.domain.rss.guessResourceLocation
+import me.him188.ani.datasources.api.SubtitleKind
+import me.him188.ani.datasources.api.topic.EpisodeRange
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.datasources.api.topic.titles.ParsedTopicTitle
+import me.him188.ani.datasources.api.topic.titles.RawTitleParser
+import me.him188.ani.datasources.api.topic.titles.parse
+
+@Immutable
+class RssItemInfo(
+    val rss: RssItem,
+    val parsed: ParsedTopicTitle,
+    val tags: List<MatchTag>,
+) {
+    companion object {
+        fun compute(
+            rss: RssItem,
+            config: RssSearchConfig,
+            query: RssSearchQuery,
+        ): RssItemInfo {
+            val parsed = RawTitleParser.getDefault().parse(rss.title)
+            val tags = computeTags(rss, parsed, query, config)
+            return RssItemInfo(rss, parsed, tags)
+        }
+
+        /**
+         * 计算出用于标记该资源与 [RssSearchQuery] 的匹配情况的 tags. 例如标题成功匹配、缺失 EP 等.
+         */
+        private fun computeTags(
+            rss: RssItem,
+            title: ParsedTopicTitle,
+            query: RssSearchQuery,
+            config: RssSearchConfig,
+        ): List<MatchTag> = buildMatchTags {
+            with(query.toFilterContext()) {
+                val candidate = rss.asCandidate(title)
+
+                if (config.filterByEpisodeSort) {
+                    val episodeRange = title.episodeRange
+                    if (episodeRange == null) {
+                        // 期望使用 EP 过滤但是没有 EP 信息, 属于为缺失
+                        emit("EP", isMissing = true)
+                    } else {
+                        emit(
+                            episodeRange.toString(),
+                            isMatch = me.him188.ani.app.domain.mediasource.MediaListFilters.ContainsAnyEpisodeInfo.applyOn(
+                                candidate,
+                            ),
+                        )
+                    }
+                } else {
+                    // 不需要用 EP 过滤也展示 EP 信息
+                    title.episodeRange?.let {
+                        emit(it.toString())
+                    }
+                }
+
+                if (config.filterBySubjectName) {
+                    emit(
+                        "标题",
+                        isMatch = me.him188.ani.app.domain.mediasource.MediaListFilters.ContainsSubjectName.applyOn(
+                            candidate,
+                        ),
+                    )
+                }
+            }
+
+            val resourceLocation = rss.guessResourceLocation()
+            when (resourceLocation) {
+                is ResourceLocation.HttpStreamingFile -> emit("Streaming")
+                is ResourceLocation.HttpTorrentFile -> emit("Torrent")
+                is ResourceLocation.LocalFile -> emit("Local")
+                is ResourceLocation.MagnetLink -> emit("Magnet")
+                is ResourceLocation.WebVideo -> emit("WEB")
+                null -> emit("Download", isMissing = true)
+            }
+
+            // 以下为普通 tags
+
+            if (title.subtitleLanguages.isEmpty()) {
+                emit("Subtitle", isMissing = true)
+            } else {
+                for (subtitleLanguage in title.subtitleLanguages) {
+                    emit(subtitleLanguage.displayName)
+                }
+            }
+
+            title.resolution?.displayName?.let(::emit)
+
+            title.subtitleKind?.let {
+                emit(renderSubtitleKind(it) + "字幕")
+            }
+        }
+    }
+}
+
+// TODO: 2024/12/14  renderSubtitleKind is a duplicate of MediaDetailsRenderer.renderSubtitleKind. RssItemInfo should not use this.
+private fun renderSubtitleKind(
+    subtitleKind: SubtitleKind?,
+): String? {
+    return when (subtitleKind) {
+        SubtitleKind.EMBEDDED -> "内嵌"
+        SubtitleKind.CLOSED -> "内封"
+        SubtitleKind.EXTERNAL_PROVIDED -> "外挂"
+        SubtitleKind.EXTERNAL_DISCOVER -> "未知"
+        SubtitleKind.CLOSED_OR_EXTERNAL_DISCOVER -> "内封或未知"
+        null -> null
+    }
+}
+
+private fun RssItem.asCandidate(parsed: ParsedTopicTitle): MediaListFilter.Candidate {
+    return object : MediaListFilter.Candidate {
+        override val originalTitle: String get() = title
+        override val episodeRange: EpisodeRange? get() = parsed.episodeRange
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectTestEpisodeResult.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectTestEpisodeResult.kt
@@ -7,16 +7,16 @@
  * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
-package me.him188.ani.app.ui.settings.mediasource.selector.test
+package me.him188.ani.app.domain.mediasource.test.web
 
 import androidx.compose.runtime.Immutable
 import me.him188.ani.app.data.repository.RepositoryException
+import me.him188.ani.app.domain.mediasource.test.MatchTag
+import me.him188.ani.app.domain.mediasource.test.RefreshResult
+import me.him188.ani.app.domain.mediasource.test.buildMatchTags
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
 import me.him188.ani.app.domain.mediasource.web.WebSearchEpisodeInfo
-import me.him188.ani.app.ui.settings.mediasource.RefreshResult
-import me.him188.ani.app.ui.settings.mediasource.rss.test.MatchTag
-import me.him188.ani.app.ui.settings.mediasource.rss.test.buildMatchTags
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.utils.platform.Uuid
 import me.him188.ani.utils.xml.Element

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
@@ -12,12 +12,7 @@ package me.him188.ani.app.domain.mediasource.test.web
 import androidx.compose.ui.util.fastDistinctBy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.*
 import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
@@ -131,7 +126,8 @@ class SelectorMediaSourceTester(
                     subjectDetailsPageUrl to searchEpisodes(subjectDetailsPageUrl)
                 }
             }
-        }.shareIn(scope, sharingStarted, replay = 1)
+        }.restartable(episodeSearchLifecycle)
+        .shareIn(scope, sharingStarted, replay = 1)
         .distinctUntilChanged()
 
     /**
@@ -158,7 +154,7 @@ class SelectorMediaSourceTester(
                 )
             }
         }
-    }.restartable(episodeSearchLifecycle)
+    }
         .shareIn(scope, sharingStarted, replay = 1)
         .distinctUntilChanged()
 
@@ -188,7 +184,7 @@ class SelectorMediaSourceTester(
 
     private fun createSelectorSearchQuery(
         query: SubjectQuery,
-        episodeQuery: EpisodeQuery
+        episodeQuery: EpisodeQuery,
     ) = SelectorSearchQuery(
         subjectName = query.searchKeyword,
         episodeSort = episodeQuery.sort,
@@ -211,7 +207,7 @@ class SelectorMediaSourceTester(
         url: String?,
         searchKeyword: String,
         useOnlyFirstWord: Boolean?,
-        removeSpecial: Boolean?
+        removeSpecial: Boolean?,
     ) =
         if (url.isNullOrBlank() || searchKeyword.isBlank() || useOnlyFirstWord == null || removeSpecial == null) {
             null

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
@@ -79,6 +79,7 @@ class SelectorMediaSourceTester(
                 )
             }
         }
+        .restartable(subjectSearchLifecycle)
         .shareIn(scope, sharingStarted, replay = 1)
         .distinctUntilChanged()
 
@@ -98,7 +99,7 @@ class SelectorMediaSourceTester(
             apiResponse, searchConfig,
             createSelectorSearchQuery(query, episodeQuery),
         )
-    }.restartable(subjectSearchLifecycle)
+    }
         .shareIn(scope, sharingStarted, replay = 1)
         .distinctUntilChanged()
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorMediaSourceTester.kt
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.test.web
+
+import androidx.compose.ui.util.fastDistinctBy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.shareIn
+import me.him188.ani.app.data.repository.RepositoryException
+import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
+import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
+import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.utils.coroutines.flows.FlowRestarter
+import me.him188.ani.utils.coroutines.flows.FlowRunning
+import me.him188.ani.utils.coroutines.flows.restartable
+import me.him188.ani.utils.xml.Document
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * 交互式的 [SelectorMediaSourceEngine]. 用于 UI 的 "测试数据源" 功能.
+ */
+class SelectorMediaSourceTester(
+    private val engine: SelectorMediaSourceEngine,
+    flowContext: CoroutineContext = Dispatchers.Default,
+    sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(),
+) {
+    // must be data class
+    data class SubjectQuery(
+        val searchKeyword: String,
+        val searchUrl: String?,
+        val searchUseOnlyFirstWord: Boolean?,
+        val searchRemoveSpecial: Boolean?,
+    )
+
+    data class EpisodeQuery(
+        val sort: EpisodeSort,
+    )
+
+    private val scope = CoroutineScope(flowContext) // No ExceptionHandler! You must catch all exceptions in shareIn!
+
+    val subjectSearchLifecycle = FlowRestarter()
+    val subjectSearchRunning = FlowRunning()
+    val episodeSearchLifecycle = FlowRestarter()
+    val episodeSearchRunning = FlowRunning()
+
+    /**
+     * 将会影响两个筛选. 不会直接触发搜索. 如果变更导致 subject 的搜索结果变化, 可能会触发 episode list 搜索.
+     */
+    private val selectorSearchConfigFlow = MutableStateFlow<SelectorSearchConfig?>(null)
+    private val subjectQueryFlow = MutableStateFlow<SubjectQuery?>(null)
+    private val episodeQueryFlow = MutableStateFlow<EpisodeQuery?>(null)
+    private val selectedSubjectIndexFlow = MutableStateFlow(0)
+
+    /**
+     * 用于查询条目列表, 每当编辑请求和 `searchUrl`, 会重新搜索, 但不会筛选.
+     * 筛选在 [subjectSelectionResultFlow].
+     */
+    private val subjectSearchResultFlow = subjectQueryFlow
+        .mapLatest { query ->
+            if (query == null) {
+                return@mapLatest null
+            }
+
+            subjectSearchRunning.withRunning {
+                searchSubject(
+                    query.searchUrl,
+                    query.searchKeyword,
+                    query.searchUseOnlyFirstWord,
+                    query.searchRemoveSpecial,
+                )
+            }
+        }
+        .shareIn(scope, sharingStarted, replay = 1)
+        .distinctUntilChanged()
+
+    /**
+     * 解析好的搜索结果.
+     */
+    val subjectSelectionResultFlow = combine(
+        subjectSearchResultFlow,
+        selectorSearchConfigFlow,
+        subjectQueryFlow,
+        episodeQueryFlow,
+    ) { apiResponse, searchConfig, query, episodeQuery ->
+        if (apiResponse == null) return@combine null
+        if (searchConfig == null || query == null || episodeQuery == null) return@combine SelectorTestSearchSubjectResult.InvalidConfig
+
+        selectSubjectResult(
+            apiResponse, searchConfig,
+            createSelectorSearchQuery(query, episodeQuery),
+        )
+    }.restartable(subjectSearchLifecycle)
+        .shareIn(scope, sharingStarted, replay = 1)
+        .distinctUntilChanged()
+
+    /**
+     * 用户选择的条目.
+     */
+    private val selectedSubjectFlow = subjectSelectionResultFlow
+        .combine(selectedSubjectIndexFlow) { result, index ->
+            if (result == null) return@combine null
+
+            (result as? SelectorTestSearchSubjectResult.Success)?.subjects?.getOrNull(index)
+        } // not shared
+        .distinctUntilChanged() // required, 否则在修改无关配置时也会触发重新搜索
+
+    /**
+     * 用于查询条目的剧集列表, 每当选择新的条目时, 会重新搜索. 但不会筛选. 筛选在 [episodeListSelectionResultFlow].
+     */
+    private val episodeListSearchResultFlow = selectedSubjectFlow
+        .mapLatest { subject ->
+            val subjectDetailsPageUrl = subject?.subjectDetailsPageUrl
+            if (subjectDetailsPageUrl == null) {
+                null
+            } else {
+                episodeSearchRunning.withRunning {
+                    subjectDetailsPageUrl to searchEpisodes(subjectDetailsPageUrl)
+                }
+            }
+        }.shareIn(scope, sharingStarted, replay = 1)
+        .distinctUntilChanged()
+
+    /**
+     * 解析好的剧集列表.
+     */
+    val episodeListSelectionResultFlow = combine(
+        episodeListSearchResultFlow, subjectQueryFlow, selectorSearchConfigFlow, episodeQueryFlow,
+    ) { episodeListDocumentResult, query, searchConfig, episodeQuery ->
+        when {
+            query == null || searchConfig == null || episodeQuery == null -> {
+                SelectorTestEpisodeListResult.InvalidConfig
+            }
+
+            episodeListDocumentResult == null -> {
+                SelectorTestEpisodeListResult.Success(null, emptyList())
+            }
+
+            else -> {
+                val (subjectUrl, documentResult) = episodeListDocumentResult
+                convertEpisodeResult(
+                    documentResult, searchConfig,
+                    createSelectorSearchQuery(query, episodeQuery),
+                    subjectUrl,
+                )
+            }
+        }
+    }.restartable(episodeSearchLifecycle)
+        .shareIn(scope, sharingStarted, replay = 1)
+        .distinctUntilChanged()
+
+    // region setters
+
+    fun setSelectorSearchConfig(config: SelectorSearchConfig?) {
+        selectorSearchConfigFlow.value = config
+    }
+
+    fun setSubjectQuery(query: SubjectQuery) {
+        subjectQueryFlow.value = query
+    }
+
+    fun setEpisodeQuery(query: EpisodeQuery) {
+        episodeQueryFlow.value = query
+    }
+
+    fun clearSubjectQuery() {
+        subjectQueryFlow.value = null
+    }
+
+    fun setSubjectIndex(index: Int) {
+        selectedSubjectIndexFlow.value = index
+    }
+
+    // endregion
+
+    private fun createSelectorSearchQuery(
+        query: SubjectQuery,
+        episodeQuery: EpisodeQuery
+    ) = SelectorSearchQuery(
+        subjectName = query.searchKeyword,
+        episodeSort = episodeQuery.sort,
+        allSubjectNames = setOf(query.searchKeyword),
+        episodeName = null,
+        episodeEp = null,
+    )
+
+    private suspend fun searchEpisodes(subjectDetailsPageUrl: String): Result<Document?> {
+        return try {
+            Result.success(engine.searchEpisodes(subjectDetailsPageUrl))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun searchSubject(
+        url: String?,
+        searchKeyword: String,
+        useOnlyFirstWord: Boolean?,
+        removeSpecial: Boolean?
+    ) =
+        if (url.isNullOrBlank() || searchKeyword.isBlank() || useOnlyFirstWord == null || removeSpecial == null) {
+            null
+        } else {
+            try {
+                val res = engine.searchSubjects(
+                    searchUrl = url,
+                    searchKeyword,
+                    useOnlyFirstWord = useOnlyFirstWord,
+                    removeSpecial = removeSpecial,
+                )
+                Result.success(res)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Result.failure(e)
+            }
+        }
+
+
+    private fun convertEpisodeResult(
+        res: Result<Document?>,
+        config: SelectorSearchConfig,
+        query: SelectorSearchQuery,
+        subjectUrl: String,
+    ): SelectorTestEpisodeListResult {
+        return res.fold(
+            onSuccess = { document ->
+                try {
+                    document ?: return SelectorTestEpisodeListResult.Success(null, emptyList())
+                    val episodeList = engine.selectEpisodes(document, subjectUrl, config)
+                        ?: return SelectorTestEpisodeListResult.InvalidConfig
+                    SelectorTestEpisodeListResult.Success(
+                        episodeList.channels,
+                        episodeList.episodes
+                            .fastDistinctBy { it.playUrl }
+                            .map {
+                                SelectorTestEpisodePresentation.compute(it, query, document, config)
+                            },
+                    )
+                } catch (e: Throwable) {
+                    SelectorTestEpisodeListResult.UnknownError(e)
+                }
+            },
+            onFailure = { reason ->
+                if (reason is RepositoryException) {
+                    SelectorTestEpisodeListResult.ApiError(reason)
+                } else {
+                    SelectorTestEpisodeListResult.UnknownError(reason)
+                }
+            },
+        )
+    }
+
+    private fun selectSubjectResult(
+        res: Result<SelectorMediaSourceEngine.SearchSubjectResult>,
+        searchConfig: SelectorSearchConfig,
+        query: SelectorSearchQuery,
+    ): SelectorTestSearchSubjectResult {
+        return res.fold(
+            onSuccess = { data ->
+                val document = data.document
+
+                val originalList = if (document == null) {
+                    emptyList()
+                } else {
+                    engine.selectSubjects(document, searchConfig).let { list ->
+                        if (list == null) {
+                            return SelectorTestSearchSubjectResult.InvalidConfig
+                        }
+                        list
+                    }
+                }
+
+                SelectorTestSearchSubjectResult.Success(
+                    data.url.toString(),
+                    originalList.map {
+                        SelectorTestSubjectPresentation.compute(
+                            it,
+                            query,
+                            document,
+                            searchConfig.filterBySubjectName,
+                        )
+                    },
+                )
+            },
+            onFailure = { reason ->
+                if (reason is RepositoryException) {
+                    SelectorTestSearchSubjectResult.ApiError(reason)
+                } else {
+                    SelectorTestSearchSubjectResult.UnknownError(reason)
+                }
+            },
+        )
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorTestSearchSubjectResult.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/test/web/SelectorTestSearchSubjectResult.kt
@@ -7,18 +7,18 @@
  * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
-package me.him188.ani.app.ui.settings.mediasource.selector.test
+package me.him188.ani.app.domain.mediasource.test.web
 
 import androidx.compose.runtime.Immutable
 import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.MediaListFilters
+import me.him188.ani.app.domain.mediasource.test.MatchTag
+import me.him188.ani.app.domain.mediasource.test.RefreshResult
+import me.him188.ani.app.domain.mediasource.test.buildMatchTags
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
 import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
 import me.him188.ani.app.domain.mediasource.web.asCandidate
 import me.him188.ani.app.domain.mediasource.web.toFilterContext
-import me.him188.ani.app.ui.settings.mediasource.RefreshResult
-import me.him188.ani.app.ui.settings.mediasource.rss.test.MatchTag
-import me.him188.ani.app.ui.settings.mediasource.rss.test.buildMatchTags
 import me.him188.ani.utils.xml.Element
 
 // For UI

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
@@ -56,6 +56,9 @@ import me.him188.ani.utils.xml.Html
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * For [SelectorMediaSourceEngine.selectMedia]
+ */
 data class SelectorSearchQuery(
     val subjectName: String,
     val allSubjectNames: Set<String>,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
@@ -25,8 +25,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
-import me.him188.ani.app.data.models.ApiResponse
-import me.him188.ani.app.data.models.runApiRequest
+import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.MediaListFilter
 import me.him188.ani.app.domain.mediasource.MediaListFilterContext
 import me.him188.ani.app.domain.mediasource.MediaListFilters
@@ -38,6 +37,7 @@ import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatConfig
 import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormat
 import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.MediaProperties
 import me.him188.ani.datasources.api.SubtitleKind
 import me.him188.ani.datasources.api.matcher.WebVideo
@@ -54,6 +54,7 @@ import me.him188.ani.utils.xml.Document
 import me.him188.ani.utils.xml.Element
 import me.him188.ani.utils.xml.Html
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 
 data class SelectorSearchQuery(
     val subjectName: String,
@@ -71,12 +72,15 @@ fun SelectorSearchQuery.toFilterContext() = MediaListFilterContext(
 )
 
 /**
+ * 基于 CSS Selector 解析页面的数据源引擎.
+ *
  * 解析流程:
  *
- * [SelectorMediaSourceEngine.searchSubjects]
- * -> [SelectorMediaSourceEngine.selectSubjects]
- * -> [SelectorMediaSourceEngine.searchEpisodes]
- * -> [SelectorMediaSourceEngine.selectEpisodes]
+ * 1. 搜索条目列表: [SelectorMediaSourceEngine.searchSubjects]
+ * 2. 解析条目页面: [SelectorMediaSourceEngine.selectSubjects]
+ * 3. 搜索一个条目的剧集列表 [SelectorMediaSourceEngine.searchEpisodes]
+ * 4. 解析剧集列表页面 [SelectorMediaSourceEngine.selectEpisodes]
+ * 5. 将剧集信息转换为 [Media]: [SelectorMediaSourceEngine.selectMedia]
  */
 abstract class SelectorMediaSourceEngine {
     companion object {
@@ -96,12 +100,16 @@ abstract class SelectorMediaSourceEngine {
         override fun toString(): String = "SearchSubjectResult(url=$url, document=${document.toString().length}...)"
     }
 
+    /**
+     * 根据给定信息搜索条目列表.
+     */
+    @Throws(RepositoryException::class, CancellationException::class)
     suspend fun searchSubjects(
         searchUrl: String,
         subjectName: String,
         useOnlyFirstWord: Boolean,
         removeSpecial: Boolean,
-    ): ApiResponse<SearchSubjectResult> {
+    ): SearchSubjectResult {
         val finalName = if (removeSpecial) {
             MediaListFilters.removeSpecials(
                 subjectName,
@@ -127,11 +135,14 @@ abstract class SelectorMediaSourceEngine {
         return string.substringBefore(' ').ifBlank { string }
     }
 
+    @Throws(RepositoryException::class, CancellationException::class)
     protected abstract suspend fun searchImpl(
         finalUrl: Url,
-    ): ApiResponse<SearchSubjectResult>
+    ): SearchSubjectResult
 
     /**
+     * 解析条目搜索结果. 返回该页面的所有条目.
+     *
      * @return `null` if config is invalid
      */
     open fun selectSubjects(
@@ -155,12 +166,12 @@ abstract class SelectorMediaSourceEngine {
 
     suspend fun searchEpisodes(
         subjectDetailsPageUrl: String,
-    ): ApiResponse<Document?> = try {
+    ): Document? = try {
         doHttpGet(subjectDetailsPageUrl)
     } catch (e: ClientRequestException) {
         e.response.status.let {
             if (it == HttpStatusCode.NotFound) {
-                return ApiResponse.success(null)
+                return null
             }
             throw e
         }
@@ -325,7 +336,8 @@ abstract class SelectorMediaSourceEngine {
         )
     }
 
-    protected abstract suspend fun doHttpGet(uri: String): ApiResponse<Document>
+    @Throws(RepositoryException::class, CancellationException::class)
+    protected abstract suspend fun doHttpGet(uri: String): Document
 }
 
 // TODO: require MediaListFilterContext when context parameters
@@ -358,8 +370,8 @@ class DefaultSelectorMediaSourceEngine(
 ) : SelectorMediaSourceEngine() {
     override suspend fun searchImpl(
         finalUrl: Url,
-    ): ApiResponse<SearchSubjectResult> = withContext(ioDispatcher) {
-        runApiRequest {
+    ): SearchSubjectResult = withContext(ioDispatcher) {
+        try {
             val document = try {
                 client.first().get(finalUrl) {
                     accept(ContentType.Text.Html)
@@ -369,7 +381,7 @@ class DefaultSelectorMediaSourceEngine(
             } catch (e: ClientRequestException) {
                 if (e.response.status == HttpStatusCode.NotFound) {
                     // 404 Not Found
-                    return@runApiRequest SearchSubjectResult(
+                    return@withContext SearchSubjectResult(
                         finalUrl,
                         document = null,
                     )
@@ -381,17 +393,22 @@ class DefaultSelectorMediaSourceEngine(
                 finalUrl,
                 document,
             )
+        } catch (e: Exception) {
+            throw RepositoryException.wrapOrThrowCancellation(e)
         }
     }
 
 
-    public override suspend fun doHttpGet(uri: String): ApiResponse<Document> = withContext(ioDispatcher) {
-        runApiRequest {
+    @Throws(RepositoryException::class, CancellationException::class)
+    public override suspend fun doHttpGet(uri: String): Document = withContext(ioDispatcher) {
+        try {
             client.first().get(uri) {
                 accept(ContentType.Text.Html)
             }.let { resp ->
                 parseResp(resp)
             }
+        } catch (e: Exception) {
+            throw RepositoryException.wrapOrThrowCancellation(e)
         }
     }
 

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePane.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePane.android.kt
@@ -18,15 +18,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.tooling.preview.Preview
 import me.him188.ani.app.domain.media.resolver.TestWebViewVideoExtractor
 import me.him188.ani.app.domain.mediasource.codec.createTestMediaSourceCodecManager
+import me.him188.ani.app.domain.mediasource.test.buildMatchTags
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceArguments
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.ui.foundation.ProvideFoundationCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.settings.mediasource.rss.createTestSaveableStorage
-import me.him188.ani.app.ui.settings.mediasource.rss.test.buildMatchTags
 import me.him188.ani.app.ui.settings.mediasource.selector.EditSelectorMediaSourcePageState
-import me.him188.ani.app.ui.settings.mediasource.selector.test.SelectorTestEpisodePresentation
 import me.him188.ani.app.ui.settings.mediasource.selector.test.TestSelectorMediaSourceEngine
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.utils.platform.annotations.TestOnly

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.android.kt
@@ -21,8 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.tooling.preview.Preview
 import io.ktor.http.Url
-import me.him188.ani.app.data.models.ApiResponse
-import me.him188.ani.app.data.models.networkError
+import kotlinx.io.IOException
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
@@ -45,9 +44,9 @@ fun PreviewSelectorTestPane() = ProvideFoundationCompositionLocalsForPreview {
                         SelectorTestState(
                             searchConfigState = mutableStateOf(SelectorSearchConfig.Empty),
                             engine = TestSelectorMediaSourceEngine(),
-                            scope,
+                            backgroundScope = scope,
                         ).apply {
-                            subjectSearcher.restartCurrentSearch()
+                            restartCurrentSubjectSearch()
                         }
                     },
                     {},
@@ -63,12 +62,10 @@ fun PreviewSelectorTestPane() = ProvideFoundationCompositionLocalsForPreview {
 class TestSelectorMediaSourceEngine : SelectorMediaSourceEngine() {
     override suspend fun searchImpl(
         finalUrl: Url
-    ): ApiResponse<SearchSubjectResult> {
-        return ApiResponse.success(
-            SearchSubjectResult(
-                Url("https://example.com"),
-                null,
-            ),
+    ): SearchSubjectResult {
+        return SearchSubjectResult(
+            Url("https://example.com"),
+            null,
         )
     }
 
@@ -81,7 +78,7 @@ class TestSelectorMediaSourceEngine : SelectorMediaSourceEngine() {
         )
     }
 
-    override suspend fun doHttpGet(uri: String): ApiResponse<Document> {
-        return ApiResponse.networkError()
+    override suspend fun doHttpGet(uri: String): Document {
+        throw IOException("Dummy")
     }
 }

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.android.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.tooling.preview.Preview
 import io.ktor.http.Url
 import kotlinx.io.IOException
+import me.him188.ani.app.domain.mediasource.test.web.SelectorMediaSourceTester
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
@@ -43,7 +44,7 @@ fun PreviewSelectorTestPane() = ProvideFoundationCompositionLocalsForPreview {
                     remember {
                         SelectorTestState(
                             searchConfigState = mutableStateOf(SelectorSearchConfig.Empty),
-                            engine = TestSelectorMediaSourceEngine(),
+                            tester = SelectorMediaSourceTester(TestSelectorMediaSourceEngine()),
                             backgroundScope = scope,
                         ).apply {
                             restartCurrentSubjectSearch()

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SubjectResultLazyRow.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/mediasource/selector/test/SubjectResultLazyRow.android.kt
@@ -20,8 +20,9 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
+import me.him188.ani.app.domain.mediasource.test.MatchTag
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestSubjectPresentation
 import me.him188.ani.app.ui.foundation.ProvideFoundationCompositionLocalsForPreview
-import me.him188.ani.app.ui.settings.mediasource.rss.test.MatchTag
 import me.him188.ani.utils.platform.annotations.TestOnly
 import me.him188.ani.utils.xml.Element
 import kotlin.random.Random

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/detail/RssDetailPane.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/detail/RssDetailPane.android.kt
@@ -15,7 +15,7 @@ import me.him188.ani.app.domain.media.TestMediaList
 import me.him188.ani.app.ui.foundation.preview.PreviewTabletLightDark
 import me.him188.ani.app.ui.settings.mediasource.rss.detail.RssDetailPane
 import me.him188.ani.app.ui.settings.mediasource.rss.detail.RssViewingItem
-import me.him188.ani.app.ui.settings.tabs.media.source.rss.test.TestRssItemPresentations
+import me.him188.ani.app.ui.settings.tabs.media.source.rss.test.TestRssItemInfos
 import me.him188.ani.utils.platform.annotations.TestOnly
 
 @OptIn(TestOnly::class)
@@ -25,9 +25,9 @@ import me.him188.ani.utils.platform.annotations.TestOnly
 fun PreviewRssDetailPaneRssItemShowTopBar() {
     RssDetailPane(
         RssViewingItem.ViewingRssItem(
-            TestRssItemPresentations[0],
+            TestRssItemInfos[0],
         ),
-        mediaDetailsColumn = {}
+        mediaDetailsColumn = {},
     )
 }
 
@@ -38,9 +38,9 @@ fun PreviewRssDetailPaneRssItemShowTopBar() {
 fun PreviewRssDetailPaneRssItem() {
     RssDetailPane(
         RssViewingItem.ViewingRssItem(
-            TestRssItemPresentations[0],
+            TestRssItemInfos[0],
         ),
-        mediaDetailsColumn = {}
+        mediaDetailsColumn = {},
     )
 }
 

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/OverviewTab.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/OverviewTab.android.kt
@@ -19,12 +19,12 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import me.him188.ani.app.domain.media.TestMediaList
+import me.him188.ani.app.domain.mediasource.test.MatchTag
 import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.app.domain.rss.RssChannel
 import me.him188.ani.app.domain.rss.RssEnclosure
 import me.him188.ani.app.domain.rss.RssItem
 import me.him188.ani.app.ui.foundation.preview.PreviewTabletLightDark
-import me.him188.ani.app.ui.settings.mediasource.rss.test.MatchTag
 import me.him188.ani.app.ui.settings.mediasource.rss.test.OverviewTab
 import me.him188.ani.app.ui.settings.mediasource.rss.test.RssTestPaneDefaults
 import me.him188.ani.app.ui.settings.mediasource.rss.test.RssTestResult

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/OverviewTab.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/OverviewTab.android.kt
@@ -19,13 +19,13 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import me.him188.ani.app.domain.media.TestMediaList
+import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.app.domain.rss.RssChannel
 import me.him188.ani.app.domain.rss.RssEnclosure
 import me.him188.ani.app.domain.rss.RssItem
 import me.him188.ani.app.ui.foundation.preview.PreviewTabletLightDark
 import me.him188.ani.app.ui.settings.mediasource.rss.test.MatchTag
 import me.him188.ani.app.ui.settings.mediasource.rss.test.OverviewTab
-import me.him188.ani.app.ui.settings.mediasource.rss.test.RssItemPresentation
 import me.him188.ani.app.ui.settings.mediasource.rss.test.RssTestPaneDefaults
 import me.him188.ani.app.ui.settings.mediasource.rss.test.RssTestResult
 import me.him188.ani.datasources.api.topic.titles.ParsedTopicTitle
@@ -63,9 +63,9 @@ internal val TestRssItems
     )
 
 @TestOnly
-internal val TestRssItemPresentations
+internal val TestRssItemInfos
     get() = listOf(
-        RssItemPresentation(
+        RssItemInfo(
             RssItem(
                 title = "Title",
                 description = "Description",
@@ -80,7 +80,7 @@ internal val TestRssItemPresentations
                 MatchTag("1080P"),
             ),
         ),
-        RssItemPresentation(
+        RssItemInfo(
             RssItem(
                 title = "Title",
                 description = "Description",
@@ -108,7 +108,7 @@ private fun PreviewOverviewTab() {
                 RssTestResult.Success(
                     "https://example.com",
                     TestRssChannel,
-                    TestRssItemPresentations,
+                    TestRssItemInfos,
                     TestMediaList,
                     null,
                 )

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/RssInfoTab.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/rss/test/RssInfoTab.android.kt
@@ -22,8 +22,8 @@ import me.him188.ani.utils.platform.annotations.TestOnly
 @PreviewTabletLightDark
 fun PreviewRssInfoTab() {
     RssTestPaneDefaults.RssInfoTab(
-        items = TestRssItemPresentations,
+        items = TestRssItemInfos,
         onViewDetails = { },
-        selectedItemProvider = { TestRssItemPresentations[1] },
+        selectedItemProvider = { TestRssItemInfos[1] },
     )
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/RefreshIndicatedHeadlineRow.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/RefreshIndicatedHeadlineRow.kt
@@ -38,7 +38,12 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import me.him188.ani.app.data.models.ApiFailure
+import me.him188.ani.app.data.repository.RepositoryAuthorizationException
+import me.him188.ani.app.data.repository.RepositoryException
+import me.him188.ani.app.data.repository.RepositoryNetworkException
+import me.him188.ani.app.data.repository.RepositoryRateLimitedException
+import me.him188.ani.app.data.repository.RepositoryServiceUnavailableException
+import me.him188.ani.app.data.repository.RepositoryUnknownException
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 
 /**
@@ -61,7 +66,7 @@ interface RefreshResult {
      * 一个已知类型的 API 错误
      */
     interface ApiError : Failed {
-        val reason: ApiFailure
+        val exception: RepositoryException
     }
 
     /**
@@ -147,10 +152,12 @@ object RefreshIndicationDefaults {
             Text(
                 when (result) {
                     is RefreshResult.ApiError -> {
-                        when (result.reason) {
-                            ApiFailure.NetworkError -> "网络错误"
-                            ApiFailure.ServiceUnavailable -> "服务器错误"
-                            ApiFailure.Unauthorized -> "未授权"
+                        when (result.exception) {
+                            is RepositoryAuthorizationException -> "未授权"
+                            is RepositoryNetworkException -> "网络错误"
+                            is RepositoryRateLimitedException -> "请求过快"
+                            is RepositoryServiceUnavailableException -> "服务器错误"
+                            is RepositoryUnknownException -> "未知错误: ${result.exception}"
                         }
                     }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/RefreshIndicatedHeadlineRow.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/RefreshIndicatedHeadlineRow.kt
@@ -39,48 +39,13 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.repository.RepositoryAuthorizationException
-import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.data.repository.RepositoryNetworkException
 import me.him188.ani.app.data.repository.RepositoryRateLimitedException
 import me.him188.ani.app.data.repository.RepositoryServiceUnavailableException
 import me.him188.ani.app.data.repository.RepositoryUnknownException
+import me.him188.ani.app.domain.mediasource.test.RefreshResult
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 
-/**
- * 标记接口, 表示一个通用的刷新结果.
- */
-interface RefreshResult {
-    /**
-     * 刷新成功, 不会显示错误按钮.
-     */
-    interface Success : RefreshResult
-
-    interface InProgress : RefreshResult
-
-    /**
-     * 刷新失败, 会显示错误按钮.
-     */
-    sealed interface Failed : RefreshResult
-
-    /**
-     * 一个已知类型的 API 错误
-     */
-    interface ApiError : Failed {
-        val exception: RepositoryException
-    }
-
-    /**
-     * 配置有误, 例如测试 RSS 数据源. UI 只会显示 "配置不完整". 你需要让你的编辑框自己显示 error.
-     */
-    interface InvalidConfig : Failed
-
-    /**
-     * 一个任意类型异常. 这属于不期望遇到的错误 (bug).
-     */
-    interface UnknownError : Failed {
-        val exception: Throwable
-    }
-}
 
 /**
  * 包含一个 Text, 一个刷新按钮, 一个错误提示的 [Row].

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
@@ -65,6 +65,7 @@ import me.him188.ani.app.ui.settings.mediasource.DropdownMenuImport
 import me.him188.ani.app.ui.settings.mediasource.ExportMediaSourceState
 import me.him188.ani.app.ui.settings.mediasource.ImportMediaSourceState
 import me.him188.ani.app.ui.settings.mediasource.MediaSourceConfigurationDefaults
+import me.him188.ani.app.ui.settings.mediasource.observeTestDataChanges
 import me.him188.ani.app.ui.settings.mediasource.rss.detail.RssDetailPane
 import me.him188.ani.app.ui.settings.mediasource.rss.detail.SideSheetPane
 import me.him188.ani.app.ui.settings.mediasource.rss.edit.RssEditPane
@@ -161,7 +162,7 @@ fun EditRssMediaSourcePage(
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
     LaunchedEffect(Unit) {
-        testState.searcher.observeChangeLoop()
+        testState.searcher.observeTestDataChanges(testState.testDataState)
     }
 
     Scaffold(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/detail/RssDetailPane.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/detail/RssDetailPane.kt
@@ -43,9 +43,10 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.app.tools.formatDateTime
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
-import me.him188.ani.app.ui.settings.mediasource.rss.test.RssItemPresentation
+import me.him188.ani.app.ui.settings.mediasource.rss.test.subtitleLanguageRendered
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.isSingleEpisode
 
@@ -100,7 +101,7 @@ fun RssDetailPane(
 
 @Composable
 private fun RssItemDetailColumn(
-    item: RssItemPresentation,
+    item: RssItemInfo,
     modifier: Modifier = Modifier,
 ) {
     val browser = LocalUriHandler.current

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/detail/RssViewingItem.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/detail/RssViewingItem.kt
@@ -10,7 +10,7 @@
 package me.him188.ani.app.ui.settings.mediasource.rss.detail
 
 import androidx.compose.runtime.Immutable
-import me.him188.ani.app.ui.settings.mediasource.rss.test.RssItemPresentation
+import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.datasources.api.Media
 
 /**
@@ -24,5 +24,5 @@ sealed class RssViewingItem {
     class ViewingMedia(override val value: Media) : RssViewingItem()
 
     @Immutable
-    class ViewingRssItem(override val value: RssItemPresentation) : RssViewingItem()
+    class ViewingRssItem(override val value: RssItemInfo) : RssViewingItem()
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/OutlinedMatchTag.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/OutlinedMatchTag.kt
@@ -19,41 +19,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import me.him188.ani.app.domain.mediasource.test.MatchTag
 import me.him188.ani.app.ui.foundation.OutlinedTag
-
-@Immutable
-class MatchTag(
-    val value: String,
-    /**
-     * 该标签表示一个缺失的项目. 例如缺失 EP.
-     */
-    val isMissing: Boolean = false,
-    /**
-     * 该标签是否匹配了用户的搜索条件.
-     * - `true`: 满足了一个条件. UI 显示为紫色的 check
-     * - `false`: 不满足条件. UI 显示为红色的 close
-     * - `null`: 这不是一个搜索条件. UI 不会特别高亮此标签.
-     */
-    val isMatch: Boolean? = null,
-)
-
-class MatchTagsBuilder
-@PublishedApi
-internal constructor() {
-    private val list = mutableListOf<MatchTag>()
-
-    fun emit(value: String, isMissing: Boolean = false, isMatch: Boolean? = null) {
-        list.add(MatchTag(value, isMissing, isMatch))
-    }
-
-    @PublishedApi
-    internal fun build(): List<MatchTag> = list
-}
-
-inline fun buildMatchTags(builder: MatchTagsBuilder.() -> Unit): List<MatchTag> =
-    MatchTagsBuilder().apply(builder).build()
 
 @Composable
 fun OutlinedMatchTag(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestPane.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestPane.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -53,6 +54,7 @@ fun RssTestPane(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
+    val searchResult by state.searcher.searchResultFlow.collectAsStateWithLifecycle()
     Column(
         modifier
             .padding(contentPadding),
@@ -71,7 +73,7 @@ fun RssTestPane(
             RefreshIndicatedHeadlineRow(
                 headline = { Text("查询结果") },
                 onRefresh = { state.searcher.restartCurrentSearch() },
-                result = state.searcher.searchResult,
+                result = searchResult,
                 Modifier.padding(top = 20.dp),
             )
 
@@ -115,7 +117,7 @@ fun RssTestPane(
             }
         }
 
-        Crossfade(state.searcher.searchResult, Modifier.padding(top = 20.dp)) { result ->
+        Crossfade(searchResult, Modifier.padding(top = 20.dp)) { result ->
 
             HorizontalPager(
                 pagerState,

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestPaneState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestPaneState.kt
@@ -24,6 +24,7 @@ import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.rss.RssMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.rss.RssSearchConfig
 import me.him188.ani.app.domain.mediasource.rss.RssSearchQuery
+import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.app.ui.settings.mediasource.AbstractMediaSourceTestState
 import me.him188.ani.app.ui.settings.mediasource.BackgroundSearcher
 import me.him188.ani.app.ui.settings.mediasource.rss.EditRssMediaSourceState
@@ -38,7 +39,7 @@ import kotlin.coroutines.cancellation.CancellationException
  * @see EditRssMediaSourceState
  * @see RssTestResult
  * @see RssTestData
- * @see RssItemPresentation.compute
+ * @see RssItemInfo.compute
  */
 @Stable
 class RssTestPaneState(
@@ -73,7 +74,7 @@ class RssTestPaneState(
         viewingItem = RssViewingItem.ViewingMedia(media)
     }
 
-    fun viewDetails(rssItem: RssItemPresentation) {
+    fun viewDetails(rssItem: RssItemInfo) {
         viewingItem = RssViewingItem.ViewingRssItem(rssItem)
     }
 
@@ -140,7 +141,7 @@ class RssTestPaneState(
             encodedUrl.toString(),
             channel,
             channel.items.map {
-                RssItemPresentation.compute(it, searchConfigState.value, query)
+                RssItemInfo.compute(it, searchConfigState.value, query)
             },
             matchedMediaList,
             origin = document,

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestResult.kt
@@ -11,8 +11,9 @@ package me.him188.ani.app.ui.settings.mediasource.rss.test
 
 import androidx.compose.runtime.Immutable
 import me.him188.ani.app.data.repository.RepositoryException
+import me.him188.ani.app.domain.mediasource.test.RefreshResult
+import me.him188.ani.app.domain.mediasource.test.rss.RssItemInfo
 import me.him188.ani.app.domain.rss.RssChannel
-import me.him188.ani.app.ui.settings.mediasource.RefreshResult
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.utils.xml.Element
 
@@ -25,7 +26,7 @@ sealed class RssTestResult : RefreshResult { // for ui
     data class Success(
         val encodedUrl: String,
         val channel: RssChannel,
-        val rssItems: List<RssItemPresentation>,
+        val rssItems: List<RssItemInfo>,
         val mediaList: List<Media>,
         val origin: Element?,
     ) : RssTestResult(), RefreshResult.Success {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/test/RssTestResult.kt
@@ -10,7 +10,7 @@
 package me.him188.ani.app.ui.settings.mediasource.rss.test
 
 import androidx.compose.runtime.Immutable
-import me.him188.ani.app.data.models.ApiFailure
+import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.rss.RssChannel
 import me.him188.ani.app.ui.settings.mediasource.RefreshResult
 import me.him188.ani.datasources.api.Media
@@ -36,7 +36,7 @@ sealed class RssTestResult : RefreshResult { // for ui
 
     @Immutable
     data class ApiError(
-        override val reason: ApiFailure,
+        override val exception: RepositoryException,
     ) : Failed(), RefreshResult.ApiError
 
     @Immutable

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
@@ -63,6 +63,7 @@ import me.him188.ani.app.ui.settings.mediasource.DropdownMenuImport
 import me.him188.ani.app.ui.settings.mediasource.ExportMediaSourceState
 import me.him188.ani.app.ui.settings.mediasource.ImportMediaSourceState
 import me.him188.ani.app.ui.settings.mediasource.MediaSourceConfigurationDefaults
+import me.him188.ani.app.ui.settings.mediasource.observeTestDataChanges
 import me.him188.ani.app.ui.settings.mediasource.rss.SaveableStorage
 import me.him188.ani.app.ui.settings.mediasource.selector.edit.SelectorConfigState
 import me.him188.ani.app.ui.settings.mediasource.selector.edit.SelectorConfigurationPane
@@ -222,13 +223,10 @@ fun EditSelectorMediaSourcePage(
 
         // 在外面启动, 避免在切换页面后重新启动导致刷新
         LaunchedEffect(state) {
-            state.testState.subjectSearcher.observeChangeLoop()
+            state.episodeState.searcher.observeTestDataChanges(state.episodeState.searcherTestDataState)
         }
         LaunchedEffect(state) {
-            state.testState.episodeListSearcher.observeChangeLoop()
-        }
-        LaunchedEffect(state) {
-            state.episodeState.searcher.observeChangeLoop()
+            state.testState.observeChanges()
         }
 
         ListDetailPaneScaffold(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
@@ -46,6 +46,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import me.him188.ani.app.domain.media.resolver.WebViewVideoExtractor
 import me.him188.ani.app.domain.mediasource.codec.MediaSourceCodecManager
+import me.him188.ani.app.domain.mediasource.test.web.SelectorMediaSourceTester
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceArguments
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.platform.Context
@@ -72,7 +74,6 @@ import me.him188.ani.app.ui.settings.mediasource.selector.episode.SelectorEpisod
 import me.him188.ani.app.ui.settings.mediasource.selector.episode.SelectorEpisodePaneRoutes
 import me.him188.ani.app.ui.settings.mediasource.selector.episode.SelectorEpisodeState
 import me.him188.ani.app.ui.settings.mediasource.selector.episode.SelectorTestAndEpisodePane
-import me.him188.ani.app.ui.settings.mediasource.selector.test.SelectorTestEpisodePresentation
 import me.him188.ani.app.ui.settings.mediasource.selector.test.SelectorTestState
 import kotlin.coroutines.CoroutineContext
 
@@ -92,7 +93,7 @@ class EditSelectorMediaSourcePageState(
     )
 
     internal val testState: SelectorTestState =
-        SelectorTestState(configurationState.searchConfigState, engine, backgroundScope)
+        SelectorTestState(configurationState.searchConfigState, SelectorMediaSourceTester(engine), backgroundScope)
 
     private val viewingItemState = mutableStateOf<SelectorTestEpisodePresentation?>(null)
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePaneDefaults.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePaneDefaults.kt
@@ -25,12 +25,14 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
@@ -47,6 +49,7 @@ object SelectorEpisodePaneDefaults {
         windowInsets: WindowInsets = WindowInsets(0.dp),
     ) {
         val onRefresh = { state.searcher.restartCurrentSearch() }
+        val searchResult by state.searcher.searchResultFlow.collectAsStateWithLifecycle()
         TopAppBar(
             navigationIcon = {
                 TopAppBarGoBackButton()
@@ -61,7 +64,7 @@ object SelectorEpisodePaneDefaults {
                         onClick = onRefresh,
                     )
                     RefreshIndicationDefaults.RefreshResultTextButton(
-                        result = state.searcher.searchResult,
+                        result = searchResult,
                         onRefresh = onRefresh,
                     )
                 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeResult.kt
@@ -12,7 +12,7 @@ package me.him188.ani.app.ui.settings.mediasource.selector.episode
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.StateFlow
 import me.him188.ani.app.data.repository.RepositoryException
-import me.him188.ani.app.ui.settings.mediasource.RefreshResult
+import me.him188.ani.app.domain.mediasource.test.RefreshResult
 
 sealed class SelectorEpisodeResult : RefreshResult {
     data class InProgress(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeResult.kt
@@ -11,7 +11,7 @@ package me.him188.ani.app.ui.settings.mediasource.selector.episode
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.StateFlow
-import me.him188.ani.app.data.models.ApiFailure
+import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.ui.settings.mediasource.RefreshResult
 
 sealed class SelectorEpisodeResult : RefreshResult {
@@ -24,7 +24,7 @@ sealed class SelectorEpisodeResult : RefreshResult {
     ) : SelectorEpisodeResult(), RefreshResult.Success
 
     object InvalidConfig : SelectorEpisodeResult(), RefreshResult.InvalidConfig
-    data class ApiError(override val reason: ApiFailure) : SelectorEpisodeResult(), RefreshResult.ApiError
+    data class ApiError(override val exception: RepositoryException) : SelectorEpisodeResult(), RefreshResult.ApiError
     data class UnknownError(override val exception: Throwable) : SelectorEpisodeResult(), RefreshResult.UnknownError
 }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeState.kt
@@ -20,12 +20,12 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeoutOrNull
 import me.him188.ani.app.domain.media.resolver.WebViewVideoExtractor
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.platform.Context
 import me.him188.ani.app.ui.settings.mediasource.BackgroundSearcher
 import me.him188.ani.app.ui.settings.mediasource.launchCollectedInBackground
-import me.him188.ani.app.ui.settings.mediasource.selector.test.SelectorTestEpisodePresentation
 import me.him188.ani.datasources.api.matcher.WebVideo
 import me.him188.ani.datasources.api.matcher.WebViewConfig
 import me.him188.ani.datasources.api.matcher.videoOrNull

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodeState.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeoutOrNull
@@ -60,15 +61,16 @@ class SelectorEpisodeState(
     val episodeName: String by derivedStateOf { itemState.value?.name ?: "" }
     val episodeUrl: String by derivedStateOf { itemState.value?.playUrl ?: "" }
 
+    val searcherTestDataState = derivedStateOf {
+        Pair(itemState.value?.playUrl, webViewVideoExtractor.value)
+    }
+
     /**
      * 该页面的所有链接
      */
     val searcher =
-        BackgroundSearcher(
+        BackgroundSearcher<Pair<String?, WebViewVideoExtractor?>, SelectorEpisodeResult>(
             backgroundScope,
-            testDataState = derivedStateOf {
-                Pair(itemState.value?.playUrl, webViewVideoExtractor.value)
-            },
         ) { (episodeUrl, extractor) ->
             // Dot trigger re-fetch on config change.
             val config = matchVideoConfigState.value
@@ -126,30 +128,32 @@ class SelectorEpisodeState(
     /**
      * 不断更新的匹配结果
      */
-    val rawMatchResults: Flow<List<MatchResult>> by derivedStateOf {
+    val rawMatchResults: Flow<List<MatchResult>> by derivedStateOf { // TODO: 2024/12/14 this is shit 
         val matchVideoConfig = matchVideoConfigState.value ?: return@derivedStateOf emptyFlow()
-        val searchResult = searcher.searchResult ?: return@derivedStateOf emptyFlow()
-        val flow = when (searchResult) {
-            is SelectorEpisodeResult.ApiError,
-            is SelectorEpisodeResult.UnknownError,
-            is SelectorEpisodeResult.InvalidConfig,
-                -> return@derivedStateOf emptyFlow()
+        searcher.searchResultFlow.flatMapLatest { searchResult ->
+            searchResult ?: return@flatMapLatest emptyFlow()
+            val flow = when (searchResult) {
+                is SelectorEpisodeResult.ApiError,
+                is SelectorEpisodeResult.UnknownError,
+                is SelectorEpisodeResult.InvalidConfig,
+                    -> return@flatMapLatest emptyFlow()
 
-            is SelectorEpisodeResult.InProgress -> searchResult.flow
-            is SelectorEpisodeResult.Success -> searchResult.flow
-        }
+                is SelectorEpisodeResult.InProgress -> searchResult.flow
+                is SelectorEpisodeResult.Success -> searchResult.flow
+            }
 
-        flow.map { list ->
-            list.asSequence()
-                .map { original ->
-                    MatchResult(original, engine.matchWebVideo(original.url, matchVideoConfig).videoOrNull)
-                }
-                .distinctBy { it.key } // O(n) extra space, O(1) time
-                .toMutableList() // single list instance construction
-                .apply {
-                    // sort in-place for better performance
-                    sortByDescending { it.isMatchedVideo() } // 优先展示匹配的
-                }
+            flow.map { list ->
+                list.asSequence()
+                    .map { original ->
+                        MatchResult(original, engine.matchWebVideo(original.url, matchVideoConfig).videoOrNull)
+                    }
+                    .distinctBy { it.key } // O(n) extra space, O(1) time
+                    .toMutableList() // single list instance construction
+                    .apply {
+                        // sort in-place for better performance
+                        sortByDescending { it.isMatchedVideo() } // 优先展示匹配的
+                    }
+            }
         }.flowOn(flowDispatcher) // possibly significant computation
     }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectTestEpisodeResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectTestEpisodeResult.kt
@@ -10,7 +10,7 @@
 package me.him188.ani.app.ui.settings.mediasource.selector.test
 
 import androidx.compose.runtime.Immutable
-import me.him188.ani.app.data.models.ApiFailure
+import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
 import me.him188.ani.app.domain.mediasource.web.WebSearchEpisodeInfo
@@ -34,7 +34,7 @@ sealed class SelectorTestEpisodeListResult : RefreshResult {
 
     @Immutable
     data class ApiError(
-        override val reason: ApiFailure
+        override val exception: RepositoryException
     ) : SelectorTestEpisodeListResult(), RefreshResult.ApiError
 
     @Immutable

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestEpisodeList.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestEpisodeList.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
 import me.him188.ani.app.ui.foundation.layout.cardHorizontalPadding
 import me.him188.ani.app.ui.foundation.layout.cardVerticalPadding
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.kt
@@ -49,6 +49,9 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodeListResult
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestSearchSubjectResult
 import me.him188.ani.app.ui.foundation.layout.cardHorizontalPadding
 import me.him188.ani.app.ui.foundation.layout.cardVerticalPadding
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
@@ -181,7 +184,8 @@ fun SharedTransitionScope.SelectorTestPane(
 
             val result = presentation.episodeListSearchResult
             if (result is SelectorTestEpisodeListResult.Success) {
-                if (result.channels != null) {
+                val channels = result.channels
+                if (channels != null) {
                     item(span = { GridItemSpan(maxLineSpan) }) {
                         Row(
                             Modifier
@@ -190,12 +194,12 @@ fun SharedTransitionScope.SelectorTestPane(
                             horizontalArrangement = Arrangement.spacedBy(16.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text("${result.channels.size} 线路")
+                            Text("${channels.size} 线路")
                             LazyRow(
                                 Modifier,
                                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                             ) {
-                                items(result.channels) {
+                                items(channels) {
                                     FilterChip(
                                         selected = state.filterByChannel == it,
                                         onClick = {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestSearchSubjectResult.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestSearchSubjectResult.kt
@@ -10,7 +10,7 @@
 package me.him188.ani.app.ui.settings.mediasource.selector.test
 
 import androidx.compose.runtime.Immutable
-import me.him188.ani.app.data.models.ApiFailure
+import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.domain.mediasource.MediaListFilters
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
 import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
@@ -32,7 +32,7 @@ sealed class SelectorTestSearchSubjectResult : RefreshResult {
 
     @Immutable
     data class ApiError(
-        override val reason: ApiFailure,
+        override val exception: RepositoryException,
     ) : SelectorTestSearchSubjectResult(), RefreshResult.ApiError
 
     @Immutable

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestState.kt
@@ -19,31 +19,24 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.util.fastDistinctBy
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
-import me.him188.ani.app.data.repository.RepositoryException
-import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
+import me.him188.ani.app.domain.mediasource.test.web.SelectorMediaSourceTester
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodeListResult
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestEpisodePresentation
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestSearchSubjectResult
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestSubjectPresentation
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
-import me.him188.ani.app.domain.mediasource.web.SelectorSearchQuery
 import me.him188.ani.app.ui.settings.mediasource.AbstractMediaSourceTestState
 import me.him188.ani.datasources.api.EpisodeSort
-import me.him188.ani.utils.coroutines.flows.FlowRestarter
-import me.him188.ani.utils.coroutines.flows.FlowRunning
 import me.him188.ani.utils.coroutines.flows.combine
-import me.him188.ani.utils.coroutines.flows.restartable
-import me.him188.ani.utils.xml.Document
-import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
 
@@ -75,11 +68,9 @@ data class SelectorTestPresentation(
 @Stable
 class SelectorTestState(
     private val searchConfigState: State<SelectorSearchConfig?>,
-    engine: SelectorMediaSourceEngine,
+    private val tester: SelectorMediaSourceTester,
     backgroundScope: CoroutineScope,
 ) : AbstractMediaSourceTestState() {
-    private val tester = SelectorMediaSourceTester(engine)
-
     var selectedSubjectIndex by mutableIntStateOf(0)
         private set
 
@@ -186,281 +177,3 @@ class SelectorTestState(
     }
 }
 
-/**
- * 交互式的 [SelectorMediaSourceEngine].
- */
-internal class SelectorMediaSourceTester(
-    private val engine: SelectorMediaSourceEngine,
-    flowContext: CoroutineContext = Dispatchers.Default,
-    sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(),
-) {
-    // must be data class
-    data class SubjectQuery(
-        val searchKeyword: String,
-        val searchUrl: String?,
-        val searchUseOnlyFirstWord: Boolean?,
-        val searchRemoveSpecial: Boolean?,
-    )
-
-    data class EpisodeQuery(
-        val sort: EpisodeSort,
-    )
-
-    private val scope = CoroutineScope(flowContext) // No ExceptionHandler! You must catch all exceptions in shareIn!
-
-    val subjectSearchLifecycle = FlowRestarter()
-    val subjectSearchRunning = FlowRunning()
-    val episodeSearchLifecycle = FlowRestarter()
-    val episodeSearchRunning = FlowRunning()
-
-    /**
-     * 将会影响两个筛选. 不会直接触发搜索. 如果变更导致 subject 的搜索结果变化, 可能会触发 episode list 搜索.
-     */
-    private val selectorSearchConfigFlow = MutableStateFlow<SelectorSearchConfig?>(null)
-    private val subjectQueryFlow = MutableStateFlow<SubjectQuery?>(null)
-    private val episodeQueryFlow = MutableStateFlow<EpisodeQuery?>(null)
-    private val selectedSubjectIndexFlow = MutableStateFlow(0)
-
-    /**
-     * 用于查询条目列表, 每当编辑请求和 `searchUrl`, 会重新搜索, 但不会筛选.
-     * 筛选在 [subjectSelectionResultFlow].
-     */
-    private val subjectSearchResultFlow = subjectQueryFlow
-        .mapLatest { query ->
-            if (query == null) {
-                return@mapLatest null
-            }
-
-            subjectSearchRunning.withRunning {
-                searchSubject(
-                    query.searchUrl,
-                    query.searchKeyword,
-                    query.searchUseOnlyFirstWord,
-                    query.searchRemoveSpecial,
-                )
-            }
-        }
-        .shareIn(scope, sharingStarted, replay = 1)
-        .distinctUntilChanged()
-
-    /**
-     * 解析好的搜索结果.
-     */
-    val subjectSelectionResultFlow = combine(
-        subjectSearchResultFlow,
-        selectorSearchConfigFlow,
-        subjectQueryFlow,
-        episodeQueryFlow,
-    ) { apiResponse, searchConfig, query, episodeQuery ->
-        if (apiResponse == null) return@combine null
-        if (searchConfig == null || query == null || episodeQuery == null) return@combine SelectorTestSearchSubjectResult.InvalidConfig
-
-        selectSubjectResult(
-            apiResponse, searchConfig,
-            createSelectorSearchQuery(query, episodeQuery),
-        )
-    }.restartable(subjectSearchLifecycle)
-        .shareIn(scope, sharingStarted, replay = 1)
-        .distinctUntilChanged()
-
-    /**
-     * 用户选择的条目.
-     */
-    private val selectedSubjectFlow = subjectSelectionResultFlow
-        .combine(selectedSubjectIndexFlow) { result, index ->
-            if (result == null) return@combine null
-
-            (result as? SelectorTestSearchSubjectResult.Success)?.subjects?.getOrNull(index)
-        } // not shared
-        .distinctUntilChanged() // required, 否则在修改无关配置时也会触发重新搜索
-
-    /**
-     * 用于查询条目的剧集列表, 每当选择新的条目时, 会重新搜索. 但不会筛选. 筛选在 [episodeListSelectionResultFlow].
-     */
-    private val episodeListSearchResultFlow = selectedSubjectFlow
-        .mapLatest { subject ->
-            val subjectDetailsPageUrl = subject?.subjectDetailsPageUrl
-            if (subjectDetailsPageUrl == null) {
-                null
-            } else {
-                episodeSearchRunning.withRunning {
-                    subjectDetailsPageUrl to searchEpisodes(subjectDetailsPageUrl)
-                }
-            }
-        }.shareIn(scope, sharingStarted, replay = 1)
-        .distinctUntilChanged()
-
-    /**
-     * 解析好的剧集列表.
-     */
-    val episodeListSelectionResultFlow = combine(
-        episodeListSearchResultFlow, subjectQueryFlow, selectorSearchConfigFlow, episodeQueryFlow,
-    ) { episodeListDocumentResult, query, searchConfig, episodeQuery ->
-        when {
-            query == null || searchConfig == null || episodeQuery == null -> {
-                SelectorTestEpisodeListResult.InvalidConfig
-            }
-
-            episodeListDocumentResult == null -> {
-                SelectorTestEpisodeListResult.Success(null, emptyList())
-            }
-
-            else -> {
-                val (subjectUrl, documentResult) = episodeListDocumentResult
-                convertEpisodeResult(
-                    documentResult, searchConfig,
-                    createSelectorSearchQuery(query, episodeQuery),
-                    subjectUrl,
-                )
-            }
-        }
-    }.restartable(episodeSearchLifecycle)
-        .shareIn(scope, sharingStarted, replay = 1)
-        .distinctUntilChanged()
-
-    // region setters
-
-    fun setSelectorSearchConfig(config: SelectorSearchConfig?) {
-        selectorSearchConfigFlow.value = config
-    }
-
-    fun setSubjectQuery(query: SubjectQuery) {
-        subjectQueryFlow.value = query
-    }
-
-    fun setEpisodeQuery(query: EpisodeQuery) {
-        episodeQueryFlow.value = query
-    }
-
-    fun clearSubjectQuery() {
-        subjectQueryFlow.value = null
-    }
-
-    fun setSubjectIndex(index: Int) {
-        selectedSubjectIndexFlow.value = index
-    }
-
-    // endregion
-
-    private fun createSelectorSearchQuery(
-        query: SubjectQuery,
-        episodeQuery: EpisodeQuery
-    ) = SelectorSearchQuery(
-        subjectName = query.searchKeyword,
-        episodeSort = episodeQuery.sort,
-        allSubjectNames = setOf(query.searchKeyword),
-        episodeName = null,
-        episodeEp = null,
-    )
-
-    private suspend fun searchEpisodes(subjectDetailsPageUrl: String): Result<Document?> {
-        return try {
-            Result.success(engine.searchEpisodes(subjectDetailsPageUrl))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            Result.failure(e)
-        }
-    }
-
-    private suspend fun searchSubject(
-        url: String?,
-        searchKeyword: String,
-        useOnlyFirstWord: Boolean?,
-        removeSpecial: Boolean?
-    ) =
-        if (url.isNullOrBlank() || searchKeyword.isBlank() || useOnlyFirstWord == null || removeSpecial == null) {
-            null
-        } else {
-            try {
-                val res = engine.searchSubjects(
-                    searchUrl = url,
-                    searchKeyword,
-                    useOnlyFirstWord = useOnlyFirstWord,
-                    removeSpecial = removeSpecial,
-                )
-                Result.success(res)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                Result.failure(e)
-            }
-        }
-
-
-    private fun convertEpisodeResult(
-        res: Result<Document?>,
-        config: SelectorSearchConfig,
-        query: SelectorSearchQuery,
-        subjectUrl: String,
-    ): SelectorTestEpisodeListResult {
-        return res.fold(
-            onSuccess = { document ->
-                try {
-                    document ?: return SelectorTestEpisodeListResult.Success(null, emptyList())
-                    val episodeList = engine.selectEpisodes(document, subjectUrl, config)
-                        ?: return SelectorTestEpisodeListResult.InvalidConfig
-                    SelectorTestEpisodeListResult.Success(
-                        episodeList.channels,
-                        episodeList.episodes
-                            .fastDistinctBy { it.playUrl }
-                            .map {
-                                SelectorTestEpisodePresentation.compute(it, query, document, config)
-                            },
-                    )
-                } catch (e: Throwable) {
-                    SelectorTestEpisodeListResult.UnknownError(e)
-                }
-            },
-            onFailure = { reason ->
-                if (reason is RepositoryException) {
-                    SelectorTestEpisodeListResult.ApiError(reason)
-                } else {
-                    SelectorTestEpisodeListResult.UnknownError(reason)
-                }
-            },
-        )
-    }
-
-    private fun selectSubjectResult(
-        res: Result<SelectorMediaSourceEngine.SearchSubjectResult>,
-        searchConfig: SelectorSearchConfig,
-        query: SelectorSearchQuery,
-    ): SelectorTestSearchSubjectResult {
-        return res.fold(
-            onSuccess = { data ->
-                val document = data.document
-
-                val originalList = if (document == null) {
-                    emptyList()
-                } else {
-                    engine.selectSubjects(document, searchConfig).let { list ->
-                        if (list == null) {
-                            return SelectorTestSearchSubjectResult.InvalidConfig
-                        }
-                        list
-                    }
-                }
-
-                SelectorTestSearchSubjectResult.Success(
-                    data.url.toString(),
-                    originalList.map {
-                        SelectorTestSubjectPresentation.compute(
-                            it,
-                            query,
-                            document,
-                            searchConfig.filterBySubjectName,
-                        )
-                    },
-                )
-            },
-            onFailure = { reason ->
-                if (reason is RepositoryException) {
-                    SelectorTestSearchSubjectResult.ApiError(reason)
-                } else {
-                    SelectorTestSearchSubjectResult.UnknownError(reason)
-                }
-            },
-        )
-    }
-}

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestSubjectResultLazyRow.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestSubjectResultLazyRow.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import me.him188.ani.app.domain.mediasource.test.web.SelectorTestSubjectPresentation
 import me.him188.ani.app.ui.foundation.Tag
 import me.him188.ani.app.ui.settings.mediasource.rss.test.OutlinedMatchTag
 


### PR DESCRIPTION
- BackgroundSearcher 完全使用 Flow, 现在它的定位是 domain layer 而不是 ui layer.
- 将搜索和筛选逻辑从 UI layer `SelectorTestState` 中拆分到 domain layer 的 `SelectorMediaSourceTester`. `SelectorMediaSourceTester` 只使用 Flow.
- `SelectorTestState` 对接 UI 和 domain layer: 
   - Compose UI 调用 `SelectorTestState.observeChanges`, 在正确的时间将 compose state (例如各种编辑框状态) 交付给 tester.
   - `SelectorTestState.presentation` 是一个包含此页面所有显示信息的 flow, 从 tester 获取测试结果.
   - Compose UI 将 flow `collectAsStateWithLifecycle`, 获得需要显示的内容.
