### PR TITLE
Explicitly handle back navigation, fix double back, close #1343

### DIFF
--- a/app/shared/app-platform/src/commonMain/kotlin/navigation/AniNavigator.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/navigation/AniNavigator.kt
@@ -45,6 +45,10 @@ interface AniNavigator {
         navigator.popBackStack()
     }
 
+    fun popBackStack(route: NavRoutes, inclusive: Boolean, saveState: Boolean = false) {
+        navigator.popBackStack(route, inclusive, saveState)
+    }
+
 //    fun popBackStack(
 //        route: String,
 //        inclusive: Boolean,

--- a/app/shared/src/androidMain/kotlin/ui/cache/CacheManagePage.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/cache/CacheManagePage.android.kt
@@ -25,6 +25,7 @@ import me.him188.ani.app.ui.cache.components.CacheGroupCommonInfo
 import me.him188.ani.app.ui.cache.components.CacheGroupState
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.stateOf
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.FileSize.Companion.megaBytes
@@ -42,7 +43,7 @@ fun PreviewCacheManagementPage() {
                     stateOf(TestCacheGroupSates),
                 )
             },
-            showBack = true,
+            navigationIcon = { BackNavigationIconButton({ }) },
         )
     }
 }

--- a/app/shared/src/androidMain/kotlin/ui/cache/details/CacheGroupDetailsPage.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/cache/details/CacheGroupDetailsPage.android.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import me.him188.ani.app.domain.media.TestMediaList
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.datasources.mikan.MikanMediaSource
 import me.him188.ani.utils.platform.annotations.TestOnly
 
@@ -20,5 +21,5 @@ import me.him188.ani.utils.platform.annotations.TestOnly
 @Composable
 @Preview
 fun PreviewMediaCacheDetailsPage() = ProvideCompositionLocalsForPreview {
-    MediaCacheDetailsPage(TestMediaList[0], MikanMediaSource.INFO)
+    MediaCacheDetailsPage(TestMediaList[0], MikanMediaSource.INFO, { BackNavigationIconButton({ }) })
 }

--- a/app/shared/src/androidMain/kotlin/ui/profile/auth/BangumiOAuthPage.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/profile/auth/BangumiOAuthPage.android.kt
@@ -1,9 +1,19 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.profile.auth
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.profile.BangumiOAuthViewModel
 
 @PreviewLightDark
@@ -13,6 +23,7 @@ private fun PreviewAuthRequestPage() {
         BangumiOAuthPage(
             remember { BangumiOAuthViewModel() },
             {},
+            navigationIcon = { BackNavigationIconButton({}) },
         )
     }
 }

--- a/app/shared/src/commonMain/kotlin/ui/cache/CacheManagementPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/cache/CacheManagementPage.kt
@@ -69,7 +69,6 @@ import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
 import me.him188.ani.app.ui.foundation.produceState
 import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.datasources.api.creationTimeOrNull
 import me.him188.ani.datasources.api.episodeIdInt
 import me.him188.ani.datasources.api.subjectIdInt
@@ -241,13 +240,13 @@ class CacheManagementState(
 @Composable
 fun CacheManagementPage(
     vm: CacheManagementViewModel,
-    showBack: Boolean,
+    navigationIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
 ) {
     CacheManagementPage(
         vm.state,
-        showBack = showBack,
+        navigationIcon = navigationIcon,
         modifier = modifier,
         lazyGridState = vm.lazyGridState,
         contentWindowInsets = contentWindowInsets,
@@ -258,7 +257,7 @@ fun CacheManagementPage(
 @Composable
 fun CacheManagementPage(
     state: CacheManagementState,
-    showBack: Boolean,
+    navigationIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     lazyGridState: CacheGroupGridLayoutState = rememberLazyStaggeredGridState(),
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
@@ -269,11 +268,7 @@ fun CacheManagementPage(
         topBar = {
             AniTopAppBar(
                 title = { AniTopAppBarDefaults.Title("缓存管理") },
-                navigationIcon = {
-                    if (showBack) {
-                        TopAppBarGoBackButton()
-                    }
-                },
+                navigationIcon = navigationIcon,
                 colors = appBarColors,
                 windowInsets = AniWindowInsets.forTopAppBarWithoutDesktopTitle(),
             )

--- a/app/shared/src/commonMain/kotlin/ui/cache/details/CacheGroupDetailsPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/cache/details/CacheGroupDetailsPage.kt
@@ -45,7 +45,6 @@ import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.ui.foundation.AbstractViewModel
 import me.him188.ani.app.ui.foundation.interaction.WindowDragArea
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceInfo
 import org.koin.core.component.KoinComponent
@@ -81,15 +80,15 @@ class MediaCacheDetailsPageViewModel(
 @Composable
 fun MediaCacheDetailsPage(
     vm: MediaCacheDetailsPageViewModel,
+    navigationIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    allowBack: Boolean = true,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
     MediaCacheDetailsPage(
         media = vm.media,
         sourceInfo = vm.sourceInfo,
+        navigationIcon = navigationIcon,
         modifier = modifier,
-        allowBack = allowBack,
         windowInsets = windowInsets,
     )
 }
@@ -98,8 +97,8 @@ fun MediaCacheDetailsPage(
 fun MediaCacheDetailsPage(
     media: Media?,
     sourceInfo: MediaSourceInfo?,
+    navigationIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
-    allowBack: Boolean = true,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
     Scaffold(
@@ -108,11 +107,7 @@ fun MediaCacheDetailsPage(
             WindowDragArea {
                 TopAppBar(
                     title = { Text("详情") },
-                    navigationIcon = {
-                        if (allowBack) {
-                            TopAppBarGoBackButton()
-                        }
-                    },
+                    navigationIcon = navigationIcon,
                     colors = AniThemeDefaults.topAppBarColors(),
                     windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                 )

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -58,6 +58,7 @@ import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBar
 import me.him188.ani.app.ui.foundation.theme.LocalNavigationMotionScheme
 import me.him188.ani.app.ui.foundation.theme.NavigationMotionScheme
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.profile.BangumiOAuthViewModel
 import me.him188.ani.app.ui.profile.auth.BangumiOAuthScene
 import me.him188.ani.app.ui.profile.auth.BangumiTokenAuthPage
@@ -181,6 +182,13 @@ private fun AniAppContentImpl(
             ) {
                 BangumiOAuthScene(
                     viewModel { BangumiOAuthViewModel() },
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popUntilNotAuth()
+                            },
+                        )
+                    },
                     windowInsets = windowInsets,
                 )
             }
@@ -194,6 +202,13 @@ private fun AniAppContentImpl(
                     viewModel { BangumiTokenAuthViewModel() },
                     Modifier.fillMaxSize(),
                     windowInsets,
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popUntilNotAuth()
+                            },
+                        )
+                    },
                 )
             }
             composable<NavRoutes.SubjectDetail>(
@@ -223,6 +238,13 @@ private fun AniAppContentImpl(
                         onPlay = { aniNavigator.navigateEpisodeDetails(details.subjectId, it) },
                         onLoadErrorRetry = { vm.reload() },
                         windowInsets = windowInsets,
+                        navigationIcon = {
+                            BackNavigationIconButton(
+                                {
+                                    aniNavigator.popBackStack(details, inclusive = true)
+                                },
+                            )
+                        },
                     )
                 }
             }
@@ -262,7 +284,13 @@ private fun AniAppContentImpl(
                     },
                     Modifier.fillMaxSize(),
                     route.tab,
-                    showNavigationIcon = true,
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popBackStack(route, inclusive = true)
+                            },
+                        )
+                    },
                 )
             }
             composable<NavRoutes.Caches>(
@@ -270,10 +298,17 @@ private fun AniAppContentImpl(
                 exitTransition = exitTransition,
                 popEnterTransition = popEnterTransition,
                 popExitTransition = popExitTransition,
-            ) {
+            ) { backStackEntry ->
+                val route = backStackEntry.toRoute<NavRoutes.Caches>()
                 CacheManagementPage(
                     viewModel { CacheManagementViewModel(aniNavigator) },
-                    showBack = true,
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popBackStack(route, inclusive = true)
+                            },
+                        )
+                    },
                     Modifier.fillMaxSize(),
                 )
             }
@@ -286,6 +321,13 @@ private fun AniAppContentImpl(
                 val route = backStackEntry.toRoute<NavRoutes.CacheDetail>()
                 MediaCacheDetailsPage(
                     viewModel(key = route.toString()) { MediaCacheDetailsPageViewModel(route.cacheId) },
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popBackStack(route, inclusive = true)
+                            },
+                        )
+                    },
                     Modifier.fillMaxSize(),
                     windowInsets = windowInsets,
                 )
@@ -299,7 +341,16 @@ private fun AniAppContentImpl(
                 val route = backStackEntry.toRoute<NavRoutes.SubjectCaches>()
                 // Don't use rememberViewModel to save memory
                 val vm = remember(route.subjectId) { SubjectCacheViewModelImpl(route.subjectId) }
-                SubjectCacheScene(vm, Modifier.fillMaxSize(), windowInsets)
+                SubjectCacheScene(
+                    vm, Modifier.fillMaxSize(), windowInsets,
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popBackStack(route, inclusive = true)
+                            },
+                        )
+                    },
+                )
             }
             composable<NavRoutes.EditMediaSource>(
                 enterTransition = enterTransition,
@@ -325,6 +376,13 @@ private fun AniAppContentImpl(
                         },
                         Modifier,
                         windowInsets,
+                        navigationIcon = {
+                            BackNavigationIconButton(
+                                {
+                                    aniNavigator.popBackStack(route, inclusive = true)
+                                },
+                            )
+                        },
                     )
 
                     SelectorMediaSource.FactoryId -> {
@@ -335,6 +393,13 @@ private fun AniAppContentImpl(
                             },
                             Modifier,
                             windowInsets = windowInsets,
+                            navigationIcon = {
+                                BackNavigationIconButton(
+                                    {
+                                        aniNavigator.popBackStack(route, inclusive = true)
+                                    },
+                                )
+                            },
                         )
                     }
 

--- a/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
@@ -65,6 +65,7 @@ import me.him188.ani.app.ui.foundation.layout.isAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.setRequestFullScreen
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.subject.collection.CollectionPage
 import me.him188.ani.app.ui.subject.collection.UserCollectionsViewModel
 import me.him188.ani.app.ui.subject.details.SubjectDetailsPage
@@ -208,15 +209,16 @@ private fun MainSceneContent(
 
                     MainScenePage.CacheManagement -> CacheManagementPage(
                         viewModel { CacheManagementViewModel(navigator) },
-                        showBack = false,
+                        navigationIcon = { },
                         Modifier.fillMaxSize(),
                     )
 
                     MainScenePage.Search -> {
                         val vm = viewModel { SearchViewModel() }
-                        BackHandler(true) {
+                        val onBack = {
                             onNavigateToPage(MainScenePage.Exploration)
                         }
+                        BackHandler(true, onBack)
                         val listDetailNavigator = rememberListDetailPaneScaffoldNavigator()
                         SearchPage(
                             vm.searchPageState,
@@ -231,6 +233,16 @@ private fun MainSceneContent(
                                         }
                                     },
                                     onLoadErrorRetry = { vm.reloadCurrentSubjectDetails() },
+                                    navigationIcon = {
+                                        // 只有在单面板模式下才显示返回按钮
+                                        if (listDetailLayoutParameters.isSinglePane) {
+                                            BackNavigationIconButton(
+                                                {
+                                                    listDetailNavigator.navigateBack()
+                                                },
+                                            )
+                                        }
+                                    },
                                 )
                             },
                             Modifier.fillMaxSize(),
@@ -241,6 +253,9 @@ private fun MainSceneContent(
                             },
                             navigator = listDetailNavigator,
                             contentWindowInsets = WindowInsets.safeDrawing, // 不包含 macos 标题栏, 因为左侧有 navigation rail
+                            navigationIcon = {
+                                BackNavigationIconButton(onBack)
+                            },
                         )
                     }
                 }

--- a/app/shared/src/commonMain/kotlin/ui/profile/auth/BangumiOAuthPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/profile/auth/BangumiOAuthPage.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.profile.auth
 
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -41,15 +51,14 @@ import me.him188.ani.app.navigation.BrowserNavigator
 import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.ui.foundation.feedback.ErrorDialogHost
-import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.profile.BangumiOAuthViewModel
 import org.koin.mp.KoinPlatform
 
 @Composable
 fun BangumiOAuthScene(
     vm: BangumiOAuthViewModel,
+    navigationIcon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
@@ -59,9 +68,10 @@ fun BangumiOAuthScene(
             nav.popUntilNotAuth()
         }
     }
-    BackHandler {
-        vm.onCancel("BangumiOAuthScene BackHandler")
-        nav.popUntilNotAuth()
+    DisposableEffect(vm) {
+        onDispose {
+            vm.onCancel("BangumiOAuthScene disposed")
+        }
     }
     BangumiOAuthPage(
         vm,
@@ -70,6 +80,7 @@ fun BangumiOAuthScene(
         },
         modifier,
         windowInsets = windowInsets,
+        navigationIcon,
     )
 }
 
@@ -101,6 +112,7 @@ fun BangumiOAuthPage(
     onClickTokenAuth: () -> Unit,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     Scaffold(
         modifier
@@ -108,7 +120,7 @@ fun BangumiOAuthPage(
             .fillMaxSize(),
         topBar = {
             TopAppBar(
-                navigationIcon = { TopAppBarGoBackButton() },
+                navigationIcon = navigationIcon,
                 actions = {},
                 title = { Text(text = "Bangumi 授权") },
                 colors = AniThemeDefaults.topAppBarColors(),

--- a/app/shared/src/commonMain/kotlin/ui/profile/auth/BangumiTokenAuthPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/profile/auth/BangumiTokenAuthPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -52,7 +53,6 @@ import me.him188.ani.app.ui.foundation.AbstractViewModel
 import me.him188.ani.app.ui.foundation.launchInBackground
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.utils.platform.currentTimeMillis
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -77,11 +77,16 @@ fun BangumiTokenAuthPage(
     vm: BangumiTokenAuthViewModel,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     var token by rememberSaveable { mutableStateOf("") }
     val navigator = LocalNavigator.current
+    DisposableEffect(vm) {
+        onDispose {
+            vm.onCancel("BangumiTokenAuthPage BackHandler")
+        }
+    }
     BackHandler {
-        vm.onCancel("BangumiTokenAuthPage BackHandler")
         navigator.popUntilNotAuth()
     }
     Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -90,9 +95,7 @@ fun BangumiTokenAuthPage(
             topBar = {
                 TopAppBar(
                     title = { Text("Bangumi 授权") },
-                    navigationIcon = {
-                        TopAppBarGoBackButton()
-                    },
+                    navigationIcon = navigationIcon,
                     colors = AniThemeDefaults.topAppBarColors(),
                     windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                 )

--- a/app/shared/src/commonMain/kotlin/ui/subject/cache/SubjectCacheScene.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/cache/SubjectCacheScene.kt
@@ -65,7 +65,6 @@ import me.him188.ani.app.ui.foundation.launchInBackground
 import me.him188.ani.app.ui.foundation.produceState
 import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
@@ -246,6 +245,7 @@ fun SubjectCacheScene(
     vm: SubjectCacheViewModel,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     SubjectCachePageScaffold(
         title = {
@@ -277,6 +277,7 @@ fun SubjectCacheScene(
         },
         modifier,
         windowInsets = windowInsets,
+        navigationIcon = navigationIcon,
     )
 }
 
@@ -294,6 +295,7 @@ fun SubjectCachePageScaffold(
     cacheListGroup: @Composable SettingsScope.() -> Unit,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     val appBarColors = AniThemeDefaults.topAppBarColors()
     Scaffold(
@@ -304,9 +306,7 @@ fun SubjectCachePageScaffold(
                     title = {
                         title()
                     },
-                    navigationIcon = {
-                        TopAppBarGoBackButton()
-                    },
+                    navigationIcon = navigationIcon,
                     colors = appBarColors,
                     windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                 )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
@@ -160,13 +161,13 @@ private fun EpisodeSceneContent(
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
-    // 处理当用户点击返回键时, 如果是全屏, 则退出全屏
-    val navigator = LocalNavigator.current
-    BackHandler {
-        vm.stopPlaying()
-        navigator.popBackStack()
+    DisposableEffect(vm) {
+        onDispose {
+            vm.stopPlaying()
+        }
     }
 
+    // 处理当用户点击返回键时, 如果是全屏, 则退出全屏
     // 按返回退出全屏
     val context by rememberUpdatedState(LocalContext.current)
     val window = LocalPlatformWindow.current

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -153,6 +153,7 @@ fun EpisodeDetails(
                     onLoadErrorRetry = { state.subjectDetailsStateLoader.reload(state.subjectId) },
                     showTopBar = false,
                     showBlurredBackground = false,
+                    navigationIcon = {},
                 )
             }
         }

--- a/app/shared/ui-adaptive/src/androidMain/kotlin/ui/adaptive/AniTopAppBar.android.kt
+++ b/app/shared/ui-adaptive/src/androidMain/kotlin/ui/adaptive/AniTopAppBar.android.kt
@@ -24,7 +24,7 @@ import me.him188.ani.app.domain.session.createTestAuthState
 import me.him188.ani.app.ui.foundation.ProvideFoundationCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.layout.Zero
 import me.him188.ani.app.ui.foundation.session.SelfAvatar
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.utils.platform.annotations.TestOnly
 
 
@@ -35,7 +35,7 @@ private fun PreviewAniTopAppBar() = ProvideFoundationCompositionLocalsForPreview
     val scope = rememberCoroutineScope()
     AniTopAppBar(
         title = { Text("MyTitle") },
-        navigationIcon = { TopAppBarGoBackButton() },
+        navigationIcon = { BackNavigationIconButton({}) },
         actions = {
             IconButton({}) {
                 Icon(Icons.Rounded.Settings, null)

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
@@ -70,8 +70,8 @@ import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.layout.paneVerticalPadding
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.foundation.widgets.NsfwMask
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.search.LoadErrorCard
 import me.him188.ani.app.ui.search.SearchDefaults
 import me.him188.ani.app.ui.search.SearchResultLazyVerticalStaggeredGrid
@@ -86,6 +86,7 @@ fun SearchPage(
     focusSearchBarByDefault: Boolean = true,
     navigator: ThreePaneScaffoldNavigator<*> = rememberListDetailPaneScaffoldNavigator(),
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     BackHandler(navigator.canNavigateBack()) {
         navigator.navigateBack()
@@ -143,6 +144,13 @@ fun SearchPage(
             }
         },
         modifier,
+        navigationIcon = {
+            if (navigator.canNavigateBack()) {
+                BackNavigationIconButton({ navigator.navigateBack() })
+            } else {
+                navigationIcon()
+            }
+        },
         contentWindowInsets = contentWindowInsets,
     )
 
@@ -313,6 +321,7 @@ internal fun SearchPageLayout(
     searchResultList: @Composable (PaneScope.() -> Unit),
     detailContent: @Composable (PaneScope.() -> Unit),
     modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
     searchBarHeight: Dp = 64.dp,
 ) {
@@ -323,7 +332,11 @@ internal fun SearchPageLayout(
                 title = { Text("搜索") },
                 Modifier.fillMaxWidth(),
                 navigationIcon = {
-                    TopAppBarGoBackButton()
+                    if (navigator.canNavigateBack()) {
+                        BackNavigationIconButton({ navigator.navigateBack() })
+                    } else {
+                        navigationIcon()
+                    }
                 },
                 windowInsets = paneContentWindowInsets.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
             )

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/navigation/LocalBackDispatcher.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/navigation/LocalBackDispatcher.kt
@@ -10,16 +10,11 @@
 package me.him188.ani.app.ui.foundation.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import me.him188.ani.app.navigation.LocalNavigator
+import androidx.compose.runtime.Stable
 
 fun interface BackDispatcher {
     /**
-     * Call the most recently registered [BackHandler], if any.
-     *
-     * If no [BackHandler] has been registered, this will call [AniNavigator.popBackStack].
+     * 调用此 [BackDispatcher], 也就是相当于调用最后一个注册并启用的 [BackHandler].
      */
     fun onBackPressed()
 }
@@ -28,21 +23,18 @@ fun interface BackDispatcher {
  * 可模拟点击返回键
  */
 object LocalBackDispatcher {
+    @Stable
+    private val NoopBackDispatcher = BackDispatcher {}
+    
     /**
-     * @see BackDispatcher
+     * 获取当前的 [BackDispatcher] 实例.
+     * 注意, 此功能不能用于返回上一页面, 会导致 #1343.
      */
     val current: BackDispatcher
         @Composable
-        get() {
-            val backPressed by rememberUpdatedState(LocalOnBackPressedDispatcherOwner.current)
-            val navigator by rememberUpdatedState(LocalNavigator.current)
-            return remember {
-                BackDispatcher {
-                    backPressed?.onBackPressedDispatcher?.onBackPressed()
-                        ?: kotlin.run {
-                            navigator.popBackStack()
-                        }
-                }
+        get() = LocalOnBackPressedDispatcherOwner.current?.let { owner ->
+            BackDispatcher {
+                owner.onBackPressedDispatcher.onBackPressed()
             }
-        }
+        } ?: NoopBackDispatcher
 }

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/TopAppBarGoBackButton.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/TopAppBarGoBackButton.kt
@@ -18,20 +18,16 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import me.him188.ani.app.ui.foundation.navigation.LocalBackDispatcher
-
 
 @Composable
-fun TopAppBarGoBackButton() {
-    val handler = LocalBackDispatcher.current
-    TopAppBarGoBackButton {
-        handler.onBackPressed()
-    }
-}
-
-@Composable
-fun TopAppBarGoBackButton(goBack: () -> Unit) {
-    TopAppBarActionButton(goBack) {
+fun BackNavigationIconButton(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TopAppBarActionButton(
+        onNavigateBack,
+        modifier,
+    ) {
         Icon(
             Icons.AutoMirrored.Outlined.ArrowBack,
             null,
@@ -42,10 +38,12 @@ fun TopAppBarGoBackButton(goBack: () -> Unit) {
 @Composable
 fun TopAppBarActionButton(
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     IconButton(
         onClick,
+        modifier,
 //        Modifier.offset(x = (-8).dp, y = (-8).dp).width(36.dp + 16.dp).height(36.dp + 16.dp)
     ) { // 让可点击区域大一点, 更方便
         Box(Modifier.size(24.dp)) {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsPage.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsPage.kt
@@ -73,7 +73,7 @@ import me.him188.ani.app.ui.foundation.layout.cardVerticalPadding
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.paneVerticalPadding
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.rendering.P2p
 import me.him188.ani.app.ui.settings.tabs.AboutTab
@@ -102,8 +102,8 @@ fun SettingsPage(
     vm: SettingsViewModel,
     modifier: Modifier = Modifier,
     initialTab: SettingsTab? = null,
-    showNavigationIcon: Boolean = false,
     windowInsets: WindowInsets = AniWindowInsets.forPageContent(),
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     val navigator: ThreePaneScaffoldNavigator<SettingsTab> = rememberListDetailPaneScaffoldNavigator(
         initialDestinationHistory = buildList {
@@ -198,7 +198,7 @@ fun SettingsPage(
         },
         modifier,
         windowInsets,
-        showNavigationIcon = showNavigationIcon,
+        navigationIcon = navigationIcon,
         layoutParameters = layoutParameters,
     )
 }
@@ -212,7 +212,7 @@ internal fun SettingsPageLayout(
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
     containerColor: Color = AniThemeDefaults.pageContentBackgroundColor,
     layoutParameters: ListDetailLayoutParameters = ListDetailLayoutParameters.calculate(navigator.scaffoldDirective),
-    showNavigationIcon: Boolean = false,
+    navigationIcon: @Composable () -> Unit = {},
 ) = Surface(color = containerColor) {
     val layoutParametersState by rememberUpdatedState(layoutParameters)
 
@@ -246,8 +246,10 @@ internal fun SettingsPageLayout(
             AniTopAppBar(
                 title = { AniTopAppBarDefaults.Title("设置") },
                 navigationIcon = {
-                    if (showNavigationIcon) {
-                        TopAppBarGoBackButton()
+                    if (navigator.canNavigateBack()) {
+                        BackNavigationIconButton({ navigator.navigateBack() })
+                    } else {
+                        navigationIcon()
                     }
                 },
                 colors = AniThemeDefaults.transparentAppBarColors(),
@@ -306,9 +308,9 @@ internal fun SettingsPageLayout(
                             },
                             navigationIcon = {
                                 if (listDetailLayoutParameters.isSinglePane) {
-                                    TopAppBarGoBackButton {
-                                        navigator.navigateBack(BackNavigationBehavior.PopUntilScaffoldValueChange)
-                                    }
+                                    BackNavigationIconButton(
+                                        { navigator.navigateBack(BackNavigationBehavior.PopUntilScaffoldValueChange) },
+                                    )
                                 }
                             },
                             colors = AniThemeDefaults.transparentAppBarColors(),

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
@@ -59,7 +59,7 @@ import me.him188.ani.app.ui.foundation.layout.only
 import me.him188.ani.app.ui.foundation.layout.panePadding
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.settings.mediasource.DropdownMenuExport
 import me.him188.ani.app.ui.settings.mediasource.DropdownMenuImport
 import me.him188.ani.app.ui.settings.mediasource.ExportMediaSourceState
@@ -146,9 +146,13 @@ fun EditRssMediaSourcePage(
     mediaDetailsColumn: @Composable (Media) -> Unit,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit,
 ) {
     viewModel.state.collectAsStateWithLifecycle(null).value?.let {
-        EditRssMediaSourcePage(it, viewModel.testState, mediaDetailsColumn, modifier, windowInsets = windowInsets)
+        EditRssMediaSourcePage(
+            it, viewModel.testState, mediaDetailsColumn, modifier, windowInsets = windowInsets,
+            navigationIcon = navigationIcon,
+        )
     }
 }
 
@@ -160,6 +164,7 @@ fun EditRssMediaSourcePage(
     modifier: Modifier = Modifier,
     navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     LaunchedEffect(Unit) {
         testState.searcher.observeTestDataChanges(testState.testDataState)
@@ -184,7 +189,13 @@ fun EditRssMediaSourcePage(
                             }
                         }
                     },
-                    navigationIcon = { TopAppBarGoBackButton() },
+                    navigationIcon = {
+                        if (navigator.canNavigateBack()) {
+                            BackNavigationIconButton({ navigator.navigateBack() })
+                        } else {
+                            navigationIcon()
+                        }
+                    },
                     colors = AniThemeDefaults.topAppBarColors(),
                     windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                     actions = {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/EditSelectorMediaSourcePage.kt
@@ -59,7 +59,7 @@ import me.him188.ani.app.ui.foundation.layout.materialWindowMarginPadding
 import me.him188.ani.app.ui.foundation.layout.rememberConnectedScrollState
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.settings.mediasource.DropdownMenuExport
 import me.him188.ani.app.ui.settings.mediasource.DropdownMenuImport
 import me.him188.ani.app.ui.settings.mediasource.ExportMediaSourceState
@@ -147,10 +147,14 @@ fun EditSelectorMediaSourcePage(
     modifier: Modifier = Modifier,
     navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     val state by vm.state.collectAsStateWithLifecycle(null)
     state?.let {
-        EditSelectorMediaSourcePage(it, modifier, navigator, windowInsets)
+        EditSelectorMediaSourcePage(
+            it, modifier, navigator, windowInsets,
+            navigationIcon,
+        )
     }
 }
 
@@ -160,6 +164,7 @@ fun EditSelectorMediaSourcePage(
     modifier: Modifier = Modifier,
     navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     val episodePaneLayout = SelectorEpisodePaneLayout.calculate(navigator.scaffoldValue)
     val testConnectedScrollState = rememberConnectedScrollState()
@@ -167,11 +172,20 @@ fun EditSelectorMediaSourcePage(
         modifier,
         topBar = {
             WindowDragArea {
+                val myNavigationIcon = @Composable {
+                    if (navigator.canNavigateBack()) {
+                        BackNavigationIconButton({ navigator.navigateBack() })
+                    } else {
+                        navigationIcon()
+                    }
+                }
+
                 val viewingItem = state.viewingItem
                 if (viewingItem != null && episodePaneLayout.showTopBarInScaffold) {
                     SelectorEpisodePaneDefaults.TopAppBar(
                         state.episodeState,
                         windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+                        navigationIcon = myNavigationIcon,
                     )
                 } else {
                     TopAppBar(
@@ -182,7 +196,7 @@ fun EditSelectorMediaSourcePage(
                                 Text(state.configurationState.displayName)
                             }
                         },
-                        navigationIcon = { TopAppBarGoBackButton() },
+                        navigationIcon = myNavigationIcon,
                         actions = {
                             if (currentWindowAdaptiveInfo1().isWidthCompact && navigator.currentDestination?.pane != ListDetailPaneScaffoldRole.Detail) {
                                 TextButton({ navigator.navigateTo(ListDetailPaneScaffoldRole.Detail) }) {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePane.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePane.kt
@@ -64,6 +64,7 @@ import kotlinx.serialization.Serializable
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.foundation.widgets.FastLinearProgressIndicator
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.settings.mediasource.selector.EditSelectorMediaSourcePageState
@@ -95,10 +96,11 @@ fun SelectorTestAndEpisodePane(
                 )
             }
             composable<SelectorEpisodePaneRoutes.EPISODE> {
-                BackHandler {
+                val onBack: () -> Unit = {
                     state.stopViewing()
                     nestedNav.popBackStack(SelectorEpisodePaneRoutes.EPISODE, inclusive = true)
                 }
+                BackHandler(onBack = onBack)
                 val cardColors: CardColors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 )
@@ -121,7 +123,12 @@ fun SelectorTestAndEpisodePane(
                             colors = cardColors,
                             shape = MaterialTheme.shapes.large,
                         ) {
-                            SelectorEpisodePaneDefaults.TopAppBar(state.episodeState)
+                            SelectorEpisodePaneDefaults.TopAppBar(
+                                state.episodeState,
+                                navigationIcon = {
+                                    BackNavigationIconButton({ onBack() })
+                                },
+                            )
                             content()
                         }
                     }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePaneDefaults.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/episode/SelectorEpisodePaneDefaults.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.settings.mediasource.RefreshIndicationDefaults
 import me.him188.ani.app.ui.settings.mediasource.selector.edit.MatchVideoSection
 import me.him188.ani.app.ui.settings.mediasource.selector.edit.SelectorConfigState
@@ -47,13 +46,12 @@ object SelectorEpisodePaneDefaults {
         state: SelectorEpisodeState,
         modifier: Modifier = Modifier.Companion,
         windowInsets: WindowInsets = WindowInsets(0.dp),
+        navigationIcon: @Composable () -> Unit = {},
     ) {
         val onRefresh = { state.searcher.restartCurrentSearch() }
         val searchResult by state.searcher.searchResultFlow.collectAsStateWithLifecycle()
         TopAppBar(
-            navigationIcon = {
-                TopAppBarGoBackButton()
-            },
+            navigationIcon = navigationIcon,
             title = {
                 Row(
                     verticalAlignment = Alignment.Companion.CenterVertically,

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/torrent/peer/PeerFilterSettings.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/torrent/peer/PeerFilterSettings.kt
@@ -46,14 +46,15 @@ import me.him188.ani.app.ui.adaptive.AniTopAppBarDefaults
 import me.him188.ani.app.ui.foundation.IconButton
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 
 @Composable
 fun PeerFilterSettingsPage(
     state: PeerFilterSettingsState,
     modifier: Modifier = Modifier,
-    navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator()
+    navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     Surface(color = AniThemeDefaults.pageContentBackgroundColor) {
         AniListDetailPaneScaffold(
@@ -64,6 +65,13 @@ fun PeerFilterSettingsPage(
                     title = { AniTopAppBarDefaults.Title("Peer 过滤和屏蔽设置") },
                     state = state,
                     windowInsets = paneContentWindowInsets.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+                    navigationIcon = {
+                        if (navigator.canNavigateBack()) {
+                            BackNavigationIconButton({ navigator.navigateBack() })
+                        } else {
+                            navigationIcon()
+                        }
+                    },
                 )
             },
             listPaneContent = {
@@ -120,6 +128,7 @@ private fun SearchBlockedIpTopAppBar(
     state: PeerFilterSettingsState,
     title: @Composable () -> Unit,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     BackHandler(enableSearch && state.searchingBlockedIp) {
         state.stopSearchBlockedIp()
@@ -129,7 +138,7 @@ private fun SearchBlockedIpTopAppBar(
         title = {
             if (enableSearch && state.searchingBlockedIp) SearchBlockedIp(state) else title()
         },
-        navigationIcon = { TopAppBarGoBackButton() },
+        navigationIcon = navigationIcon,
         avatar = {
             if (enableSearch && !state.searchingBlockedIp) {
                 IconButton({ state.startSearchBlockedIp() }) {

--- a/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/details/SubjectDetailsPage.android.kt
+++ b/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/details/SubjectDetailsPage.android.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.tooling.preview.Preview
 import me.him188.ani.app.ui.foundation.ProvideFoundationCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
 import me.him188.ani.app.ui.search.LoadError
 import me.him188.ani.app.ui.subject.details.state.SubjectDetailsStateLoader
 import me.him188.ani.app.ui.subject.details.state.createTestSubjectDetailsState
@@ -30,6 +31,7 @@ internal fun PreviewSubjectDetails() = ProvideFoundationCompositionLocalsForPrev
         state,
         onPlay = { },
         onLoadErrorRetry = { },
+        navigationIcon = { BackNavigationIconButton({}) },
     )
 }
 
@@ -46,6 +48,7 @@ internal fun PreviewPlaceholderSubjectDetails() = ProvideFoundationCompositionLo
         state,
         onPlay = { },
         onLoadErrorRetry = { },
+        navigationIcon = { BackNavigationIconButton({}) },
     )
 }
 
@@ -62,5 +65,6 @@ internal fun PreviewErrorSubjectDetails() = ProvideFoundationCompositionLocalsFo
         state,
         onPlay = { },
         onLoadErrorRetry = { },
+        navigationIcon = { BackNavigationIconButton({}) },
     )
 }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -96,7 +96,6 @@ import me.him188.ani.app.ui.foundation.pagerTabIndicatorOffset
 import me.him188.ani.app.ui.foundation.rememberImageViewerHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 import me.him188.ani.app.ui.foundation.widgets.LocalToaster
-import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.richtext.RichTextDefaults
 import me.him188.ani.app.ui.search.LoadError
 import me.him188.ani.app.ui.search.LoadErrorCard
@@ -125,6 +124,7 @@ fun SubjectDetailsPage(
     showTopBar: Boolean = true,
     showBlurredBackground: Boolean = true,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     SubjectDetailsPage(
         vm.result,
@@ -134,6 +134,7 @@ fun SubjectDetailsPage(
         showTopBar,
         showBlurredBackground,
         windowInsets,
+        navigationIcon,
     )
 }
 
@@ -146,6 +147,7 @@ fun SubjectDetailsPage(
     showTopBar: Boolean = true,
     showBlurredBackground: Boolean = true,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     when (state) {
         is SubjectDetailsStateLoader.LoadState.Ok -> SubjectDetailsPage(
@@ -155,6 +157,7 @@ fun SubjectDetailsPage(
             showTopBar,
             showBlurredBackground && !state.value.showPlaceholder,
             windowInsets,
+            navigationIcon,
         )
 
         is SubjectDetailsStateLoader.LoadState.Err -> ErrorSubjectDetailsPage(
@@ -165,6 +168,7 @@ fun SubjectDetailsPage(
             modifier,
             showTopBar,
             windowInsets,
+            navigationIcon,
         )
 
         SubjectDetailsStateLoader.LoadState.Loading -> {
@@ -182,6 +186,7 @@ private fun SubjectDetailsPage(
     showTopBar: Boolean = true,
     showBlurredBackground: Boolean = true,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     val toaster = LocalToaster.current
     val browserNavigator = LocalUriHandler.current
@@ -254,6 +259,7 @@ private fun SubjectDetailsPage(
         showTopBar = showTopBar,
         showBlurredBackground = showBlurredBackground,
         windowInsets = windowInsets,
+        navigationIcon = navigationIcon,
     ) { paddingValues ->
         Box {
             AnimatedVisibility(
@@ -328,6 +334,7 @@ private fun ErrorSubjectDetailsPage(
     modifier: Modifier = Modifier,
     showTopBar: Boolean = true,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    navigationIcon: @Composable () -> Unit = {},
 ) {
     SubjectDetailsPageLayout(
         subjectId = subjectId,
@@ -342,6 +349,7 @@ private fun ErrorSubjectDetailsPage(
         showTopBar,
         showBlurredBackground = false,
         windowInsets,
+        navigationIcon,
     ) { paddingValues ->
         LoadErrorCard(
             problem = error,
@@ -382,6 +390,7 @@ fun SubjectDetailsPageLayout(
     showTopBar: Boolean = true,
     showBlurredBackground: Boolean = true,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    navigationIcon: @Composable () -> Unit = {},
     content: @Composable (contentPadding: PaddingValues) -> Unit,
 ) {
     val backgroundColor = AniThemeDefaults.pageContentBackgroundColor
@@ -399,7 +408,7 @@ fun SubjectDetailsPageLayout(
                         // 透明背景的, 总是显示
                         TopAppBar(
                             title = {},
-                            navigationIcon = { TopAppBarGoBackButton() },
+                            navigationIcon = navigationIcon,
                             actions = {
                                 IconButton(onClickOpenExternal) {
                                     Icon(Icons.AutoMirrored.Outlined.OpenInNew, null)
@@ -419,7 +428,7 @@ fun SubjectDetailsPageLayout(
                                         overflow = TextOverflow.Ellipsis,
                                     )
                                 },
-                                navigationIcon = { TopAppBarGoBackButton() },
+                                navigationIcon = navigationIcon,
                                 actions = {
                                     IconButton(onClickOpenExternal) {
                                         Icon(Icons.AutoMirrored.Outlined.OpenInNew, null)


### PR DESCRIPTION
修改返回逻辑:
- 以前点击左上角箭头是模拟了按返回键, 这实际上不好. 快速点击多次就会 pop 多个页面, 导致退出多个页面.
- 现在改成了单独处理按箭头的操作, 统一叫做 `onNavigateBack`, 在 navigation 层处理 (`NavHost` 附近), 保证只 pop 当前页面

修正生命周期逻辑:
- 以前依赖 `BackHandler` 来关闭一些资源 (例如退出页面时自动停止播放)
- 现在使用 `DisposableEffect` 来正确地响应生命周期.
