### PR TITLE
新番时间表

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/schedule/AnimeScheduleInfo.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/schedule/AnimeScheduleInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -38,6 +38,7 @@ data class OnAirAnimeInfo(
 
 typealias AnimeRecurrence = SubjectRecurrence
 
+
 @Serializable
 enum class AnimeSeason(val quarterNumber: Int, val monthRange: Set<Int>) {
     WINTER(1, setOf(12, 1, 2)), // 1
@@ -58,14 +59,6 @@ data class AnimeSeasonId(
 ) : Comparable<AnimeSeasonId> {
     // serialized
     val id: String = "${year}q${season.quarterNumber}"
-
-    val yearMonths
-        get() = when (season) {
-            AnimeSeason.WINTER -> listOf(year - 1 to 12, year to 1, year to 2)
-            AnimeSeason.SPRING -> listOf(year to 3, year to 4, year to 5)
-            AnimeSeason.SUMMER -> listOf(year to 6, year to 7, year to 8)
-            AnimeSeason.AUTUMN -> listOf(year to 9, year to 10, year to 11)
-        }
 
     companion object {
         private val COMPARATOR = compareBy<AnimeSeasonId> { it.year }
@@ -110,3 +103,12 @@ data class AnimeSeasonId(
 
     override fun compareTo(other: AnimeSeasonId): Int = COMPARATOR.compare(this, other)
 }
+
+val AnimeSeasonId.yearMonths
+    get() = when (season) {
+        // 2024 年 1 月新番, 是从 2023 年 12 月末开播, 播到 2024 年 3 月.
+        AnimeSeason.WINTER -> listOf(year - 1 to 12, year to 1, year to 2)
+        AnimeSeason.SPRING -> listOf(year to 3, year to 4, year to 5)
+        AnimeSeason.SUMMER -> listOf(year to 6, year to 7, year to 8)
+        AnimeSeason.AUTUMN -> listOf(year to 9, year to 10, year to 11)
+    }

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/subject/LightSubjectAndEpisodes.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/subject/LightSubjectAndEpisodes.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.data.models.subject
 
+import kotlinx.datetime.TimeZone
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.PackedDate
 
@@ -33,6 +34,7 @@ data class LightEpisodeInfo(
     val name: String,
     val nameCn: String,
     val airDate: PackedDate,
+    val timezone: TimeZone,
     val sort: EpisodeSort,
     val ep: EpisodeSort?,
 )

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/subject/LightSubjectAndEpisodes.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/subject/LightSubjectAndEpisodes.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.models.subject
+
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.PackedDate
+
+data class LightSubjectAndEpisodes(
+    val subject: LightSubjectInfo,
+    val episodes: List<LightEpisodeInfo>,
+) {
+    val subjectId get() = subject.subjectId
+}
+
+data class LightSubjectInfo(
+    val subjectId: Int,
+    val name: String,
+    val nameCn: String,
+    val imageLarge: String,
+)
+
+val LightSubjectInfo.displayName get() = nameCn.takeIf { it.isNotBlank() } ?: name
+
+data class LightEpisodeInfo(
+    val episodeId: Int,
+    val name: String,
+    val nameCn: String,
+    val airDate: PackedDate,
+    val sort: EpisodeSort,
+    val ep: EpisodeSort?,
+)
+
+val LightEpisodeInfo.displayName get() = nameCn.takeIf { it.isNotBlank() } ?: name

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/AbstractBangumiBatchGraphQLExecutor.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/AbstractBangumiBatchGraphQLExecutor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,10 +9,16 @@
 
 package me.him188.ani.app.data.network
 
+import androidx.collection.IntList
 import androidx.collection.IntSet
+import androidx.collection.mutableIntObjectMapOf
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import me.him188.ani.app.data.repository.Repository
+import me.him188.ani.datasources.bangumi.BangumiClient
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.serialization.getOrFail
 
@@ -46,4 +52,115 @@ fun IntSet.toIntArray(): IntArray {
     var i = 0
     forEach { array[i++] = it }
     return array
+}
+
+/**
+ * @param fragment 里面需要定义 `MyFragment`
+ */
+class BangumiBatchGraphQLExecutorEngine(
+    private val actionName: String,
+    private val targetSchema: String,
+    private val fragment: String,
+) {
+    private fun buildQueryOfSize(fragments: String, size: Int): String {
+        return buildString(
+            capacity = fragment.length + 30 + 55 * size, // big enough to avoid resizing
+        ) {
+            appendLine(fragments)
+
+            appendLine("query BatchQuery(")
+            repeat(size) { i ->
+                append("\$id").append(i).append(": Int!")
+                if (i != size - 1) {
+                    append(", ")
+                }
+            }
+            appendLine(") {")
+
+            repeat(size) { i ->
+                append('s')
+                append(i)
+                append(":$targetSchema(id: \$id").append(i).append("){...MyFragment}")
+                appendLine()
+            }
+
+            append("}")
+        }
+    }
+
+    private val cachedQueries = mutableIntObjectMapOf<String>()
+
+    init {
+        cacheQuery(1)
+        cacheQuery(Repository.defaultPagingConfig.pageSize)
+    }
+
+    /**
+     * Pre-builds a query of the given size so that we can reuse the same query for multiple requests.
+     */
+    fun cacheQuery(size: Int) {
+        cachedQueries[size] = buildQueryOfSize(fragment, size)
+    }
+
+    /**
+     * 返回对应每个 id
+     */
+    private fun processResponse(
+        rawGraphQLResponse: JsonObject,
+    ): List<JsonObject?> = when (val element = rawGraphQLResponse.getOrFail("data")) {
+        is JsonObject -> {
+            element.values.map {
+                if (it is JsonNull) null else it.jsonObject
+            }
+        }
+
+        is JsonNull -> throw IllegalStateException("Bangumi GraphQL response data is null: $rawGraphQLResponse")
+        else -> throw IllegalStateException("Unexpected Bangumi GraphQL response: $element")
+    }
+
+    suspend fun execute(client: BangumiClient, ids: IntList): BangumiGraphQLResponse {
+        if (ids.size == 0) {
+            return BangumiGraphQLResponse(emptyList(), "")
+        }
+
+        val cachedQuery = cachedQueries[ids.size]
+
+        // 尽量使用 variables
+        val resp = if (cachedQuery == null) {
+            client.executeGraphQL(
+                actionName,
+                buildQueryOfSize(
+                    fragment,
+                    ids.size,
+                ),
+                variables = buildJsonObject {
+                    repeat(ids.size) { i ->
+                        put("id$i", ids[i])
+                    }
+                },
+            )
+        } else {
+            client.executeGraphQL(
+                actionName,
+                cachedQuery,
+                variables = buildJsonObject {
+                    repeat(ids.size) { i ->
+                        put("id$i", ids[i])
+                    }
+                },
+            )
+        }
+        return try {
+            BangumiGraphQLResponse(
+                processResponse(resp),
+                errors = resp["errors"]?.toString(),
+            )
+        } catch (e: Exception) {
+            throw IllegalStateException(
+                "Exception while processing Bangumi GraphQL response for action $actionName, ids $ids, see cause",
+                e,
+            )
+        }
+    }
+
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/AnimeScheduleService.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/AnimeScheduleService.kt
@@ -29,6 +29,7 @@ import me.him188.ani.client.apis.ScheduleAniApi
 import me.him188.ani.client.models.AniAnimeRecurrence
 import me.him188.ani.client.models.AniAnimeSeason
 import me.him188.ani.client.models.AniAnimeSeasonId
+import me.him188.ani.client.models.AniLatestAnimeSchedules
 import me.him188.ani.client.models.AniOnAirAnimeInfo
 import me.him188.ani.utils.coroutines.IO_
 import kotlin.coroutines.CoroutineContext
@@ -90,6 +91,17 @@ class AnimeScheduleService(
             } catch (e: Exception) {
                 throw RepositoryException.wrapOrThrowCancellation(e)
             }
+        }
+    }
+
+    suspend fun getLatestAnimeScheduleInfos(): List<AnimeScheduleInfo> = withContext(ioDispatcher) {
+        try {
+            val resp = api.getLatestAnimeSeasons()
+            resp.typedBody<AniLatestAnimeSchedules>(typeInfo<AniLatestAnimeSchedules>()).list.map { item ->
+                AnimeScheduleInfo(item.seasonId.toAnimeSeasonId(), item.list.map { it.toAnimeScheduleInfo() })
+            }
+        } catch (e: Exception) {
+            throw RepositoryException.wrapOrThrowCancellation(e)
         }
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/AnimeScheduleService.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/AnimeScheduleService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -128,8 +128,8 @@ private fun AniAnimeSeasonId.toAnimeSeasonId(): AnimeSeasonId {
 
 private val AniAnimeSeason.quarterNumber: Int
     get() = when (this) {
-        AniAnimeSeason.SPRING -> 1
-        AniAnimeSeason.SUMMER -> 2
-        AniAnimeSeason.AUTUMN -> 3
-        AniAnimeSeason.WINTER -> 4
+        AniAnimeSeason.WINTER -> 1
+        AniAnimeSeason.SPRING -> 2
+        AniAnimeSeason.SUMMER -> 3
+        AniAnimeSeason.AUTUMN -> 4
     }

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiLightSubjectGraphQLExecutor.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiLightSubjectGraphQLExecutor.kt
@@ -9,14 +9,10 @@
 
 package me.him188.ani.app.data.network
 
-import androidx.collection.IntList
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import me.him188.ani.app.data.repository.Repository
-import me.him188.ani.datasources.bangumi.BangumiClient
-
-object BangumiLightSubjectGraphQLExecutor : AbstractBangumiBatchGraphQLExecutor() {
-    private const val SUBJECT_DETAILS_FRAGMENTS = """
+val BangumiLightSubjectGraphQLExecutor = BangumiBatchGraphQLExecutorEngine(
+    actionName = "BangumiLightSubjectGraphQLExecutor",
+    targetSchema = "subject",
+    fragment = """
 fragment Ep on Episode {
   id
   type
@@ -26,7 +22,7 @@ fragment Ep on Episode {
   sort
 }
 
-fragment SubjectFragment on Subject {
+fragment MyFragment on Subject {
   id
   type
   name
@@ -35,96 +31,5 @@ fragment SubjectFragment on Subject {
   airtime{date}
   episodes : episodes(limit: 100) { ...Ep }
 }
-        """
-
-    private const val QUERY_1 = """
-$SUBJECT_DETAILS_FRAGMENTS
-query BatchGetSubjectQuery(${'$'}id: Int!) {
-  s0:subject(id: ${'$'}id){...SubjectFragment}
-}
-"""
-
-    // 服务器会缓存 query 编译, 用 variables 可以让查询更快
-    private val QUERY_WHOLE_PAGE by lazy {
-        buildString {
-            appendLine(SUBJECT_DETAILS_FRAGMENTS)
-
-            appendLine("query BatchGetSubjectQuery(")
-            repeat(Repository.defaultPagingConfig.pageSize) { i ->
-                append("\$id").append(i).append(": Int!")
-                if (i != Repository.defaultPagingConfig.pageSize - 1) {
-                    append(", ")
-                }
-            }
-            appendLine(") {")
-
-            repeat(Repository.defaultPagingConfig.pageSize) { i ->
-                append('s')
-                append(i)
-                append(":subject(id: \$id").append(i).append("){...SubjectFragment}")
-                appendLine()
-            }
-
-            append("}")
-        }
-    }
-
-    suspend fun execute(client: BangumiClient, ids: IntList): BangumiGraphQLResponse {
-        val actionName = "SubjectCollectionRepositoryImpl.batchGetSubjectDetails"
-        // 尽量使用 variables
-        val resp = when (ids.size) {
-            0 -> return BangumiGraphQLResponse(emptyList(), "")
-            1 -> {
-                client.executeGraphQL(
-                    actionName,
-                    QUERY_1,
-                    variables = buildJsonObject {
-                        put("id", ids.first())
-                    },
-                )
-            }
-
-            Repository.defaultPagingConfig.pageSize -> {
-                client.executeGraphQL(
-                    actionName,
-                    QUERY_WHOLE_PAGE,
-                    variables = buildJsonObject {
-                        repeat(ids.size) { i ->
-                            put("id$i", ids[i])
-                        }
-                    },
-                )
-            }
-
-            else -> {
-                client.executeGraphQL(
-                    actionName,
-                    buildString(
-                        capacity = SUBJECT_DETAILS_FRAGMENTS.length + 30 + 55 * ids.size, // big enough to avoid resizing
-                    ) {
-                        appendLine(SUBJECT_DETAILS_FRAGMENTS)
-                        appendLine("query BatchGetSubjectQuery {")
-                        ids.forEach { id ->
-                            append('s')
-                            append(id)
-                            append(":subject(id: ").append(id).append("){...SubjectFragment}")
-                            appendLine()
-                        }
-                        append("}")
-                    },
-                )
-            }
-        }
-        return try {
-            BangumiGraphQLResponse(
-                processResponse(resp),
-                errors = resp["errors"]?.toString(),
-            )
-        } catch (e: Exception) {
-            throw IllegalStateException(
-                "Exception while processing Bangumi GraphQL response for action $actionName, ids $ids, see cause",
-                e,
-            )
-        }
-    }
-}
+""".trimIndent(),
+)

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiLightSubjectGraphQLExecutor.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiLightSubjectGraphQLExecutor.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.network
+
+import androidx.collection.IntList
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import me.him188.ani.app.data.repository.Repository
+import me.him188.ani.datasources.bangumi.BangumiClient
+
+object BangumiLightSubjectGraphQLExecutor : AbstractBangumiBatchGraphQLExecutor() {
+    private const val SUBJECT_DETAILS_FRAGMENTS = """
+fragment Ep on Episode {
+  id
+  type
+  name
+  name_cn
+  airdate
+  sort
+}
+
+fragment SubjectFragment on Subject {
+  id
+  type
+  name
+  name_cn
+  images{large}
+  airtime{date}
+  episodes : episodes(limit: 100) { ...Ep }
+}
+        """
+
+    private const val QUERY_1 = """
+$SUBJECT_DETAILS_FRAGMENTS
+query BatchGetSubjectQuery(${'$'}id: Int!) {
+  s0:subject(id: ${'$'}id){...SubjectFragment}
+}
+"""
+
+    // 服务器会缓存 query 编译, 用 variables 可以让查询更快
+    private val QUERY_WHOLE_PAGE by lazy {
+        buildString {
+            appendLine(SUBJECT_DETAILS_FRAGMENTS)
+
+            appendLine("query BatchGetSubjectQuery(")
+            repeat(Repository.defaultPagingConfig.pageSize) { i ->
+                append("\$id").append(i).append(": Int!")
+                if (i != Repository.defaultPagingConfig.pageSize - 1) {
+                    append(", ")
+                }
+            }
+            appendLine(") {")
+
+            repeat(Repository.defaultPagingConfig.pageSize) { i ->
+                append('s')
+                append(i)
+                append(":subject(id: \$id").append(i).append("){...SubjectFragment}")
+                appendLine()
+            }
+
+            append("}")
+        }
+    }
+
+    suspend fun execute(client: BangumiClient, ids: IntList): BangumiGraphQLResponse {
+        val actionName = "SubjectCollectionRepositoryImpl.batchGetSubjectDetails"
+        // 尽量使用 variables
+        val resp = when (ids.size) {
+            0 -> return BangumiGraphQLResponse(emptyList(), "")
+            1 -> {
+                client.executeGraphQL(
+                    actionName,
+                    QUERY_1,
+                    variables = buildJsonObject {
+                        put("id", ids.first())
+                    },
+                )
+            }
+
+            Repository.defaultPagingConfig.pageSize -> {
+                client.executeGraphQL(
+                    actionName,
+                    QUERY_WHOLE_PAGE,
+                    variables = buildJsonObject {
+                        repeat(ids.size) { i ->
+                            put("id$i", ids[i])
+                        }
+                    },
+                )
+            }
+
+            else -> {
+                client.executeGraphQL(
+                    actionName,
+                    buildString(
+                        capacity = SUBJECT_DETAILS_FRAGMENTS.length + 30 + 55 * ids.size, // big enough to avoid resizing
+                    ) {
+                        appendLine(SUBJECT_DETAILS_FRAGMENTS)
+                        appendLine("query BatchGetSubjectQuery {")
+                        ids.forEach { id ->
+                            append('s')
+                            append(id)
+                            append(":subject(id: ").append(id).append("){...SubjectFragment}")
+                            appendLine()
+                        }
+                        append("}")
+                    },
+                )
+            }
+        }
+        return try {
+            BangumiGraphQLResponse(
+                processResponse(resp),
+                errors = resp["errors"]?.toString(),
+            )
+        } catch (e: Exception) {
+            throw IllegalStateException(
+                "Exception while processing Bangumi GraphQL response for action $actionName, ids $ids, see cause",
+                e,
+            )
+        }
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectGraphQLParser.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectGraphQLParser.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.data.network
 
+import kotlinx.datetime.TimeZone
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -45,6 +46,7 @@ import me.him188.ani.utils.serialization.getStringOrFail
 import me.him188.ani.utils.serialization.jsonObjectOrNull
 
 object BangumiSubjectGraphQLParser {
+    private val utc9 = TimeZone.of("UTC+9")
     private fun JsonElement.vSequence(): Sequence<String> {
         return when (this) {
             is JsonArray -> this.asSequence().flatMap { it.vSequence() }
@@ -284,6 +286,7 @@ object BangumiSubjectGraphQLParser {
                 name = episode.getStringOrFail("name"),
                 nameCn = episode.getStringOrFail("name_cn"),
                 airDate = PackedDate.parseFromDate(episode.getStringOrFail("airdate")),
+                timezone = utc9,
                 sort = EpisodeSort(
                     BigNum(episode.getStringOrFail("sort")),
                     type = parseBangumiEpisodeType(episode.getIntOrFail("type")),

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectGraphQLParser.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectGraphQLParser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -19,6 +19,9 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.him188.ani.app.data.models.subject.CharacterInfo
 import me.him188.ani.app.data.models.subject.CharacterRole
+import me.him188.ani.app.data.models.subject.LightEpisodeInfo
+import me.him188.ani.app.data.models.subject.LightSubjectAndEpisodes
+import me.him188.ani.app.data.models.subject.LightSubjectInfo
 import me.him188.ani.app.data.models.subject.PersonInfo
 import me.him188.ani.app.data.models.subject.PersonPosition
 import me.him188.ani.app.data.models.subject.PersonType
@@ -30,7 +33,10 @@ import me.him188.ani.app.data.models.subject.SubjectCollectionStats
 import me.him188.ani.app.data.models.subject.SubjectInfo
 import me.him188.ani.app.data.models.subject.Tag
 import me.him188.ani.app.domain.search.SubjectType
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.EpisodeType
 import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.utils.serialization.BigNum
 import me.him188.ani.utils.serialization.getBooleanOrFail
 import me.him188.ani.utils.serialization.getIntOrFail
 import me.him188.ani.utils.serialization.getOrFail
@@ -268,5 +274,48 @@ object BangumiSubjectGraphQLParser {
 
                 action(subjectId, characterId)
             }
+    }
+
+    fun parseLightSubjectAndEpisodes(jsonObject: JsonObject): LightSubjectAndEpisodes {
+        val episodes = jsonObject.getOrFail("episodes").jsonArray.map {
+            val episode = it.jsonObject
+            LightEpisodeInfo(
+                episodeId = episode.getIntOrFail("id"),
+                name = episode.getStringOrFail("name"),
+                nameCn = episode.getStringOrFail("name_cn"),
+                airDate = PackedDate.parseFromDate(episode.getStringOrFail("airdate")),
+                sort = EpisodeSort(
+                    BigNum(episode.getStringOrFail("sort")),
+                    type = parseBangumiEpisodeType(episode.getIntOrFail("type")),
+                ),
+                ep = null, // TODO: parseLightSubjectAndEpisodes does not support EP because bangumi graphql API does not provide it
+//                    EpisodeSort(
+//                    episode.getIntOrFail("ep"),
+//                    type = parseBangumiEpisodeType(episode.getIntOrFail("type")),
+//                ),
+            )
+        }
+
+        return LightSubjectAndEpisodes(
+            subject = LightSubjectInfo(
+                subjectId = jsonObject.getIntOrFail("id"),
+                name = jsonObject.getStringOrFail("name"),
+                nameCn = jsonObject.getStringOrFail("name_cn"),
+                imageLarge = jsonObject.getOrFail("images").jsonObjectOrNull?.getStringOrFail("large") ?: "",
+            ),
+            episodes = episodes,
+        )
+    }
+
+    private fun parseBangumiEpisodeType(type: Int): EpisodeType? {
+        return when (type) {
+            0 -> EpisodeType.MainStory
+            1 -> EpisodeType.SP
+            2 -> EpisodeType.OP
+            3 -> EpisodeType.ED
+            4 -> EpisodeType.PV
+            5 -> EpisodeType.MAD
+            else -> null
+        }
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectService.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectService.kt
@@ -354,12 +354,8 @@ class RemoteBangumiSubjectService(
             return emptyList()
         }
         return withContext(ioDispatcher) {
-            val respDeferred = async {
-                BangumiLightSubjectGraphQLExecutor.execute(client, subjectIds)
-            }
-
             // 等待查询条目信息
-            val (response, errors) = respDeferred.await()
+            val (response, errors) = BangumiLightSubjectGraphQLExecutor.execute(client, subjectIds)
 
             // 解析条目详情
             response.mapIndexed { index, element ->

--- a/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectService.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/network/BangumiSubjectService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -31,6 +31,8 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.data.models.subject.CharacterInfo
 import me.him188.ani.app.data.models.subject.CharacterRole
+import me.him188.ani.app.data.models.subject.LightSubjectAndEpisodes
+import me.him188.ani.app.data.models.subject.LightSubjectInfo
 import me.him188.ani.app.data.models.subject.PersonInfo
 import me.him188.ani.app.data.models.subject.PersonPosition
 import me.him188.ani.app.data.models.subject.RatingCounts
@@ -90,6 +92,10 @@ interface BangumiSubjectService {
         ids: IntList,
         withCharacterActors: Boolean,
     ): List<BatchSubjectRelations>
+
+    suspend fun batchGetLightSubjectAndEpisodes(
+        subjectIds: IntList,
+    ): List<LightSubjectAndEpisodes>
 
     /**
      * 获取用户对这个条目的收藏状态. flow 一定会 emit 至少一个值或抛出异常. 当用户没有收藏这个条目时 emit `null`.
@@ -338,6 +344,38 @@ class RemoteBangumiSubjectService(
                             }.orEmpty()
                         },
                     )
+                }
+            }
+        }
+    }
+
+    override suspend fun batchGetLightSubjectAndEpisodes(subjectIds: IntList): List<LightSubjectAndEpisodes> {
+        if (subjectIds.isEmpty()) {
+            return emptyList()
+        }
+        return withContext(ioDispatcher) {
+            val respDeferred = async {
+                BangumiLightSubjectGraphQLExecutor.execute(client, subjectIds)
+            }
+
+            // 等待查询条目信息
+            val (response, errors) = respDeferred.await()
+
+            // 解析条目详情
+            response.mapIndexed { index, element ->
+                if (element == null) { // error
+                    val subjectId = subjectIds[index]
+                    LightSubjectAndEpisodes(
+                        subject = LightSubjectInfo(
+                            subjectId,
+                            name = "错误 $subjectId: $errors",
+                            nameCn = "错误 $subjectId: $errors",
+                            imageLarge = "",
+                        ),
+                        episodes = emptyList(),
+                    )
+                } else {
+                    BangumiSubjectGraphQLParser.parseLightSubjectAndEpisodes(element)
                 }
             }
         }

--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -178,6 +178,9 @@ interface SubjectCollectionDao {
 
     @Query("""SELECT * FROM subject_collection WHERE subjectId = :subjectId""")
     fun findById(subjectId: Int): Flow<SubjectCollectionEntity?>
+
+    @Query("""SELECT * FROM subject_collection WHERE subjectId IN (:subjectIds)""")
+    fun filterByIds(subjectIds: IntArray): Flow<List<SubjectCollectionEntity>>
 
     @Query(
         """

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/episode/AnimeScheduleRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/episode/AnimeScheduleRepository.kt
@@ -47,7 +47,7 @@ class AnimeScheduleRepository(
      * 获取所有新番季度的 ID
      */
     private fun animeSeasonIdsFlow(): Flow<List<AnimeSeasonId>> =
-        refreshTicker.mapLatest { animeScheduleService.getSeasonIds() }
+        refreshTicker.mapLatest { animeScheduleService.getSeasonIds().sortedDescending() }
 
     /**
      * 获取指定季度的新番时间表

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/episode/AnimeScheduleRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/episode/AnimeScheduleRepository.kt
@@ -11,13 +11,9 @@ package me.him188.ani.app.data.repository.episode
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.toList
 import me.him188.ani.app.data.models.schedule.AnimeScheduleInfo
 import me.him188.ani.app.data.models.schedule.AnimeSeasonId
 import me.him188.ani.app.data.models.subject.SubjectRecurrence
@@ -76,16 +72,11 @@ class AnimeScheduleRepository(
     /**
      * 获取最近两季度的新番时间表
      */
-    fun recentSchedulesFlow(): Flow<List<AnimeScheduleInfo>> =
-        animeSeasonIdsFlow().mapLatest { seasons ->
-            seasons.take(2)
-                .map {
-                    suspend { animeScheduleService.getScheduleInfo(it) }.asFlow() // emits 1 item
-                }
-                .merge() // launches 4 coroutines, emits at most 4 items
-                .filterNotNull() // should not be null, just defensive programming
-                .toList()
+    fun recentSchedulesFlow(): Flow<List<AnimeScheduleInfo>> {
+        return flow {
+            emit(animeScheduleService.getLatestAnimeScheduleInfos())
         }.flowOn(defaultDispatcher)
+    }
 
 
 //    fun recentScheduleSubjectsFlow(): Flow<List<SubjectCollectionInfo>> =

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,6 +9,8 @@
 
 package me.him188.ani.app.data.repository.subject
 
+import androidx.collection.IntList
+import androidx.collection.mutableIntListOf
 import androidx.paging.LoadType
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
@@ -25,6 +27,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -36,7 +39,11 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
+import me.him188.ani.app.data.models.episode.EpisodeInfo
 import me.him188.ani.app.data.models.preference.NsfwMode
+import me.him188.ani.app.data.models.subject.LightEpisodeInfo
+import me.him188.ani.app.data.models.subject.LightSubjectAndEpisodes
+import me.him188.ani.app.data.models.subject.LightSubjectInfo
 import me.him188.ani.app.data.models.subject.SelfRatingInfo
 import me.him188.ani.app.data.models.subject.SubjectAiringInfo
 import me.him188.ani.app.data.models.subject.SubjectCollectionCounts
@@ -76,6 +83,7 @@ import me.him188.ani.datasources.bangumi.processing.toSubjectCollectionType
 import me.him188.ani.utils.coroutines.combine
 import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.platform.collections.toIntArray
 import me.him188.ani.utils.platform.currentTimeMillis
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
@@ -98,6 +106,11 @@ sealed class SubjectCollectionRepository(
     abstract fun subjectCollectionCountsFlow(): Flow<SubjectCollectionCounts?>
 
     abstract fun subjectCollectionFlow(subjectId: Int): Flow<SubjectCollectionInfo>
+
+    /**
+     * 批量获取多个条目的基本信息和前 100 剧集列表.
+     */
+    abstract fun batchLightSubjectAndEpisodesFlow(subjectIds: IntList): Flow<List<LightSubjectAndEpisodes>>
 
     abstract fun subjectCollectionsPager(
         query: CollectionsFilterQuery = CollectionsFilterQuery.Empty,
@@ -232,6 +245,32 @@ class SubjectCollectionRepositoryImpl(
                     nsfwModeSettings = nsfwModeSettings,
                 )
             }.flowOn(defaultDispatcher)
+
+    override fun batchLightSubjectAndEpisodesFlow(subjectIds: IntList): Flow<List<LightSubjectAndEpisodes>> {
+        return flow {
+            val existing = subjectCollectionDao.filterByIds(subjectIds.toIntArray()).first()
+            val missingIds = mutableIntListOf()
+            subjectIds.forEach { subjectId ->
+                val existingSubject = existing.find { it.subjectId == subjectId }
+                if (existingSubject == null || existingSubject.isExpired()) {
+                    missingIds.add(subjectId)
+                }
+            }
+
+            emit(
+                existing.map { subjectCollectionEntity ->
+                    LightSubjectAndEpisodes(
+                        subjectCollectionEntity.toLightSubjectInfo(),
+                        episodeCollectionRepository.subjectEpisodeCollectionInfosFlow(subjectCollectionEntity.subjectId)
+                            .first().map {
+                                it.episodeInfo.toLightEpisodeInfo()
+                            },
+                    )
+                }
+                    .plus(batchGetLightSubjectEpisodes(missingIds)),// TODO: 2025/1/14 batchGetLightSubjectEpisodes 没有按 epType 过滤 
+            )
+        }
+    }
 
     override fun mostRecentlyUpdatedSubjectCollectionsFlow(
         limit: Int,
@@ -457,6 +496,10 @@ class SubjectCollectionRepositoryImpl(
         }
     }
 
+    private suspend fun batchGetLightSubjectEpisodes(subjectIds: IntList): List<LightSubjectAndEpisodes> {
+        return bangumiSubjectService.batchGetLightSubjectAndEpisodes(subjectIds)
+    }
+
     private suspend fun batchGetSubjectEpisodes(items: List<BatchSubjectCollection>): List<EpisodeCollectionEntity> {
         return coroutineScope {
             // 并发
@@ -513,6 +556,20 @@ class SubjectCollectionRepositoryImpl(
         private val logger = logger<SubjectCollectionRepository>()
     }
 }
+
+internal fun EpisodeInfo.toLightEpisodeInfo(): LightEpisodeInfo {
+    return LightEpisodeInfo(
+        episodeId = episodeId,
+        name = name,
+        nameCn = nameCn,
+        airDate = airDate,
+        sort = sort,
+        ep = ep,
+    )
+}
+
+internal fun SubjectCollectionEntity.toLightSubjectInfo() =
+    LightSubjectInfo(subjectId, name, nameCn, imageLarge)
 
 data class CollectionsFilterQuery(
     val type: UnifiedCollectionType?,

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -75,6 +75,7 @@ import me.him188.ani.app.domain.session.SessionManager
 import me.him188.ani.app.domain.session.verifiedAccessToken
 import me.him188.ani.datasources.api.EpisodeType.MainStory
 import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.datasources.api.UTC9
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 import me.him188.ani.datasources.bangumi.apis.DefaultApi
 import me.him188.ani.datasources.bangumi.models.BangumiUserSubjectCollectionModifyPayload
@@ -563,6 +564,7 @@ internal fun EpisodeInfo.toLightEpisodeInfo(): LightEpisodeInfo {
         name = name,
         nameCn = nameCn,
         airDate = airDate,
+        timezone = UTC9,
         sort = sort,
         ep = ep,
     )

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/AnimeScheduleHelper.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/AnimeScheduleHelper.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.episode
+
+import androidx.collection.MutableIntObjectMap
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.app.data.models.schedule.OnAirAnimeInfo
+import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
+import me.him188.ani.datasources.api.toLocalDateOrNull
+
+data class EpisodeWithAiringTime(
+    val subject: SubjectCollectionInfo,
+    val episode: EpisodeInfo,
+    val airingTime: Instant,
+)
+
+object AnimeScheduleHelper {
+    private val Utc9 = TimeZone.of("UTC+9")
+
+    fun buildAiringScheduleForDate(
+        subjects: List<SubjectCollectionInfo>,
+        airInfos: List<OnAirAnimeInfo>,
+        targetDate: LocalDate,
+        localTimeZone: TimeZone,
+    ): List<EpisodeWithAiringTime> {
+        // Pre-map OnAirAnimeInfo by bangumiId (subjectId)
+        val subjectIdToAirInfo = MutableIntObjectMap<OnAirAnimeInfo>(subjects.size).apply {
+            airInfos.forEach { put(it.bangumiId, it) }
+        }
+
+        return subjects.mapNotNull { subject ->
+            val airInfo = subjectIdToAirInfo[subject.subjectId] ?: return@mapNotNull null
+
+            // If we have no actual begin time or no recurrence, we can’t do further computations
+            val subjectBegin = airInfo.begin ?: return@mapNotNull null
+            val recurrence = airInfo.recurrence ?: return@mapNotNull null
+
+            // Sort episodes in ascending order of "sort"
+            val episodes = subject.episodes
+                .map { it.episodeInfo }
+                .sortedBy { it.sort }
+
+            // Keep track of the last known valid date/time (as Instant in UTC+9).
+            // So if we have an episode with an invalid airDate, we can guess it
+            // from the previous known date + recurrence.interval.
+            //
+            // We also keep track of how many episodes we’ve processed, so we can
+            // approximate using “(n-1) * recurrence.interval” from subjectBegin
+            // if needed.
+
+            var lastKnownInstant: Instant? = null
+
+            // The actual “match” we find for targetDate
+            var matchedEpisode: EpisodeInfo? = null
+            var matchedEpisodeInstant: Instant? = null
+
+            episodes.forEachIndexed { index, ep ->
+                // 1-based index for the “(episode n) => subjectBegin + (n - 1)*interval”
+                val episodeNumber = index + 1
+
+                // Try to see if the episode’s airDate is valid.
+                val localDateFromAirDate = ep.airDate.toLocalDateOrNull()  // This is a LocalDate in UTC+9
+                    ?.atStartOfDayIn(Utc9)
+                    ?.toLocalDateTime(localTimeZone) // convert to our local timezone
+
+                // Option A: If we have a valid date in EpisodeInfo itself, trust it.
+                if (localDateFromAirDate != null) {
+                    // Convert that local date into an Instant at (subject’s known hour) if we have it,
+                    // or default to the subjectBegin’s local time-of-day. 
+                    // Usually subjectBegin is the time for Ep1, so if we’re matching Episode #N,
+                    // we might do subjectBegin + (N-1)*recurrence.
+
+                    // We'll guess the day’s time from:
+                    //   subjectBegin’s LocalTime in UTC+9
+                    val baseDateTime = subjectBegin.toLocalDateTime(localTimeZone)
+                    val localTime = baseDateTime.time
+
+                    // Now combine localDateFromAirDate + localTime to get an Instant
+                    val epLocalDateTime = LocalDateTime(
+                        localDateFromAirDate.year,
+                        localDateFromAirDate.monthNumber,
+                        localDateFromAirDate.dayOfMonth,
+                        localTime.hour,
+                        localTime.minute,
+                        localTime.second,
+                        localTime.nanosecond,
+                    )
+                    val epInstant = epLocalDateTime.toInstant(localTimeZone)
+
+                    // Because we have a real date from the episode metadata, let's reset lastKnownInstant
+                    lastKnownInstant = epInstant
+
+                    // Check if it matches the targetDate
+                    if (localDateFromAirDate == targetDate) {
+                        matchedEpisode = ep
+                        matchedEpisodeInstant = epInstant
+                        return@forEachIndexed  // Done searching this subject
+                    }
+                } else {
+                    // Option B: Guess the date/time from recurrence if no date is specified
+                    val guessedInstant = if (lastKnownInstant != null) {
+                        // Add one recurrence interval from the last known
+                        // but if the user wants “episodeNumber-based”, do that:
+                        lastKnownInstant!!.plus(recurrence.interval)
+                    } else {
+                        // if no last known instant, guess from subjectBegin + (episodeNumber - 1) * recurrence
+                        subjectBegin.plus(recurrence.interval * (episodeNumber - 1))
+                    }
+
+                    val localDateTime = guessedInstant.toLocalDateTime(localTimeZone)
+                    val localDate = localDateTime.date
+
+                    // Update lastKnownInstant
+                    lastKnownInstant = guessedInstant
+
+                    // Compare with targetDate
+                    if (localDate == targetDate) {
+                        matchedEpisode = ep
+                        matchedEpisodeInstant = guessedInstant
+                        return@forEachIndexed
+                    }
+                }
+            }
+
+            // If we found no matched episode for that subject, skip it
+            val nextEpisode = matchedEpisode ?: return@mapNotNull null
+            val nextEpisodeInstant = matchedEpisodeInstant ?: return@mapNotNull null
+
+            EpisodeWithAiringTime(
+                subject = subject,
+                episode = nextEpisode,
+                airingTime = nextEpisodeInstant,
+            )
+        }
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
@@ -67,7 +67,7 @@ class GetAnimeScheduleFlowUseCaseImpl(
 
                 subjectCollectionRepository.batchLightSubjectAndEpisodesFlow(onAirAnimeInfos.mapToIntList { it.bangumiId })
                     .mapLatest { subjects ->
-                        (-7..14).map { offsetDays ->
+                        (0..6).map { offsetDays ->
                             val date = now.toLocalDateTime(timeZone).date.plus(DatePeriod(days = offsetDays))
                             val airingSchedule = AnimeScheduleHelper.buildAiringScheduleForDate(
                                 subjects,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.domain.episode
 
+import androidx.compose.ui.util.packInts
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -39,7 +40,9 @@ data class EpisodeWithAiringTime(
     val subject: LightSubjectInfo,
     val episode: LightEpisodeInfo,
     val airingTime: Instant,
-)
+) {
+    val combinedId = packInts(subject.subjectId, episode.episodeId)
+}
 
 fun interface GetAnimeScheduleFlowUseCase : UseCase {
     operator fun invoke(now: Instant, timeZone: TimeZone): Flow<List<AiringScheduleForDate>>
@@ -79,7 +82,7 @@ class GetAnimeScheduleFlowUseCaseImpl(
                                         episode = episodeSchedule.episode,
                                         airingTime = episodeSchedule.airingTime,
                                     )
-                                },
+                                }.distinctBy { it.combinedId },
                             )
                         }
                     }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.episode
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import me.him188.ani.app.data.repository.episode.AnimeScheduleRepository
+import me.him188.ani.app.data.repository.subject.SubjectCollectionRepository
+import me.him188.ani.app.domain.usecase.UseCase
+import org.koin.core.Koin
+import kotlin.coroutines.CoroutineContext
+
+data class AiringScheduleForDate(
+    val date: LocalDate,
+    val list: List<EpisodeWithAiringTime>,
+)
+
+fun interface GetAnimeScheduleFlowUseCase : UseCase {
+    operator fun invoke(now: Instant, timeZone: TimeZone): Flow<List<AiringScheduleForDate>>
+}
+
+class GetAnimeScheduleFlowUseCaseImpl(
+    koin: Koin,
+    private val defaultDispatcher: CoroutineContext = Dispatchers.Default,
+) : GetAnimeScheduleFlowUseCase {
+    private val animeScheduleRepository: AnimeScheduleRepository by koin.inject()
+    private val subjectCollectionRepository: SubjectCollectionRepository by koin.inject()
+
+    override fun invoke(now: Instant, timeZone: TimeZone): Flow<List<AiringScheduleForDate>> =
+        animeScheduleRepository.recentSchedulesFlow()
+            .flatMapLatest { schedule ->
+                val onAirAnimeInfos = schedule.flatMap { it.list }
+                    .filter {
+                        val end = it.end
+                        it.begin != null && it.recurrence != null && (end == null || end < Clock.System.now())
+                    }
+
+                combine(
+                    onAirAnimeInfos.map { it.bangumiId }.map { subjectCollectionRepository.subjectCollectionFlow(it) },
+                ) {
+                    val subjects = it.toList()
+
+                    (-7..14).map { offsetDays ->
+                        val date = now.toLocalDateTime(timeZone).date.plus(DatePeriod(days = offsetDays))
+                        val airingSchedule = AnimeScheduleHelper.buildAiringScheduleForDate(
+                            subjects,
+                            onAirAnimeInfos,
+                            date,
+                            timeZone,
+                        )
+                        AiringScheduleForDate(date, airingSchedule)
+                    }
+                }
+
+            }.flowOn(defaultDispatcher)
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
@@ -28,7 +28,6 @@ import me.him188.ani.app.data.repository.episode.AnimeScheduleRepository
 import me.him188.ani.app.data.repository.subject.SubjectCollectionRepository
 import me.him188.ani.app.domain.usecase.UseCase
 import me.him188.ani.utils.platform.collections.mapToIntList
-import org.koin.core.Koin
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.minutes
 
@@ -50,12 +49,10 @@ fun interface GetAnimeScheduleFlowUseCase : UseCase {
 }
 
 class GetAnimeScheduleFlowUseCaseImpl(
-    koin: Koin,
+    private val animeScheduleRepository: AnimeScheduleRepository,
+    private val subjectCollectionRepository: SubjectCollectionRepository,
     private val defaultDispatcher: CoroutineContext = Dispatchers.Default,
 ) : GetAnimeScheduleFlowUseCase {
-    private val animeScheduleRepository: AnimeScheduleRepository by koin.inject()
-    private val subjectCollectionRepository: SubjectCollectionRepository by koin.inject()
-
     override fun invoke(now: Instant, timeZone: TimeZone): Flow<List<AiringScheduleForDate>> =
         animeScheduleRepository.recentSchedulesFlow()
             .flatMapLatest { schedule ->

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/GetAnimeScheduleFlowUseCase.kt
@@ -30,6 +30,7 @@ import me.him188.ani.app.domain.usecase.UseCase
 import me.him188.ani.utils.platform.collections.mapToIntList
 import org.koin.core.Koin
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.minutes
 
 data class AiringScheduleForDate(
     val date: LocalDate,
@@ -73,6 +74,7 @@ class GetAnimeScheduleFlowUseCaseImpl(
                                 onAirAnimeInfos,
                                 date,
                                 timeZone,
+                                allowedDeviation = 1.minutes,
                             )
                             AiringScheduleForDate(
                                 date,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
@@ -55,7 +55,7 @@ fun KoinApplication.useCaseModules() = module {
     single<SetDanmakuEnabledUseCase> { SetDanmakuEnabledUseCaseImpl(koin) }
     single<SetEpisodeCollectionTypeUseCase> { SetEpisodeCollectionTypeUseCaseImpl(koin) }
     single<GetEpisodeCollectionTypeUseCase> { GetEpisodeCollectionTypeUseCaseImpl(koin) }
-    single<GetAnimeScheduleFlowUseCase> { GetAnimeScheduleFlowUseCaseImpl(koin) }
+    single<GetAnimeScheduleFlowUseCase> { GetAnimeScheduleFlowUseCaseImpl(get(), get()) }
 }
 
 val GlobalKoin get() = KoinPlatform.getKoin()

--- a/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -15,6 +15,8 @@ import me.him188.ani.app.domain.danmaku.SetDanmakuEnabledUseCase
 import me.him188.ani.app.domain.danmaku.SetDanmakuEnabledUseCaseImpl
 import me.him188.ani.app.domain.episode.CreateMediaFetchSelectBundleFlowUseCase
 import me.him188.ani.app.domain.episode.CreateMediaFetchSelectBundleFlowUseCaseImpl
+import me.him188.ani.app.domain.episode.GetAnimeScheduleFlowUseCase
+import me.him188.ani.app.domain.episode.GetAnimeScheduleFlowUseCaseImpl
 import me.him188.ani.app.domain.episode.GetEpisodeCollectionInfoFlowUseCase
 import me.him188.ani.app.domain.episode.GetEpisodeCollectionInfoFlowUseCaseImpl
 import me.him188.ani.app.domain.episode.GetEpisodeCollectionTypeUseCase
@@ -53,6 +55,7 @@ fun KoinApplication.useCaseModules() = module {
     single<SetDanmakuEnabledUseCase> { SetDanmakuEnabledUseCaseImpl(koin) }
     single<SetEpisodeCollectionTypeUseCase> { SetEpisodeCollectionTypeUseCaseImpl(koin) }
     single<GetEpisodeCollectionTypeUseCase> { GetEpisodeCollectionTypeUseCaseImpl(koin) }
+    single<GetAnimeScheduleFlowUseCase> { GetAnimeScheduleFlowUseCaseImpl(koin) }
 }
 
 val GlobalKoin get() = KoinPlatform.getKoin()

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/AnimeScheduleHelperTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/AnimeScheduleHelperTest.kt
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.episode
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.app.data.models.preference.NsfwMode
+import me.him188.ani.app.data.models.schedule.AnimeRecurrence
+import me.him188.ani.app.data.models.schedule.OnAirAnimeInfo
+import me.him188.ani.app.data.models.subject.SelfRatingInfo
+import me.him188.ani.app.data.models.subject.SubjectAiringInfo
+import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
+import me.him188.ani.app.data.models.subject.SubjectInfo
+import me.him188.ani.app.data.models.subject.SubjectProgressInfo
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+
+class AnimeScheduleHelperTest {
+    // --------------------
+// SAMPLE TEST CLASS
+// --------------------
+
+    /**
+     * We'll assume we have the `convert` method somewhere in your code base:
+     *
+     *  fun convert(
+     *    subjects: List<SubjectCollectionInfo>,
+     *    airInfos: List<OnAirAnimeInfo>,
+     *    targetDate: LocalDate,
+     *  ): List<ScheduleItemPresentation> { ... }
+     *
+     * Make sure it's imported or in the same file so these tests can call it.
+     */
+
+    // --------------
+    // Helper Methods
+    // --------------
+
+    /**
+     * Creates a minimal [SubjectCollectionInfo] with some default or empty property values
+     * so that test authors only need to specify what's relevant. Example usage:
+     *
+     *   createSubjectCollectionInfo(
+     *       subjectId = 123,
+     *       episodes = listOf(episode1, episode2)
+     *   )
+     *
+     * Then add or override if needed, e.g. `subjectInfo = subjectInfo.copy(name = "NewName")`.
+     */
+    private fun createSubjectCollectionInfo(
+        subjectId: Int,
+        episodes: List<EpisodeInfo>,
+        collectionType: UnifiedCollectionType = UnifiedCollectionType.WISH, // or any default
+        subjectName: String = "Default Subject"
+    ): SubjectCollectionInfo {
+        val subjectInfo = SubjectInfo.Empty.copy(
+            subjectId = subjectId,
+            name = subjectName,
+            imageLarge = "https://example.com/default.jpg",
+        )
+        val episodeCollectionInfos = episodes.map {
+            EpisodeCollectionInfo(
+                episodeInfo = it,
+                collectionType = collectionType,
+            )
+        }
+        return SubjectCollectionInfo(
+            collectionType = collectionType,
+            subjectInfo = subjectInfo,
+            selfRatingInfo = SelfRatingInfo.Empty, // or other defaults
+            episodes = episodeCollectionInfos,
+            airingInfo = SubjectAiringInfo.EmptyCompleted, // or default
+            progressInfo = SubjectProgressInfo.Done, // or default
+            recurrence = null,   // null => not used from Subject side
+            cachedStaffUpdated = 0L,
+            cachedCharactersUpdated = 0L,
+            lastUpdated = 0L,
+            nsfwMode = NsfwMode.HIDE,
+        )
+    }
+
+    /**
+     * Creates a minimal [OnAirAnimeInfo]. If `begin` is not specified, the algorithm cannot proceed,
+     * so provide one if needed. If `recurrence` is null, the algorithm also cannot guess.
+     */
+    private fun createOnAirAnimeInfo(
+        bangumiId: Int,
+        begin: String?,            // ISO-8601 string, e.g. "2024-07-06T13:00:00Z"
+        intervalDays: Int?,        // e.g. 7
+        end: String? = null
+    ): OnAirAnimeInfo {
+        val beginInstant = begin?.let { Instant.parse(it) } // or null
+        val endInstant = end?.let { Instant.parse(it) }
+
+        val recurrence = intervalDays?.let {
+            AnimeRecurrence(
+                startTime = beginInstant ?: Instant.DISTANT_PAST,
+                interval = it.days,
+            )
+        }
+
+        return OnAirAnimeInfo(
+            bangumiId = bangumiId,
+            name = "Anime-$bangumiId",
+            aliases = listOf(),
+            begin = beginInstant,
+            recurrence = recurrence,
+            end = endInstant,
+            mikanId = null,
+        )
+    }
+
+    /**
+     * Utility to create an [EpisodeInfo] with an optional air date in 'yyyy-mm-dd' format (UTC+9).
+     * Pass null or "Invalid" to test invalid/unknown air dates.
+     */
+    private fun createEpisodeInfo(
+        episodeId: Int,
+        airDateString: String? = null,
+        sort: String = "$episodeId" // default sort is just the episode number
+    ): EpisodeInfo {
+        val packedDate = if (airDateString.isNullOrBlank() || airDateString == "Invalid") {
+            PackedDate.Invalid
+        } else {
+            // e.g. "2024-01-05" => year=2024, month=1, day=5
+            val parts = airDateString.split("-")
+            if (parts.size == 3) {
+                PackedDate(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
+            } else {
+                PackedDate.Invalid
+            }
+        }
+        return EpisodeInfo(
+            episodeId = episodeId,
+            type = null,
+            name = "Ep$episodeId",
+            nameCn = "第${episodeId}集",
+            airDate = packedDate,
+            desc = "",
+            sort = EpisodeSort(sort),
+            ep = null,
+        )
+    }
+
+    /**
+     * Converts a LocalDate (KotlinX datetime) into a string in ISO8601 with
+     * an arbitrary time (e.g. 09:00:00Z).
+     */
+    private fun localDateToInstantString(date: LocalDate, hour: Int = 9): String {
+        val dt = date.toLocalDateTime(hour = hour, minute = 0, second = 0)
+        val instant = dt.toInstant(TimeZone.UTC)
+        // Make sure we produce an ISO-8601 with UTC offset, e.g. "2025-01-14T09:00:00Z"
+        return instant.toString()
+    }
+
+    private fun convert(
+        subjects: List<SubjectCollectionInfo>,
+        airInfos: List<OnAirAnimeInfo>,
+        targetDate: LocalDate,
+        localTimeZone: TimeZone = TimeZone.UTC,
+    ): List<EpisodeWithAiringTime> = AnimeScheduleHelper.buildAiringScheduleForDate(
+        subjects,
+        airInfos,
+        targetDate,
+        localTimeZone,
+    )
+
+    // --------------
+    // Actual Tests
+    // --------------
+
+    @Test
+    fun `subject without OnAirAnimeInfo is skipped`() {
+        // We'll create a single subject but with no matching OnAirAnimeInfo in the list
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 123,
+                episodes = listOf(createEpisodeInfo(1, "2025-01-14")),
+            ),
+        )
+        val airInfos = listOf<OnAirAnimeInfo>() // empty
+
+        val result = convert(subjects, airInfos, LocalDate(2025, 1, 14))
+        assertTrue(result.isEmpty(), "No schedule items should be returned if OnAirAnimeInfo is missing.")
+    }
+
+    @Test
+    fun `subject with null begin or null recurrence is skipped`() {
+        // Create one subject with OnAirAnimeInfo, but missing essential fields
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 101,
+                episodes = listOf(createEpisodeInfo(1, "2025-01-14")),
+            ),
+        )
+        // begin = null => can't compute
+        val airInfos = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 101,
+                begin = null,
+                intervalDays = 7,
+            ),
+        )
+
+        val targetDate = LocalDate(2025, 1, 14)
+        val result = convert(subjects, airInfos, targetDate)
+        assertTrue(result.isEmpty(), "No match since begin is null => skip")
+
+        // likewise, if begin != null but intervalDays = null => skip
+        val airInfos2 = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 101,
+                begin = localDateToInstantString(LocalDate(2025, 1, 1)),
+                intervalDays = null,
+            ),
+        )
+        val result2 = convert(subjects, airInfos2, targetDate)
+        assertTrue(result2.isEmpty(), "No match since recurrence is null => skip")
+    }
+
+    @Test
+    fun `when episode airDate is valid and matches target date - it is returned`() {
+        // Suppose we have 2 episodes, ep1 = 2025-01-14, ep2 = 2025-01-21
+        val ep1 = createEpisodeInfo(1, "2025-01-14")
+        val ep2 = createEpisodeInfo(2, "2025-01-21")
+
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 201,
+                episodes = listOf(ep1, ep2),
+            ),
+        )
+        val airInfos = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 201,
+                begin = localDateToInstantString(LocalDate(2025, 1, 7)), // or any valid begin
+                intervalDays = 7,
+            ),
+        )
+        val targetDate = LocalDate(2025, 1, 14)
+
+        val result = convert(subjects, airInfos, targetDate)
+        assertEquals(1, result.size, "Expected exactly one matching episode")
+
+        val scheduleItem = result.first()
+        assertEquals(201, scheduleItem.subject.subjectId)
+        assertEquals(1f, scheduleItem.episode.sort.number)
+        // And so forth ...
+    }
+
+    @Test
+    fun `when episode airDate is invalid - guess it by recurrence from previous valid episode`() {
+        // ep1 is valid => 2025-02-01
+        // ep2 is invalid => we guess ep2 = ep1 + 7 days => 2025-02-08
+        val ep1 = createEpisodeInfo(1, "2025-02-01")
+        val ep2 = createEpisodeInfo(2, "Invalid")
+
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 202,
+                episodes = listOf(ep1, ep2),
+            ),
+        )
+        // Start at 2025-02-01T09:00:00Z. Weekly recurrence of 7 days
+        val airInfos = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 202,
+                begin = "2025-02-01T09:00:00Z",
+                intervalDays = 7,
+            ),
+        )
+        // Our target date is 2025-02-08 => that means ep2
+        val targetDate = LocalDate(2025, 2, 8)
+
+        val result = convert(subjects, airInfos, targetDate)
+        assertEquals(1, result.size)
+        val scheduleItem = result.first()
+        assertEquals(202, scheduleItem.subject.subjectId)
+        assertEquals(2f, scheduleItem.episode.sort.number, "We matched episode 2 by guess")
+    }
+
+    @Test
+    fun `when first episode is invalid - guess from subjectBegin`() {
+        // ep1 is invalid => guess from subjectBegin => 2025-03-01
+        // ep2 is invalid => guess from ep1 + 7 => 2025-03-08
+        // We'll target 2025-03-01 to see if ep1 matches
+        val ep1 = createEpisodeInfo(1, "Invalid")
+        val ep2 = createEpisodeInfo(2, "Invalid")
+
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 303,
+                episodes = listOf(ep1, ep2),
+            ),
+        )
+        val airInfos = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 303,
+                begin = "2025-03-01T13:00:00Z", // This is the time we anchor ep1 to
+                intervalDays = 7,
+            ),
+        )
+        val targetDate = LocalDate(2025, 3, 1)
+
+        val result = convert(subjects, airInfos, targetDate)
+        assertEquals(1, result.size)
+        val scheduleItem = result.first()
+        assertEquals(303, scheduleItem.subject.subjectId)
+        assertEquals(1f, scheduleItem.episode.sort.number)
+    }
+
+    @Test
+    fun `if no episodes match target date - skip`() {
+        // ep1 => 2025-04-01, ep2 => 2025-04-08 => no one matches 2025-04-14
+        val ep1 = createEpisodeInfo(1, "2025-04-01")
+        val ep2 = createEpisodeInfo(2, "2025-04-08")
+        val subjects = listOf(
+            createSubjectCollectionInfo(
+                subjectId = 404,
+                episodes = listOf(ep1, ep2),
+            ),
+        )
+        val airInfos = listOf(
+            createOnAirAnimeInfo(
+                bangumiId = 404,
+                begin = "2025-04-01T00:00:00Z",
+                intervalDays = 7,
+            ),
+        )
+        val targetDate = LocalDate(2025, 4, 14)
+
+        val result = convert(subjects, airInfos, targetDate)
+        assertTrue(result.isEmpty(), "No episodes match => skip")
+    }
+
+    // ------------------------------------
+    // You can add more edge-case tests here
+    // ------------------------------------
+}
+
+private fun LocalDate.toLocalDateTime(hour: Int, minute: Int, second: Int): LocalDateTime {
+    return LocalDateTime(this, LocalTime(hour, minute, second))
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/AnimeScheduleHelperTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/AnimeScheduleHelperTest.kt
@@ -24,6 +24,7 @@ import me.him188.ani.app.data.models.subject.LightSubjectInfo
 import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.datasources.api.UTC9
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -134,6 +135,7 @@ class AnimeScheduleHelperTest {
             name = "Ep$episodeId",
             nameCn = "第${episodeId}集",
             airDate = packedDate,
+            timezone = UTC9,
             sort = EpisodeSort(sort),
             ep = null,
         )
@@ -145,7 +147,7 @@ class AnimeScheduleHelperTest {
      */
     private fun localDateToInstantString(date: LocalDate, hour: Int = 9): String {
         val dt = date.toLocalDateTime(hour = hour, minute = 0, second = 0)
-        val instant = dt.toInstant(TimeZone.UTC)
+        val instant = dt.toInstant(UTC9)
         // Make sure we produce an ISO-8601 with UTC offset, e.g. "2025-01-14T09:00:00Z"
         return instant.toString()
     }

--- a/app/shared/app-platform/src/commonMain/kotlin/navigation/AniNavigator.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/navigation/AniNavigator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -137,6 +137,10 @@ interface AniNavigator {
 
     fun navigateCacheDetails(cacheId: String) {
         navigator.navigate(NavRoutes.CacheDetail(cacheId))
+    }
+
+    fun navigateSchedule() {
+        navigator.navigate(NavRoutes.Schedule)
     }
 }
 

--- a/app/shared/app-platform/src/commonMain/kotlin/navigation/NavRoutes.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/navigation/NavRoutes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.rounded.TravelExplore
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import kotlinx.serialization.Serializable
-import me.him188.ani.app.navigation.MainScenePage.entries
 
 @Serializable
 sealed class NavRoutes {
@@ -80,6 +79,8 @@ sealed class NavRoutes {
         val cacheId: String,
     ) : NavRoutes()
 
+    @Serializable
+    data object Schedule : NavRoutes()
 }
 
 @Serializable

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -425,6 +425,14 @@ private fun AniAppContentImpl(
                         )
                     },
                 )
+            }
+            composable<NavRoutes.Schedule>(
+                enterTransition = enterTransition,
+                exitTransition = exitTransition,
+                popEnterTransition = popEnterTransition,
+                popExitTransition = popExitTransition,
+            ) { backStackEntry ->
+
             }
         }
 

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -440,8 +440,7 @@ private fun AniAppContentImpl(
                 val vm = viewModel { SchedulePageViewModel() }
                 val presentation by vm.presentationFlow.collectAsStateWithLifecycle()
                 SchedulePage(
-                    data = presentation.airingSchedules,
-                    loadError = presentation.error,
+                    presentation,
                     onRetry = { vm.refresh() },
                     onClickItem = {
                         aniNavigator.navigateSubjectDetails(it.subjectId)

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -441,6 +441,8 @@ private fun AniAppContentImpl(
                 val presentation by vm.presentationFlow.collectAsStateWithLifecycle()
                 SchedulePage(
                     data = presentation.airingSchedules,
+                    loadError = presentation.error,
+                    onRetry = { vm.refresh() },
                     onClickItem = {
                         aniNavigator.navigateSubjectDetails(it.subjectId)
                     },

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.compose.NavHost
@@ -53,6 +54,8 @@ import me.him188.ani.app.ui.cache.CacheManagementViewModel
 import me.him188.ani.app.ui.cache.details.MediaCacheDetailsPage
 import me.him188.ani.app.ui.cache.details.MediaCacheDetailsPageViewModel
 import me.him188.ani.app.ui.cache.details.MediaDetailsLazyGrid
+import me.him188.ani.app.ui.exploration.schedule.SchedulePage
+import me.him188.ani.app.ui.exploration.schedule.SchedulePageViewModel
 import me.him188.ani.app.ui.foundation.layout.LocalSharedTransitionScopeProvider
 import me.him188.ani.app.ui.foundation.layout.SharedTransitionScopeProvider
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
@@ -432,7 +435,22 @@ private fun AniAppContentImpl(
                 popEnterTransition = popEnterTransition,
                 popExitTransition = popExitTransition,
             ) { backStackEntry ->
+                val route = backStackEntry.toRoute<NavRoutes.Schedule>()
 
+                val vm = viewModel { SchedulePageViewModel() }
+                val presentation by vm.presentationFlow.collectAsStateWithLifecycle()
+                SchedulePage(
+                    data = presentation.airingSchedules,
+                    Modifier.fillMaxSize(),
+                    windowInsets = windowInsets,
+                    navigationIcon = {
+                        BackNavigationIconButton(
+                            {
+                                aniNavigator.popBackStack(route, inclusive = true)
+                            },
+                        )
+                    },
+                )
             }
         }
 

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -450,6 +450,7 @@ private fun AniAppContentImpl(
                             },
                         )
                     },
+                    state = vm.pageState,
                 )
             }
         }

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -441,6 +441,9 @@ private fun AniAppContentImpl(
                 val presentation by vm.presentationFlow.collectAsStateWithLifecycle()
                 SchedulePage(
                     data = presentation.airingSchedules,
+                    onClickItem = {
+                        aniNavigator.navigateSubjectDetails(it.subjectId)
+                    },
                     Modifier.fillMaxSize(),
                     windowInsets = windowInsets,
                     navigationIcon = {

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/NavTitleHeader.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/NavTitleHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,8 +9,10 @@
 
 package me.him188.ani.app.ui.adaptive
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -30,9 +32,10 @@ fun NavTitleHeader(
     title: @Composable () -> Unit,
     navigationIcon: @Composable () -> Unit = {},
     modifier: Modifier = Modifier,
+    trailingActions: @Composable () -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(),
 ) {
-    Row(modifier.padding(contentPadding)) {
+    Row(modifier.fillMaxWidth().padding(contentPadding)) {
         Row(Modifier.heightIn(min = 48.dp).weight(1f, fill = false), verticalAlignment = Alignment.CenterVertically) {
             ProvideTextStyleContentColor(
                 MaterialTheme.typography.headlineSmall,
@@ -45,6 +48,12 @@ fun NavTitleHeader(
         Row {
             ProvideContentColor(MaterialTheme.colorScheme.onSurface) {
                 navigationIcon()
+            }
+        }
+
+        Row(Modifier.weight(1f), horizontalArrangement = Arrangement.End) {
+            ProvideContentColor(MaterialTheme.colorScheme.onSurface) {
+                trailingActions()
             }
         }
     }

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/NavTitleHeader.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/NavTitleHeader.kt
@@ -9,9 +9,9 @@
 
 package me.him188.ani.app.ui.adaptive
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -36,7 +36,7 @@ fun NavTitleHeader(
     contentPadding: PaddingValues = PaddingValues(),
 ) {
     Row(modifier.fillMaxWidth().padding(contentPadding)) {
-        Row(Modifier.heightIn(min = 48.dp).weight(1f, fill = false), verticalAlignment = Alignment.CenterVertically) {
+        Row(Modifier.heightIn(min = 48.dp), verticalAlignment = Alignment.CenterVertically) {
             ProvideTextStyleContentColor(
                 MaterialTheme.typography.headlineSmall,
                 MaterialTheme.colorScheme.onSurface,
@@ -51,7 +51,9 @@ fun NavTitleHeader(
             }
         }
 
-        Row(Modifier.weight(1f), horizontalArrangement = Arrangement.End) {
+        Spacer(Modifier.weight(1f))
+
+        Row {
             ProvideContentColor(MaterialTheme.colorScheme.onSurface) {
                 trailingActions()
             }

--- a/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
+++ b/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
@@ -28,6 +28,7 @@ fun PreviewSchedulePage() {
         Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
             SchedulePage(
                 TestSchedulePageData,
+                onClickItem = {},
                 navigationIcon = {
                     BackNavigationIconButton({})
                 },

--- a/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
+++ b/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
@@ -27,8 +27,10 @@ fun PreviewSchedulePage() {
     ProvideFoundationCompositionLocalsForPreview {
         Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
             SchedulePage(
-                TestSchedulePageData,
-                null,
+                presentation = SchedulePagePresentation(
+                    airingSchedules = TestSchedulePageData,
+                    null,
+                ),
                 onRetry = {},
                 onClickItem = {},
                 navigationIcon = {

--- a/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
+++ b/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
@@ -27,7 +27,7 @@ fun PreviewSchedulePage() {
     ProvideFoundationCompositionLocalsForPreview {
         Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
             SchedulePage(
-                TestSchedulePageData::get,
+                TestSchedulePageData,
                 navigationIcon = {
                     BackNavigationIconButton({})
                 },

--- a/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
+++ b/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
@@ -28,6 +28,8 @@ fun PreviewSchedulePage() {
         Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
             SchedulePage(
                 TestSchedulePageData,
+                null,
+                onRetry = {},
                 onClickItem = {},
                 navigationIcon = {
                     BackNavigationIconButton({})

--- a/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
+++ b/app/shared/ui-exploration/src/androidMain/kotlin/ui/exploration/schedule/SchedulePage.android.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+@file:OptIn(TestOnly::class)
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import me.him188.ani.app.ui.foundation.ProvideFoundationCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.preview.PreviewTabletLightDark
+import me.him188.ani.app.ui.foundation.widgets.BackNavigationIconButton
+import me.him188.ani.utils.platform.annotations.TestOnly
+
+@Composable
+@Preview
+@PreviewTabletLightDark
+fun PreviewSchedulePage() {
+    ProvideFoundationCompositionLocalsForPreview {
+        Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+            SchedulePage(
+                TestSchedulePageData::get,
+                navigationIcon = {
+                    BackNavigationIconButton({})
+                },
+            )
+        }
+    }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
@@ -24,7 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.ButtonDefaults
@@ -165,7 +165,7 @@ fun ExplorationPage(
 
         Column(Modifier.padding(topBarPadding).verticalScroll(state.pageScrollState)) {
             NavTitleHeader(
-                title = { Text("最高热度") },
+                title = { Text("最高热度", softWrap = false) },
                 contentPadding = horizontalContentPadding,
                 trailingActions = {
                     TextButton(
@@ -173,9 +173,9 @@ fun ExplorationPage(
                         Modifier,
                         contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
                     ) {
-                        Icon(Icons.Rounded.Schedule, null, Modifier.size(ButtonDefaults.IconSize))
+                        Icon(Icons.Rounded.CalendarMonth, null, Modifier.size(ButtonDefaults.IconSize))
                         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                        Text("新番时间表")
+                        Text("新番时间表", softWrap = false)
                     }
                 },
             )
@@ -216,7 +216,7 @@ fun ExplorationPage(
             }
 
             NavTitleHeader(
-                title = { Text("继续观看") },
+                title = { Text("继续观看", softWrap = false) },
                 contentPadding = horizontalContentPadding,
             )
 

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -13,21 +13,26 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.carousel.CarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -157,11 +162,22 @@ fun ExplorationPage(
         val showHorizontalNavigateTip by state.horizontalScrollTipFlow.collectAsState(false)
         val toaster = LocalToaster.current
         val scope = rememberCoroutineScope()
-        
+
         Column(Modifier.padding(topBarPadding).verticalScroll(state.pageScrollState)) {
             NavTitleHeader(
                 title = { Text("最高热度") },
                 contentPadding = horizontalContentPadding,
+                trailingActions = {
+                    TextButton(
+                        { navigator.navigateSchedule() },
+                        Modifier,
+                        contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
+                    ) {
+                        Icon(Icons.Rounded.Schedule, null, Modifier.size(ButtonDefaults.IconSize))
+                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                        Text("新番时间表")
+                    }
+                },
             )
 
             val carouselItemSize = CarouselItemDefaults.itemSize()

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
@@ -83,16 +83,22 @@ val TestAiringScheduleItemPresentationData: ImmutableEnumMap<DayOfWeek, List<Air
 
 
 @TestOnly
-val TestSchedulePageData: ImmutableEnumMap<DayOfWeek, List<AiringScheduleColumnItem>>
-    get() = ImmutableEnumMap<DayOfWeek, _> { day ->
+val TestSchedulePageData: List<AiringSchedule>
+    get() {
         val currentTime = LocalTime(12, 0)
-        val list = TestAiringScheduleItemPresentations.filter { it.dayOfWeek == day }
+        val list = TestAiringScheduleItemPresentations.filter { it.dayOfWeek == DayOfWeek.MONDAY }
             .sortedWith(
                 compareBy<AiringScheduleItemPresentation> { it.time }
                     .thenBy { it.subjectTitle },
             )
 
-        SchedulePageDataHelper.toColumnItems(list, addIndicator = true, currentTime)
+
+        return listOf(
+            AiringSchedule(
+                date = LocalDate(2024, 1, 1),
+                SchedulePageDataHelper.toColumnItems(list, addIndicator = true, currentTime),
+            ),
+        )
     }
 
 fun EpisodeWithAiringTime.toPresentation(timeZone: TimeZone): AiringScheduleItemPresentation {
@@ -118,6 +124,8 @@ object SchedulePageDataHelper {
         addIndicator: Boolean,
         currentTime: LocalTime,
     ): List<AiringScheduleColumnItem> {
+        @Suppress("NAME_SHADOWING")
+        val list = list.sortedBy { it.time }
         val insertionIndex = list.indexOfLast { it.time <= currentTime }
         return buildList(capacity = list.size + 1) {
             var previousTime: LocalTime? = null

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
@@ -147,6 +147,7 @@ object SchedulePageDataHelper {
                 add(
                     AiringScheduleColumnItem.CurrentTimeIndicator(
                         currentTime = currentTime,
+                        isPlaceholder = false,
                     ),
                 )
             }

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
@@ -27,6 +27,7 @@ data class AiringScheduleItemPresentation(
     val subjectId: Int,
     val subjectTitle: String,
     val imageUrl: String,
+    val episodeId: Int,
     val episodeSort: EpisodeSort,
     val episodeEp: EpisodeSort?,
     val episodeName: String?,
@@ -53,6 +54,7 @@ val TestAiringScheduleItemPresentations
                         subjectId = ++id,
                         subjectTitle = "Subject $id",
                         imageUrl = "https://example.com/image.jpg",
+                        episodeId = id,
                         episodeSort = EpisodeSort(if (i % 3 == 0) 13 else 1),
                         episodeEp = EpisodeSort(1),
                         episodeName = "Episode 1",
@@ -90,7 +92,7 @@ val TestSchedulePageData: ImmutableEnumMap<DayOfWeek, List<AiringScheduleColumnI
                     .thenBy { it.subjectTitle },
             )
 
-        SchedulePageDataHelper.withCurrentTimeIndicator(list, currentTime)
+        SchedulePageDataHelper.toColumnItems(list, addIndicator = true, currentTime)
     }
 
 fun EpisodeWithAiringTime.toPresentation(timeZone: TimeZone): AiringScheduleItemPresentation {
@@ -100,6 +102,7 @@ fun EpisodeWithAiringTime.toPresentation(timeZone: TimeZone): AiringScheduleItem
         subjectId = subject.subjectId,
         subjectTitle = subject.displayName,
         imageUrl = subject.imageLarge,
+        episodeId = episode.episodeId,
         episodeSort = episode.sort,
         episodeEp = episode.ep,
         episodeName = episode.displayName,
@@ -110,8 +113,9 @@ fun EpisodeWithAiringTime.toPresentation(timeZone: TimeZone): AiringScheduleItem
 }
 
 object SchedulePageDataHelper {
-    fun withCurrentTimeIndicator(
+    fun toColumnItems(
         list: List<AiringScheduleItemPresentation>,
+        addIndicator: Boolean,
         currentTime: LocalTime,
     ): List<AiringScheduleColumnItem> {
         val insertionIndex = list.indexOfLast { it.time <= currentTime }
@@ -131,11 +135,13 @@ object SchedulePageDataHelper {
             for (itemPresentation in list.subList(0, insertionIndex + 1)) {
                 handleItem(itemPresentation)
             }
-            add(
-                AiringScheduleColumnItem.CurrentTimeIndicator(
-                    currentTime = currentTime,
-                ),
-            )
+            if (addIndicator) {
+                add(
+                    AiringScheduleColumnItem.CurrentTimeIndicator(
+                        currentTime = currentTime,
+                    ),
+                )
+            }
             for (itemPresentation in list.subList(insertionIndex + 1, list.size)) {
                 handleItem(itemPresentation)
             }

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/AiringScheduleItemPresentation.kt
@@ -15,7 +15,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import me.him188.ani.app.data.models.episode.displayName
+import me.him188.ani.app.data.models.subject.displayName
 import me.him188.ani.app.domain.episode.EpisodeWithAiringTime
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
@@ -98,12 +98,12 @@ fun EpisodeWithAiringTime.toPresentation(timeZone: TimeZone): AiringScheduleItem
     // Return the item
     return AiringScheduleItemPresentation(
         subjectId = subject.subjectId,
-        subjectTitle = subject.subjectInfo.name,
-        imageUrl = subject.subjectInfo.imageLarge,
+        subjectTitle = subject.displayName,
+        imageUrl = subject.imageLarge,
         episodeSort = episode.sort,
         episodeEp = episode.ep,
         episodeName = episode.displayName,
-        subjectCollectionType = subject.collectionType,
+        subjectCollectionType = UnifiedCollectionType.NOT_COLLECTED,
         dayOfWeek = dateTime.dayOfWeek,
         time = dateTime.time,
     )

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -97,7 +98,7 @@ fun ScheduleDayColumn(
                         ScheduleCurrentTimeIndicator(
                             columnItem,
                             Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                                .placeholder(columnItem.isPlaceholder),
+                                .placeholder(columnItem.isPlaceholder, shape = RectangleShape),
                         )
                     }
 
@@ -141,22 +142,28 @@ fun ScheduleDayColumn(
                         ScheduleItem(
                             onClick = {},
                             subjectTitle = {
-                                ScheduleItemDefaults.SubjectTitle("Placeholder", Modifier.placeholder(true))
+                                ScheduleItemDefaults.SubjectTitle(
+                                    "Placeholder",
+                                    Modifier.placeholder(true, shape = RectangleShape),
+                                )
                             },
                             episode = {
                                 ScheduleItemDefaults.Episode(
                                     EpisodeSort(1),
                                     null,
                                     "Placeholder",
-                                    Modifier.placeholder(true),
+                                    Modifier.placeholder(true, shape = RectangleShape),
                                 )
                             },
                             leadingImage = {
-                                Box(Modifier.fillMaxSize().placeholder(true))
+                                Box(Modifier.fillMaxSize().placeholder(true, shape = RectangleShape))
                             },
                             time = {
                                 if (columnItem.showTime) {
-                                    ScheduleItemDefaults.Time(dummyLocalTime, Modifier.placeholder(true))
+                                    ScheduleItemDefaults.Time(
+                                        dummyLocalTime,
+                                        Modifier.placeholder(true, shape = RectangleShape),
+                                    )
                                 }
                             },
                         )

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -55,6 +55,7 @@ import me.him188.ani.datasources.api.EpisodeSort
 @Composable
 fun ScheduleDayColumn(
     items: List<AiringScheduleColumnItem>,
+    onClickItem: (item: AiringScheduleItemPresentation) -> Unit,
     dayOfWeek: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     layoutParams: ScheduleDayColumnLayoutParams = ScheduleDayColumnLayoutParams.Default,
@@ -103,6 +104,7 @@ fun ScheduleDayColumn(
                     is AiringScheduleColumnItem.Data -> {
                         val item = columnItem.item
                         ScheduleItem(
+                            onClick = { onClickItem(item) },
                             subjectTitle = {
                                 ScheduleItemDefaults.SubjectTitle(
                                     item.subjectTitle,
@@ -137,6 +139,7 @@ fun ScheduleDayColumn(
 
                     is AiringScheduleColumnItem.PlaceholderData -> {
                         ScheduleItem(
+                            onClick = {},
                             subjectTitle = {
                                 ScheduleItemDefaults.SubjectTitle("Placeholder", Modifier.placeholder(true))
                             },

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -48,7 +48,7 @@ import me.him188.ani.app.ui.foundation.text.ProvideContentColor
  */
 @Composable
 fun ScheduleDayColumn(
-    items: List<ScheduleDayColumnItem>,
+    items: List<AiringScheduleColumnItem>,
     dayOfWeek: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     layoutParams: ScheduleDayColumnLayoutParams = ScheduleDayColumnLayoutParams.Default,
@@ -72,23 +72,23 @@ fun ScheduleDayColumn(
                 items,
                 key = { item ->
                     when (item) {
-                        is ScheduleDayColumnItem.Item -> item.item.subjectId
-                        is ScheduleDayColumnItem.CurrentTimeIndicator -> item.hashCode()
+                        is AiringScheduleColumnItem.Data -> item.item.subjectId
+                        is AiringScheduleColumnItem.CurrentTimeIndicator -> item.hashCode()
                     }
                 },
                 contentType = { item ->
                     when (item) {
-                        is ScheduleDayColumnItem.Item -> true
-                        is ScheduleDayColumnItem.CurrentTimeIndicator -> false
+                        is AiringScheduleColumnItem.Data -> true
+                        is AiringScheduleColumnItem.CurrentTimeIndicator -> false
                     }
                 },
             ) { columnItem ->
                 when (columnItem) {
-                    is ScheduleDayColumnItem.CurrentTimeIndicator -> {
+                    is AiringScheduleColumnItem.CurrentTimeIndicator -> {
                         ScheduleCurrentTimeIndicator(columnItem, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
                     }
 
-                    is ScheduleDayColumnItem.Item -> {
+                    is AiringScheduleColumnItem.Data -> {
                         val item = columnItem.item
                         ScheduleItem(
                             subjectTitle = { ScheduleItemDefaults.SubjectTitle(item.subjectTitle) },
@@ -102,7 +102,7 @@ fun ScheduleDayColumn(
                             leadingImage = { AsyncImage(item.imageUrl, "${item.subjectTitle} 封面") },
                             time = {
                                 if (columnItem.showTime) {
-                                    ScheduleItemDefaults.Time(item.futureStartDate, item.time)
+                                    ScheduleItemDefaults.Time(item.time)
                                 }
                             },
                             action = {
@@ -120,7 +120,7 @@ fun ScheduleDayColumn(
 
 @Composable
 private fun ScheduleCurrentTimeIndicator(
-    columnItem: ScheduleDayColumnItem.CurrentTimeIndicator,
+    columnItem: AiringScheduleColumnItem.CurrentTimeIndicator,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -146,17 +146,17 @@ private fun ScheduleCurrentTimeIndicator(
 }
 
 @Immutable
-sealed class ScheduleDayColumnItem {
+sealed class AiringScheduleColumnItem {
     @Immutable
-    data class Item(
-        val item: ScheduleItemPresentation,
+    data class Data(
+        val item: AiringScheduleItemPresentation,
         val showTime: Boolean,
-    ) : ScheduleDayColumnItem()
+    ) : AiringScheduleColumnItem()
 
     @Immutable
     data class CurrentTimeIndicator(
         val currentTime: LocalTime,
-    ) : ScheduleDayColumnItem()
+    ) : AiringScheduleColumnItem()
 }
 
 @Immutable

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Alarm
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalTime
+import me.him188.ani.app.ui.foundation.AsyncImage
+import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
+import me.him188.ani.app.ui.foundation.text.ProvideContentColor
+
+
+/**
+ * 新番时间表的单日视图, 例如周一.
+ *
+ * [Design](https://www.figma.com/design/LET1n9mmDa6npDTIlUuJjU/Animeko?node-id=349-9250&t=hBPSAEVlsmuEWPJt-0)
+ */
+@Composable
+fun ScheduleDayColumn(
+    items: List<ScheduleDayColumnItem>,
+    dayOfWeek: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    layoutParams: ScheduleDayColumnLayoutParams = ScheduleDayColumnLayoutParams.Default,
+    state: LazyListState = rememberLazyListState(),
+    itemColors: ListItemColors = ListItemDefaults.colors(),
+) {
+    Column(modifier) {
+        Row(Modifier.paddingIfNotEmpty(layoutParams.dayOfWeekPaddings)) {
+            ProvideTextStyle(MaterialTheme.typography.headlineSmall) {
+                dayOfWeek()
+            }
+        }
+
+        LazyColumn(
+            Modifier.padding(layoutParams.listPadding),
+            state = state,
+            contentPadding = PaddingValues(vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(layoutParams.listVerticalSpacing),
+        ) {
+            items(
+                items,
+                key = { item ->
+                    when (item) {
+                        is ScheduleDayColumnItem.Item -> item.item.subjectId
+                        is ScheduleDayColumnItem.CurrentTimeIndicator -> item.hashCode()
+                    }
+                },
+                contentType = { item ->
+                    when (item) {
+                        is ScheduleDayColumnItem.Item -> true
+                        is ScheduleDayColumnItem.CurrentTimeIndicator -> false
+                    }
+                },
+            ) { columnItem ->
+                when (columnItem) {
+                    is ScheduleDayColumnItem.CurrentTimeIndicator -> {
+                        ScheduleCurrentTimeIndicator(columnItem, Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                    }
+
+                    is ScheduleDayColumnItem.Item -> {
+                        val item = columnItem.item
+                        ScheduleItem(
+                            subjectTitle = { ScheduleItemDefaults.SubjectTitle(item.subjectTitle) },
+                            episode = {
+                                ScheduleItemDefaults.Episode(
+                                    item.episodeSort,
+                                    item.episodeEp,
+                                    item.episodeName,
+                                )
+                            },
+                            leadingImage = { AsyncImage(item.imageUrl, "${item.subjectTitle} 封面") },
+                            time = {
+                                if (columnItem.showTime) {
+                                    ScheduleItemDefaults.Time(item.futureStartDate, item.time)
+                                }
+                            },
+                            action = {
+                                // TODO: 2025/1/14 新番时间表追番动作
+                            },
+                            colors = itemColors,
+                        )
+                    }
+                }
+            }
+        }
+
+    }
+}
+
+@Composable
+private fun ScheduleCurrentTimeIndicator(
+    columnItem: ScheduleDayColumnItem.CurrentTimeIndicator,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ProvideContentColor(MaterialTheme.colorScheme.primary) {
+            Row(
+                Modifier.padding(end = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.Outlined.Alarm, null)
+                Text(
+                    ScheduleItemDefaults.renderTime(null, columnItem.currentTime),
+                    softWrap = false,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+@Immutable
+sealed class ScheduleDayColumnItem {
+    @Immutable
+    data class Item(
+        val item: ScheduleItemPresentation,
+        val showTime: Boolean,
+    ) : ScheduleDayColumnItem()
+
+    @Immutable
+    data class CurrentTimeIndicator(
+        val currentTime: LocalTime,
+    ) : ScheduleDayColumnItem()
+}
+
+@Immutable
+data class ScheduleDayColumnLayoutParams(
+    val dayOfWeekPaddings: PaddingValues,
+    val listVerticalSpacing: Dp,
+    val listPadding: PaddingValues,
+) {
+    @Stable
+    companion object {
+
+        @Stable // Adaptive layout not needed by design.
+        val Default = ScheduleDayColumnLayoutParams(
+            dayOfWeekPaddings = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            listVerticalSpacing = 0.dp,
+            listPadding = PaddingValues(0.dp),
+        )
+    }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.packInts
 import kotlinx.datetime.LocalTime
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
@@ -72,7 +73,7 @@ fun ScheduleDayColumn(
                 items,
                 key = { item ->
                     when (item) {
-                        is AiringScheduleColumnItem.Data -> item.item.subjectId
+                        is AiringScheduleColumnItem.Data -> packInts(item.item.subjectId, item.item.episodeId)
                         is AiringScheduleColumnItem.CurrentTimeIndicator -> item.hashCode()
                     }
                 },

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleDayColumn.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -32,6 +33,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -100,7 +102,14 @@ fun ScheduleDayColumn(
                                     item.episodeName,
                                 )
                             },
-                            leadingImage = { AsyncImage(item.imageUrl, "${item.subjectTitle} 封面") },
+                            leadingImage = {
+                                AsyncImage(
+                                    item.imageUrl,
+                                    "${item.subjectTitle} 封面",
+                                    Modifier.fillMaxSize(),
+                                    contentScale = ContentScale.Crop,
+                                )
+                            },
                             time = {
                                 if (columnItem.showTime) {
                                     ScheduleItemDefaults.Time(item.time)

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.ui.exploration.schedule
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -55,6 +57,7 @@ import me.him188.ani.datasources.api.EpisodeSort
  */
 @Composable
 fun ScheduleItem(
+    onClick: () -> Unit,
     subjectTitle: @Composable () -> Unit,
     episode: @Composable () -> Unit,
     leadingImage: @Composable () -> Unit,
@@ -96,7 +99,7 @@ fun ScheduleItem(
             },
             trailingContent = action,
             colors = colors,
-            modifier = modifier,
+            modifier = modifier.clickable(role = Role.Button, onClickLabel = "查看详情", onClick = onClick),
         )
     }
 

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -89,7 +90,7 @@ fun ScheduleItem(
             headlineContent = subjectTitle,
             supportingContent = episode,
             leadingContent = {
-                Box(Modifier.size(56.dp)) {
+                Box(Modifier.size(56.dp).clip(MaterialTheme.shapes.small)) {
                     leadingImage()
                 }
             },

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
@@ -154,7 +154,6 @@ object ScheduleItemDefaults {
 
     @Composable
     fun Time(
-        futureStartDate: LocalDate?,
         time: LocalTime,
         modifier: Modifier = Modifier
     ) {

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItem.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.format.char
+import me.him188.ani.app.ui.foundation.AsyncImage
+import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
+import me.him188.ani.datasources.api.EpisodeSort
+
+/**
+ * 新番时间表的一个项目.
+ *
+ * @param subjectTitle 条目的标题, [ScheduleItemDefaults.SubjectTitle]
+ * @param episode 剧集的序号以及名称, [ScheduleItemDefaults.Episode]
+ * @param leadingImage 条目的封面, [AsyncImage]
+ * @param time 时间, 例如 "12:00", [ScheduleItemDefaults.Time]
+ *
+ * @see ScheduleItemDefaults
+ *
+ * [Design](https://www.figma.com/design/LET1n9mmDa6npDTIlUuJjU/Animeko?node-id=349-10249&t=hBPSAEVlsmuEWPJt-0)
+ */
+@Composable
+fun ScheduleItem(
+    subjectTitle: @Composable () -> Unit,
+    episode: @Composable () -> Unit,
+    leadingImage: @Composable () -> Unit,
+    time: @Composable () -> Unit,
+    action: @Composable (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    colors: ListItemColors = ListItemDefaults.colors(),
+) {
+//    ListItem(
+//        headlineContent = subjectTitle,
+//        supportingContent = episode,
+//        leadingContent = {
+//            Box(Modifier.size(56.dp)) {
+//                leadingImage()
+//            }
+//        },
+//        trailingContent = {
+//            ProvideTextStyle(MaterialTheme.typography.labelMedium) {
+//                time()
+//            }
+//        },
+//        colors = colors,
+//        modifier = modifier,
+//    )
+
+    Column {
+        Row(Modifier.paddingIfNotEmpty(horizontal = 16.dp).paddingIfNotEmpty(top = 8.dp)) {
+            ProvideTextStyle(MaterialTheme.typography.bodyMedium) {
+                time()
+            }
+        }
+        ListItem(
+            headlineContent = subjectTitle,
+            supportingContent = episode,
+            leadingContent = {
+                Box(Modifier.size(56.dp)) {
+                    leadingImage()
+                }
+            },
+            trailingContent = action,
+            colors = colors,
+            modifier = modifier,
+        )
+    }
+
+}
+
+/**
+ * Material3 DividerWithSubhead.
+ */
+@Composable
+fun HorizontalDividerWithSubhead(
+    modifier: Modifier = Modifier,
+    thickness: Dp = DividerDefaults.Thickness,
+    dividerColor: Color = DividerDefaults.color,
+    subheadAlignment: Alignment.Horizontal = Alignment.Start,
+    textStyle: TextStyle = MaterialTheme.typography.labelLarge,
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
+    subhead: @Composable () -> Unit,
+) {
+    Column(modifier, verticalArrangement = verticalArrangement) {
+        HorizontalDivider(thickness = thickness, color = dividerColor)
+
+        ProvideTextStyle(textStyle) {
+            Box(Modifier.align(subheadAlignment)) {
+                subhead()
+            }
+        }
+    }
+}
+
+object ScheduleItemDefaults {
+    @Composable
+    fun SubjectTitle(
+        text: String,
+        modifier: Modifier = Modifier,
+    ) {
+        Text(text, overflow = TextOverflow.Ellipsis, maxLines = 1, modifier = modifier)
+    }
+
+    @Composable
+    fun Episode(
+        episodeSort: EpisodeSort,
+        episodeEp: EpisodeSort?,
+        episodeName: String?,
+        modifier: Modifier = Modifier,
+    ) {
+        val text = remember(episodeSort) {
+            renderEpisodeDisplay(episodeSort, episodeEp, episodeName)
+        }
+        Text(
+            text,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = modifier,
+        )
+    }
+
+    @Composable
+    fun Time(
+        futureStartDate: LocalDate?,
+        time: LocalTime,
+        modifier: Modifier = Modifier
+    ) {
+        val text = renderTime(null, time)
+        Text(
+            text,
+            modifier,
+            textAlign = TextAlign.End,
+            softWrap = false,
+            maxLines = 2,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+
+    private val timeFormatter = LocalTime.Format {
+        hour()
+        char(':')
+        minute()
+    }
+
+    fun renderTime(
+        futureStartDate: LocalDate?,
+        time: LocalTime,
+    ): String {
+        val timeString = timeFormatter.format(time)
+
+        return if (futureStartDate != null) {
+            "${futureStartDate.monthNumber}/${futureStartDate.dayOfMonth} 起\n${timeString}"
+        } else {
+            timeString
+        }
+    }
+
+    // internal for testing
+    internal fun renderEpisodeDisplay(
+        episodeSort: EpisodeSort,
+        episodeEp: EpisodeSort?,
+        episodeName: String?
+    ): String {
+        val epText = episodeEp?.toString()?.removePrefix("0")
+        val sortText = episodeSort.toString().removePrefix("0")
+
+        val sortDisplay = if (episodeEp == null || episodeEp == episodeSort) {
+            if (episodeSort is EpisodeSort.Normal) {
+                "第 $sortText 话"
+            } else {
+                sortText
+            }
+        } else {
+            check(epText != null)
+            // episodeEp != episodeSort
+            if (episodeSort is EpisodeSort.Normal && episodeEp is EpisodeSort.Normal) {
+                "第 $epText ($sortText) 话"
+            } else {
+                "$epText ($sortText)"
+            }
+        }
+
+        return if (episodeName == null) {
+            sortDisplay
+        } else {
+            "$sortDisplay  $episodeName"
+        }
+    }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItemPresentation.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/ScheduleItemPresentation.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import androidx.collection.MutableIntObjectMap
+import androidx.compose.runtime.Immutable
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.app.data.models.episode.displayName
+import me.him188.ani.app.data.models.schedule.OnAirAnimeInfo
+import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import me.him188.ani.utils.platform.annotations.TestOnly
+import me.him188.ani.utils.platform.collections.ImmutableEnumMap
+
+@Immutable
+data class ScheduleItemPresentation(
+    val subjectId: Int,
+    val subjectTitle: String,
+    val imageUrl: String,
+    val episodeSort: EpisodeSort,
+    val episodeEp: EpisodeSort?,
+    val episodeName: String?,
+
+    val subjectCollectionType: UnifiedCollectionType,
+
+    /**
+     * 未来的开始日期. 如果此条目已经开播了, 则为 `null`.
+     */
+    val futureStartDate: LocalDate?,
+    val dayOfWeek: DayOfWeek,
+    val time: LocalTime,
+)
+
+@TestOnly
+val TestScheduleItemPresentations
+    get() = buildList {
+        var id = 0
+        repeat(50) { i ->
+            repeat(if (i % 8 == 0) 2 else 1) {
+                add(
+                    ScheduleItemPresentation(
+                        subjectId = ++id,
+                        subjectTitle = "Subject $id",
+                        imageUrl = "https://example.com/image.jpg",
+                        episodeSort = EpisodeSort(if (i % 3 == 0) 13 else 1),
+                        episodeEp = EpisodeSort(1),
+                        episodeName = "Episode 1",
+                        subjectCollectionType = UnifiedCollectionType.entries[i % UnifiedCollectionType.entries.size],
+                        futureStartDate = if (i % 4 == 0) {
+                            LocalDate(2024, 5, 9)
+                        } else {
+                            null
+                        },
+                        dayOfWeek = DayOfWeek.entries[i % DayOfWeek.entries.size],
+                        time = LocalTime(i % 24, 0),
+                    ),
+                )
+
+            }
+        }
+    }
+
+/**
+ * @see TestSchedulePageData
+ */
+@TestOnly
+val TestScheduleItemPresentationData: ImmutableEnumMap<DayOfWeek, List<ScheduleItemPresentation>>
+    get() = ImmutableEnumMap<DayOfWeek, List<ScheduleItemPresentation>> { day ->
+        TestScheduleItemPresentations.filter { it.dayOfWeek == day }
+            .sortedWith(
+                compareBy<ScheduleItemPresentation> { it.time }
+                    .thenBy { it.subjectTitle },
+            )
+    }
+
+
+@TestOnly
+val TestSchedulePageData: ImmutableEnumMap<DayOfWeek, List<ScheduleDayColumnItem>>
+    get() = ImmutableEnumMap<DayOfWeek, _> { day ->
+        val currentTime = LocalTime(12, 0)
+        val list = TestScheduleItemPresentations.filter { it.dayOfWeek == day }
+            .sortedWith(
+                compareBy<ScheduleItemPresentation> { it.time }
+                    .thenBy { it.subjectTitle },
+            )
+
+        SchedulePageDataHelper.withCurrentTimeIndicator(list, currentTime)
+    }
+
+object SchedulePageDataHelper {
+
+    /**
+     * Returns the subjects which will have a new episode on air on [targetDate].
+     */
+    fun convert(
+        subjects: List<SubjectCollectionInfo>,
+        airInfos: List<OnAirAnimeInfo>,
+        targetDate: LocalDate,
+    ): List<ScheduleItemPresentation> {
+        val subjectIdToAirInfo = MutableIntObjectMap<OnAirAnimeInfo>(subjects.size).apply {
+            airInfos.forEach { put(it.bangumiId, it) }
+        }
+        return subjects.mapNotNull { info ->
+            val airInfo = subjectIdToAirInfo[info.subjectId] ?: return@mapNotNull null
+            val subjectBegin = airInfo.begin ?: return@mapNotNull null
+            val recurrence = airInfo.recurrence ?: return@mapNotNull null
+
+            val nextEpisode: EpisodeInfo = TODO()
+            val nextEpisodeTime: LocalTime = TODO()
+
+            ScheduleItemPresentation(
+                subjectId = info.subjectId,
+                subjectTitle = info.subjectInfo.name,
+                imageUrl = info.subjectInfo.imageLarge,
+                episodeSort = nextEpisode.sort,
+                episodeEp = nextEpisode.ep,
+                episodeName = nextEpisode.displayName,
+                subjectCollectionType = info.collectionType,
+                futureStartDate = null,
+                dayOfWeek = DayOfWeek.MONDAY,
+                time = nextEpisodeTime,
+            )
+        }
+    }
+
+    fun withCurrentTimeIndicator(
+        list: List<ScheduleItemPresentation>,
+        currentTime: LocalTime,
+    ): List<ScheduleDayColumnItem> {
+        val insertionIndex = list.indexOfLast { it.time <= currentTime }
+        return buildList(capacity = list.size + 1) {
+            var previousTime: LocalTime? = null
+            val handleItem = { itemPresentation: ScheduleItemPresentation ->
+                val showtime = previousTime != itemPresentation.time
+                previousTime = itemPresentation.time
+                add(
+                    ScheduleDayColumnItem.Item(
+                        item = itemPresentation,
+                        showtime,
+                    ),
+                )
+            }
+
+            for (itemPresentation in list.subList(0, insertionIndex + 1)) {
+                handleItem(itemPresentation)
+            }
+            add(
+                ScheduleDayColumnItem.CurrentTimeIndicator(
+                    currentTime = currentTime,
+                ),
+            )
+            for (itemPresentation in list.subList(insertionIndex + 1, list.size)) {
+                handleItem(itemPresentation)
+            }
+        }
+    }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -11,11 +11,13 @@ package me.him188.ani.app.ui.exploration.schedule
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
@@ -219,14 +221,17 @@ fun SchedulePageLayout(
             ) {
                 HorizontalPager(
                     state.pagerState,
+                    Modifier.fillMaxSize(),
                     pageSize = layoutParams.pageSize,
                     pageSpacing = layoutParams.pageSpacing,
+                    contentPadding = layoutParams.pageContentPadding,
                     verticalAlignment = Alignment.Top,
                     key = { it },
-                ) {
-                    pageContent(dayOfWeekEntries[it])
+                ) { index ->
+                    Box(Modifier.fillMaxSize()) { // ensure the page is scrollable
+                        pageContent(dayOfWeekEntries[index])
+                    }
                 }
-
             }
         }
     }

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DayOfWeek
+import me.him188.ani.app.ui.adaptive.AniTopAppBar
+import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
+import me.him188.ani.app.ui.foundation.layout.compareTo
+import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.pagerTabIndicatorOffset
+import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
+import me.him188.ani.utils.platform.collections.ImmutableEnumMap
+
+@Stable
+private val dayOfWeekEntries = DayOfWeek.entries
+
+@Stable
+class SchedulePageState(
+    initialSelectedDay: DayOfWeek = DayOfWeek.MONDAY,
+) {
+    internal val pagerState = PagerState(
+        currentPage = dayOfWeekEntries.indexOf(initialSelectedDay),
+    ) { dayOfWeekEntries.size }
+
+    val selectedDay: DayOfWeek by derivedStateOf {
+        dayOfWeekEntries[pagerState.currentPage]
+    }
+
+    val scheduleColumnStates = ImmutableEnumMap<DayOfWeek, LazyListState> {
+        LazyListState()
+    }
+
+    suspend fun scrollTo(day: DayOfWeek) {
+        pagerState.scrollToPage(dayOfWeekEntries.indexOf(day))
+    }
+
+    suspend fun animateScrollTo(day: DayOfWeek) {
+        pagerState.animateScrollToPage(dayOfWeekEntries.indexOf(day))
+    }
+}
+
+
+@Composable
+fun SchedulePage(
+    data: (DayOfWeek) -> List<ScheduleDayColumnItem>,
+    modifier: Modifier = Modifier,
+    layoutParams: SchedulePageLayoutParams = SchedulePageLayoutParams.calculate(),
+    colors: SchedulePageColors = SchedulePageDefaults.colors(),
+    navigationIcon: @Composable () -> Unit = {},
+    state: SchedulePageState = remember { SchedulePageState() },
+    windowInsets: WindowInsets = AniWindowInsets.forPageContent(),
+) {
+    SchedulePageLayout(
+        modifier = modifier,
+        layoutParams = layoutParams,
+        colors = colors,
+        navigationIcon = navigationIcon,
+        state = state,
+        windowInsets = windowInsets,
+    ) { day ->
+        ScheduleDayColumn(
+            dayOfWeek = {
+                if (layoutParams.showDayOfWeekHeadline) {
+                    DayOfWeekHeadline(day)
+                }
+            },
+            items = data(day),
+            layoutParams = layoutParams.columnLayoutParams,
+            state = state.scheduleColumnStates[day],
+            itemColors = colors.itemColors,
+        )
+    }
+}
+
+@Composable
+private fun DayOfWeekHeadline(
+    day: DayOfWeek,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier.width(IntrinsicSize.Min)) {
+        Text(renderDayOfWeek(day), Modifier.width(IntrinsicSize.Max), softWrap = false)
+
+        // Rounded horizontal divider
+        val thickness = 2.dp
+        val color = MaterialTheme.colorScheme.outlineVariant
+        Canvas(
+            Modifier.padding(top = 2.dp)
+                .fillMaxWidth()
+                .height(thickness),
+        ) {
+            drawLine(
+                color = color,
+                strokeWidth = thickness.toPx(),
+                start = Offset(0f, thickness.toPx() / 2),
+                end = Offset(size.width, thickness.toPx() / 2),
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}
+
+@Composable
+fun SchedulePageLayout(
+    modifier: Modifier = Modifier,
+    layoutParams: SchedulePageLayoutParams = SchedulePageLayoutParams.calculate(),
+    colors: SchedulePageColors = SchedulePageDefaults.colors(),
+    navigationIcon: @Composable () -> Unit = {},
+    state: SchedulePageState = remember { SchedulePageState() },
+    windowInsets: WindowInsets = AniWindowInsets.forPageContent(),
+    pageContent: @Composable (page: DayOfWeek) -> Unit,
+) {
+    Scaffold(
+        modifier,
+        topBar = {
+            AniTopAppBar(
+                title = { Text("新番时间表") },
+                Modifier.fillMaxWidth(),
+                navigationIcon = navigationIcon,
+                windowInsets = windowInsets.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+            )
+        },
+        containerColor = AniThemeDefaults.pageContentBackgroundColor,
+        contentWindowInsets = windowInsets.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+    ) { paddingValues ->
+        Column(Modifier.padding(paddingValues)) {
+            if (layoutParams.showTabRow) {
+                ScrollableTabRow(
+                    selectedTabIndex = state.pagerState.currentPage,
+                    containerColor = colors.tabRowContainerColor,
+                    indicator = { tabPositions ->
+                        TabRowDefaults.SecondaryIndicator(
+                            Modifier.pagerTabIndicatorOffset(state.pagerState, tabPositions),
+                        )
+                    },
+                ) {
+                    val uiScope = rememberCoroutineScope()
+                    dayOfWeekEntries.forEach { day ->
+                        Tab(
+                            selected = state.selectedDay == day,
+                            onClick = {
+                                uiScope.launch {
+                                    state.animateScrollTo(day)
+                                }
+                            },
+                            text = { Text(renderDayOfWeek(day), softWrap = false) },
+                            selectedContentColor = colors.tabSelectedContentColor,
+                            unselectedContentColor = colors.tabUnselectedContentColor,
+                        )
+                    }
+                }
+            }
+
+            HorizontalPager(
+                state.pagerState,
+                pageSize = layoutParams.pageSize,
+                pageSpacing = layoutParams.pageSpacing,
+                verticalAlignment = Alignment.Top,
+                key = { it },
+            ) {
+                pageContent(dayOfWeekEntries[it])
+            }
+        }
+    }
+}
+
+@Immutable
+@ExposedCopyVisibility
+data class SchedulePageLayoutParams private constructor(
+    val pageSize: PageSize,
+    val pageSpacing: Dp,
+    val pageContentPadding: PaddingValues,
+    val showTabRow: Boolean,
+    val showDayOfWeekHeadline: Boolean,
+    val columnLayoutParams: ScheduleDayColumnLayoutParams,
+) {
+    @Stable
+    companion object {
+        @Stable
+        val Compact = SchedulePageLayoutParams(
+            pageSize = PageSize.Fill,
+            pageSpacing = 8.dp,
+            pageContentPadding = PaddingValues(0.dp),
+            showTabRow = true,
+            showDayOfWeekHeadline = false,
+            columnLayoutParams = ScheduleDayColumnLayoutParams.Default,
+        )
+
+        @Stable
+        val Medium = SchedulePageLayoutParams(
+            pageSize = PageSize.Fixed(360.dp),
+            pageSpacing = 16.dp,
+            pageContentPadding = PaddingValues(horizontal = 8.dp),
+            showTabRow = false,
+            showDayOfWeekHeadline = true,
+            columnLayoutParams = ScheduleDayColumnLayoutParams.Default,
+        )
+
+        @Composable
+        fun calculate(windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass): SchedulePageLayoutParams {
+            return if (windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM) {
+                Medium
+            } else {
+                Compact
+            }
+        }
+    }
+}
+
+@Immutable
+data class SchedulePageColors(
+    val tabRowContainerColor: Color,
+    val tabSelectedContentColor: Color,
+    val tabUnselectedContentColor: Color,
+    val itemColors: ListItemColors,
+)
+
+@Stable
+object SchedulePageDefaults {
+    @Composable
+    fun colors(
+        tabRowColor: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
+        tabSelectedContentColor: Color = contentColorFor(tabRowColor),
+        tabUnselectedContentColor: Color = contentColorFor(tabRowColor),
+        itemColors: ListItemColors = ListItemDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+    ): SchedulePageColors = SchedulePageColors(
+        tabRowContainerColor = tabRowColor,
+        tabSelectedContentColor = tabSelectedContentColor,
+        tabUnselectedContentColor = tabUnselectedContentColor,
+        itemColors = itemColors,
+    )
+}
+
+
+@Stable
+private fun renderDayOfWeek(day: DayOfWeek): String = when (day) {
+    DayOfWeek.MONDAY -> "周一"
+    DayOfWeek.TUESDAY -> "周二"
+    DayOfWeek.WEDNESDAY -> "周三"
+    DayOfWeek.THURSDAY -> "周四"
+    DayOfWeek.FRIDAY -> "周五"
+    DayOfWeek.SATURDAY -> "周六"
+    DayOfWeek.SUNDAY -> "周日"
+    else -> day.toString()
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -57,7 +57,6 @@ import androidx.window.core.layout.WindowSizeClass
 import androidx.window.core.layout.WindowWidthSizeClass
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DayOfWeek
-import me.him188.ani.app.domain.foundation.LoadError
 import me.him188.ani.app.ui.adaptive.AniTopAppBar
 import me.him188.ani.app.ui.adaptive.HorizontalScrollControlScaffoldOnDesktop
 import me.him188.ani.app.ui.foundation.HorizontalScrollControlState
@@ -107,8 +106,7 @@ class SchedulePageState(
 
 @Composable
 fun SchedulePage(
-    data: List<AiringSchedule>,
-    loadError: LoadError?,
+    presentation: SchedulePagePresentation,
     onRetry: () -> Unit,
     onClickItem: (item: AiringScheduleItemPresentation) -> Unit,
     modifier: Modifier = Modifier,
@@ -131,9 +129,9 @@ fun SchedulePage(
         containerColor = AniThemeDefaults.pageContentBackgroundColor,
         contentWindowInsets = windowInsets.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
     ) { paddingValues ->
-        if (loadError != null) {
+        if (presentation.error != null) {
             LoadErrorCard(
-                loadError,
+                presentation.error,
                 onRetry = onRetry,
                 modifier = Modifier.padding(paddingValues)
                     .padding(layoutParams.pageContentPadding)
@@ -153,7 +151,7 @@ fun SchedulePage(
                             DayOfWeekHeadline(day)
                         }
                     },
-                    items = data.firstOrNull { it.date.dayOfWeek == day }?.episodes.orEmpty(),
+                    items = presentation.airingSchedules.firstOrNull { it.date.dayOfWeek == day }?.episodes.orEmpty(),
                     layoutParams = layoutParams.columnLayoutParams,
                     state = state.scheduleColumnStates[day],
                     itemColors = colors.itemColors,

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -98,6 +98,7 @@ class SchedulePageState(
 @Composable
 fun SchedulePage(
     data: List<AiringSchedule>,
+    onClickItem: (item: AiringScheduleItemPresentation) -> Unit,
     modifier: Modifier = Modifier,
     layoutParams: SchedulePageLayoutParams = SchedulePageLayoutParams.calculate(),
     colors: SchedulePageColors = SchedulePageDefaults.colors(),
@@ -114,6 +115,7 @@ fun SchedulePage(
         windowInsets = windowInsets,
     ) { day ->
         ScheduleDayColumn(
+            onClickItem = onClickItem,
             dayOfWeek = {
                 if (layoutParams.showDayOfWeekHeadline) {
                     DayOfWeekHeadline(day)

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -90,7 +90,7 @@ class SchedulePageState(
 
 @Composable
 fun SchedulePage(
-    data: (DayOfWeek) -> List<ScheduleDayColumnItem>,
+    data: List<AiringSchedule>,
     modifier: Modifier = Modifier,
     layoutParams: SchedulePageLayoutParams = SchedulePageLayoutParams.calculate(),
     colors: SchedulePageColors = SchedulePageDefaults.colors(),
@@ -112,7 +112,7 @@ fun SchedulePage(
                     DayOfWeekHeadline(day)
                 }
             },
-            items = data(day),
+            items = data.firstOrNull { it.date.dayOfWeek == day }?.episodes.orEmpty(),
             layoutParams = layoutParams.columnLayoutParams,
             state = state.scheduleColumnStates[day],
             itemColors = colors.itemColors,

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -37,7 +37,7 @@ class SchedulePageViewModel(
         getAnimeScheduleFlowUseCase(currentTime(), timeZone = TimeZone.currentSystemDefault())
             .restartable(airingSchedulesFlowRestarter)
             .catching()
-            .shareInBackground()
+            .shareInBackground(started = SharingStarted.Lazily) // always cached
 
     val pageState = SchedulePageState(
         initialSelectedDay = currentTime().toLocalDateTime(TimeZone.currentSystemDefault()).dayOfWeek,

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -25,7 +25,7 @@ class SchedulePageViewModel(
 ) : AbstractViewModel() {
     private val getAnimeScheduleFlowUseCase: GetAnimeScheduleFlowUseCase by koin.inject()
 
-    val airingSchedulesFlow =
+    private val airingSchedulesFlow =
         getAnimeScheduleFlowUseCase(Clock.System.now(), timeZone = TimeZone.currentSystemDefault())
             .shareInBackground()
 

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -13,7 +13,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.datetime.Clock
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import me.him188.ani.app.domain.episode.GetAnimeScheduleFlowUseCase
 import me.him188.ani.app.domain.usecase.GlobalKoin
@@ -51,7 +54,10 @@ class SchedulePageViewModel(
     }.stateIn(
         backgroundScope,
         started = SharingStarted.WhileSubscribed(5000),
-        initialValue = SchedulePagePresentation(emptyList(), isPlaceholder = true),
+        initialValue = SchedulePagePresentation(
+            generatePlaceholderAiringScheduleList(),
+            isPlaceholder = true,
+        ),
     )
 
     private fun currentTime() = Clock.System.now()
@@ -61,3 +67,17 @@ data class SchedulePagePresentation(
     val airingSchedules: List<AiringSchedule>,
     val isPlaceholder: Boolean = false,
 )
+
+private fun generatePlaceholderAiringScheduleList(
+    baseDate: LocalDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+): List<AiringSchedule> {
+    val episodes = (1..10).map {
+        AiringScheduleColumnItem.PlaceholderData(id = it, showTime = true)
+    }
+    return (0..6).map { offset ->
+        AiringSchedule(
+            baseDate.plus(DatePeriod(days = offset)),
+            episodes = episodes,
+        )
+    }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -30,7 +30,7 @@ class SchedulePageViewModel(
             .shareInBackground()
 
     val pageState = SchedulePageState(
-
+        initialSelectedDay = currentTime().toLocalDateTime(TimeZone.currentSystemDefault()).dayOfWeek,
     )
 
     val presentationFlow = airingSchedulesFlow.map { list ->
@@ -57,7 +57,7 @@ class SchedulePageViewModel(
     private fun currentTime() = Clock.System.now()
 }
 
-class SchedulePagePresentation(
+data class SchedulePagePresentation(
     val airingSchedules: List<AiringSchedule>,
     val isPlaceholder: Boolean = false,
 )

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import kotlinx.coroutines.flow.map
+import me.him188.ani.app.data.repository.episode.AnimeScheduleRepository
+import me.him188.ani.app.domain.usecase.GlobalKoin
+import me.him188.ani.app.ui.foundation.AbstractViewModel
+import org.koin.core.Koin
+
+class SchedulePageViewModel(
+    koin: Koin = GlobalKoin,
+) : AbstractViewModel() {
+    private val scheduleRepository: AnimeScheduleRepository by koin.inject()
+
+    val pageStateFlow =
+        scheduleRepository.recentScheduleSubjectsFlow()
+            .map { list ->
+                SchedulePageDataHelper.withCurrentTimeIndicator()
+            }
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePageViewModel.kt
@@ -26,7 +26,7 @@ class SchedulePageViewModel(
     private val getAnimeScheduleFlowUseCase: GetAnimeScheduleFlowUseCase by koin.inject()
 
     private val airingSchedulesFlow =
-        getAnimeScheduleFlowUseCase(Clock.System.now(), timeZone = TimeZone.currentSystemDefault())
+        getAnimeScheduleFlowUseCase(currentTime(), timeZone = TimeZone.currentSystemDefault())
             .shareInBackground()
 
     val pageState = SchedulePageState(
@@ -37,11 +37,13 @@ class SchedulePageViewModel(
         val timeZone = TimeZone.currentSystemDefault()
         SchedulePagePresentation(
             airingSchedules = list.map { airingSchedule ->
+                val currentDateTime = currentTime().toLocalDateTime(timeZone)
                 AiringSchedule(
                     airingSchedule.date,
-                    SchedulePageDataHelper.withCurrentTimeIndicator(
+                    SchedulePageDataHelper.toColumnItems(
                         airingSchedule.list.map { it.toPresentation(timeZone) },
-                        Clock.System.now().toLocalDateTime(timeZone).time,
+                        addIndicator = currentDateTime.date == airingSchedule.date,
+                        currentDateTime.time,
                     ),
                 )
             },
@@ -51,6 +53,8 @@ class SchedulePageViewModel(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = SchedulePagePresentation(emptyList(), isPlaceholder = true),
     )
+
+    private fun currentTime() = Clock.System.now()
 }
 
 class SchedulePagePresentation(

--- a/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/schedule/EpisodeWithAiringTimeDefaultsTest.kt
+++ b/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/schedule/EpisodeWithAiringTimeDefaultsTest.kt
@@ -15,7 +15,7 @@ import me.him188.ani.datasources.api.EpisodeType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class ScheduleItemDefaultsTest {
+class EpisodeWithAiringTimeDefaultsTest {
     @Test
     fun `renderEpisodeDisplay sort only`() {
         assertEquals("第 1 话", renderEpisodeDisplay(EpisodeSort(1), null, null))

--- a/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/schedule/ScheduleItemDefaultsTest.kt
+++ b/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/schedule/ScheduleItemDefaultsTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.schedule
+
+import me.him188.ani.app.ui.exploration.schedule.ScheduleItemDefaults.renderEpisodeDisplay
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.EpisodeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScheduleItemDefaultsTest {
+    @Test
+    fun `renderEpisodeDisplay sort only`() {
+        assertEquals("第 1 话", renderEpisodeDisplay(EpisodeSort(1), null, null))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay sort with name`() {
+        assertEquals("第 1 话  Foo", renderEpisodeDisplay(EpisodeSort(1), null, "Foo"))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay sort equal ep`() {
+        assertEquals("第 1 话", renderEpisodeDisplay(EpisodeSort(1), EpisodeSort(1), null))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay sort equal ep with name`() {
+        assertEquals("第 1 话  Foo", renderEpisodeDisplay(EpisodeSort(1), EpisodeSort(1), "Foo"))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay sort does not equal ep`() {
+        assertEquals("第 1 (12) 话", renderEpisodeDisplay(EpisodeSort(12), EpisodeSort(1), null))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay sort does not equal ep with name`() {
+        assertEquals("第 1 (12) 话  Foo", renderEpisodeDisplay(EpisodeSort(12), EpisodeSort(1), "Foo"))
+    }
+
+    @Test
+    fun `renderEpisodeDisplay special sort`() {
+        assertEquals(
+            "OVA01  Foo",
+            renderEpisodeDisplay(
+                EpisodeSort(1, EpisodeType.OVA),
+                EpisodeSort(1, EpisodeType.OVA),
+                "Foo",
+            ),
+        )
+    }
+
+    @Test
+    fun `renderEpisodeDisplay unknown sort`() {
+        assertEquals(
+            "剧场版  Foo",
+            renderEpisodeDisplay(
+                EpisodeSort("剧场版"),
+                EpisodeSort("剧场版"),
+                "Foo",
+            ),
+        )
+    }
+}

--- a/client/openapi.yaml
+++ b/client/openapi.yaml
@@ -791,6 +791,70 @@
         "deprecated": false
       }
     },
+    "/v1/schedule/seasons/latest": {
+      "get": {
+        "tags": [ "Schedule" ],
+        "summary": "获取最近几个季度的列表",
+        "description": "获取最近几个季度的列表",
+        "operationId": "getLatestAnimeSeasons",
+        "parameters": [ ],
+        "responses": {
+          "200": {
+            "description": "获取成功",
+            "headers": { },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LatestAnimeSchedules"
+                },
+                "examples": {
+                  "example": {
+                    "value": {
+                      "list": [ {
+                        "seasonId": {
+                          "year": 2024,
+                          "season": "SUMMER",
+                          "id": "2024q3"
+                        },
+                        "list": [ {
+                          "bangumiId": 404480,
+                          "name": "ラブライブ！スーパースター!!(第3期)",
+                          "aliases": [ "Love Live ! Superstar!!", "Love Live! Superstar!! 第三季", "爱与演唱会!超级明星!! 第三季", "Love Live! Superstar!! 第三季", "LoveLive! SuperStar!! 第三季" ],
+                          "begin": "2024-10-06T08:00:00Z",
+                          "recurrence": {
+                            "startTime": "2024-10-06T08:00:00Z",
+                            "intervalMillis": 604800000
+                          },
+                          "mikanId": 3427
+                        } ]
+                      }, {
+                        "seasonId": {
+                          "year": 2024,
+                          "season": "SUMMER",
+                          "id": "2024q3"
+                        },
+                        "list": [ {
+                          "bangumiId": 404480,
+                          "name": "ラブライブ！スーパースター!!(第3期)",
+                          "aliases": [ "Love Live ! Superstar!!", "Love Live! Superstar!! 第三季", "爱与演唱会!超级明星!! 第三季", "Love Live! Superstar!! 第三季", "LoveLive! SuperStar!! 第三季" ],
+                          "begin": "2024-10-06T08:00:00Z",
+                          "recurrence": {
+                            "startTime": "2024-10-06T08:00:00Z",
+                            "intervalMillis": 604800000
+                          },
+                          "mikanId": 3427
+                        } ]
+                      } ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
     "/v1/schedule/season/{seasonId}": {
       "get": {
         "tags": [ "Schedule" ],
@@ -824,6 +888,11 @@
                 "examples": {
                   "example": {
                     "value": {
+                      "seasonId": {
+                        "year": 2024,
+                        "season": "SUMMER",
+                        "id": "2024q3"
+                      },
                       "list": [ {
                         "bangumiId": 404480,
                         "name": "ラブライブ！スーパースター!!(第3期)",
@@ -1361,6 +1430,23 @@
           }
         }
       },
+      "AnimeSchedule": {
+        "title": "AnimeSchedule",
+        "required": [ "list", "seasonId" ],
+        "type": "object",
+        "properties": {
+          "list": {
+            "title": "List<OnAirAnimeInfo>",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OnAirAnimeInfo"
+            }
+          },
+          "seasonId": {
+            "$ref": "#/components/schemas/AnimeSeasonId"
+          }
+        }
+      },
       "OnAirAnimeInfo": {
         "title": "OnAirAnimeInfo",
         "required": [ "aliases", "bangumiId", "name" ],
@@ -1417,16 +1503,16 @@
           }
         }
       },
-      "AnimeSchedule": {
-        "title": "AnimeSchedule",
+      "LatestAnimeSchedules": {
+        "title": "LatestAnimeSchedules",
         "required": [ "list" ],
         "type": "object",
         "properties": {
           "list": {
-            "title": "List<OnAirAnimeInfo>",
+            "title": "List<AnimeSchedule>",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/OnAirAnimeInfo"
+              "$ref": "#/components/schemas/AnimeSchedule"
             }
           }
         }

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/BangumiOAuthAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/BangumiOAuthAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/DanmakuAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/DanmakuAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/ScheduleAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/ScheduleAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,19 +24,21 @@
 
 package me.him188.ani.client.apis
 
-import io.ktor.client.HttpClient
-import io.ktor.client.HttpClientConfig
-import io.ktor.client.engine.HttpClientEngine
-import kotlinx.serialization.json.Json
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.toMultiValue
-import me.him188.ani.client.infrastructure.wrap
 import me.him188.ani.client.models.AniAnimeSchedule
 import me.him188.ani.client.models.AniAnimeSeasonIdList
 import me.him188.ani.client.models.AniBatchGetSubjectRecurrenceResponse
+import me.him188.ani.client.models.AniLatestAnimeSchedules
+
+import me.him188.ani.client.infrastructure.*
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
+import io.ktor.client.engine.HttpClientEngine
+import kotlinx.serialization.json.Json
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class ScheduleAniApi : ApiClient {
 
@@ -109,6 +111,38 @@ open class ScheduleAniApi : ApiClient {
         val localVariableConfig = RequestConfig<kotlin.Any?>(
             RequestMethod.GET,
             "/v1/schedule/seasons",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames,
+        ).wrap()
+    }
+
+
+    /**
+     * 获取最近几个季度的列表
+     * 获取最近几个季度的列表
+     * @return AniLatestAnimeSchedules
+     */
+    @Suppress("UNCHECKED_CAST")
+    open suspend fun getLatestAnimeSeasons(): HttpResponse<AniLatestAnimeSchedules> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody =
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/v1/schedule/seasons/latest",
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/SubjectRelationsAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/SubjectRelationsAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,16 +24,18 @@
 
 package me.him188.ani.client.apis
 
+import me.him188.ani.client.models.AniSubjectRelations
+
+import me.him188.ani.client.infrastructure.*
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.wrap
-import me.him188.ani.client.models.AniSubjectRelations
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class SubjectRelationsAniApi : ApiClient {
 

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/SubscriptionsAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/SubscriptionsAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,21 +25,16 @@
 package me.him188.ani.client.apis
 
 
+import me.him188.ani.client.infrastructure.*
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.map
-import me.him188.ani.client.infrastructure.wrap
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class SubscriptionsAniApi : ApiClient {
 

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/TrendsAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/TrendsAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,16 +24,18 @@
 
 package me.him188.ani.client.apis
 
+import me.him188.ani.client.models.AniTrends
+
+import me.him188.ani.client.infrastructure.*
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.wrap
-import me.him188.ani.client.models.AniTrends
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class TrendsAniApi : ApiClient {
 

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/UpdatesAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/UpdatesAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,18 +24,20 @@
 
 package me.him188.ani.client.apis
 
-import io.ktor.client.HttpClient
-import io.ktor.client.HttpClientConfig
-import io.ktor.client.engine.HttpClientEngine
-import kotlinx.serialization.json.Json
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.wrap
 import me.him188.ani.client.models.AniLatestVersionInfo
 import me.him188.ani.client.models.AniReleaseUpdatesDetailedResponse
 import me.him188.ani.client.models.AniReleaseUpdatesResponse
+
+import me.him188.ani.client.infrastructure.*
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
+import io.ktor.client.engine.HttpClientEngine
+import kotlinx.serialization.json.Json
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class UpdatesAniApi : ApiClient {
 

--- a/client/src/commonMain/gen/me/him188/ani/client/apis/UserAniApi.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/apis/UserAniApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,16 +24,18 @@
 
 package me.him188.ani.client.apis
 
+import me.him188.ani.client.models.AniAniUser
+
+import me.him188.ani.client.infrastructure.*
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
+import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
-import me.him188.ani.client.infrastructure.ApiClient
-import me.him188.ani.client.infrastructure.HttpResponse
-import me.him188.ani.client.infrastructure.RequestConfig
-import me.him188.ani.client.infrastructure.RequestMethod
-import me.him188.ani.client.infrastructure.wrap
-import me.him188.ani.client.models.AniAniUser
+import io.ktor.http.ParametersBuilder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 open class UserAniApi : ApiClient {
 

--- a/client/src/commonMain/gen/me/him188/ani/client/infrastructure/ApiAbstractions.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/infrastructure/ApiAbstractions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/infrastructure/ApiClient.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/infrastructure/ApiClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -13,30 +13,21 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.*
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
-import io.ktor.client.request.request
-import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
-import io.ktor.http.Parameters
-import io.ktor.http.URLBuilder
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.*
 import io.ktor.http.content.PartData
 import io.ktor.http.contentType
-import io.ktor.http.encodeURLQueryComponent
-import io.ktor.http.encodedPath
-import io.ktor.http.takeFrom
-import io.ktor.serialization.kotlinx.json.json
+import kotlin.Unit
 import kotlinx.serialization.json.Json
-import me.him188.ani.client.auth.ApiKeyAuth
-import me.him188.ani.client.auth.Authentication
-import me.him188.ani.client.auth.HttpBasicAuth
-import me.him188.ani.client.auth.HttpBearerAuth
-import me.him188.ani.client.auth.OAuth
+
+import me.him188.ani.client.auth.*
 
 open class ApiClient(
     private val baseUrl: String

--- a/client/src/commonMain/gen/me/him188/ani/client/infrastructure/Bytes.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/infrastructure/Bytes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,13 +9,7 @@
 
 package me.him188.ani.client.infrastructure
 
-import io.ktor.utils.io.core.ByteReadPacket
-import io.ktor.utils.io.core.Input
-import io.ktor.utils.io.core.buildPacket
-import io.ktor.utils.io.core.readAvailable
-import io.ktor.utils.io.core.readBytes
-import io.ktor.utils.io.core.writeFully
-import io.ktor.utils.io.core.writeText
+import io.ktor.utils.io.core.*
 import kotlin.experimental.and
 
 private val digits = "0123456789abcdef".toCharArray()

--- a/client/src/commonMain/gen/me/him188/ani/client/infrastructure/HttpResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/infrastructure/HttpResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAniUser.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAniUser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,9 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeRecurrence.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeRecurrence.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,9 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSchedule.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSchedule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,20 +24,26 @@
 
 package me.him188.ani.client.models
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import me.him188.ani.client.models.AniAnimeSeasonId
+import me.him188.ani.client.models.AniOnAirAnimeInfo
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 
  *
- * @param list 
+ * @param list
+ * @param seasonId 
  */
 @Serializable
 
 data class AniAnimeSchedule(
 
-    @SerialName(value = "list") @Required val list: kotlin.collections.List<AniOnAirAnimeInfo>
+    @SerialName(value = "list") @Required val list: kotlin.collections.List<AniOnAirAnimeInfo>,
+
+    @SerialName(value = "seasonId") @Required val seasonId: AniAnimeSeasonId
 
 )
 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeason.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeason.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,7 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import me.him188.ani.client.models.AniAnimeSeason.values
+import kotlinx.serialization.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeasonId.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeasonId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,9 +24,11 @@
 
 package me.him188.ani.client.models
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import me.him188.ani.client.models.AniAnimeSeason
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeasonIdList.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnimeSeasonIdList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,9 +24,11 @@
 
 package me.him188.ani.client.models
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import me.him188.ani.client.models.AniAnimeSeasonId
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniAnonymousBangumiUserToken.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniAnonymousBangumiUserToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,9 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniBangumiLoginResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniBangumiLoginResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,9 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniBangumiUserToken.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniBangumiUserToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -25,9 +25,9 @@
 package me.him188.ani.client.models
 
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniBatchGetSubjectRecurrenceResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniBatchGetSubjectRecurrenceResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,9 +24,11 @@
 
 package me.him188.ani.client.models
 
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import me.him188.ani.client.models.AniAnimeRecurrence
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmaku.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmaku.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuGetResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuGetResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuInfo.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuLocation.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuLocation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -27,7 +27,6 @@ package me.him188.ani.client.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import me.him188.ani.client.models.AniDanmakuLocation.values
 
 /**
  * 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuPostRequest.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniDanmakuPostRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniLatestAnimeSchedules.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniLatestAnimeSchedules.kt
@@ -24,30 +24,20 @@
 
 package me.him188.ani.client.models
 
-
-import kotlinx.serialization.*
-import kotlinx.serialization.descriptors.*
-import kotlinx.serialization.encoding.*
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
- * 
  *
- * @param bangumiToken 
- * @param clientArch 
- * @param clientOS 
- * @param clientVersion 
+ *
+ * @param list
  */
 @Serializable
 
-data class AniBangumiLoginRequest(
+data class AniLatestAnimeSchedules(
 
-    @SerialName(value = "bangumiToken") @Required val bangumiToken: kotlin.String,
-
-    @SerialName(value = "clientArch") val clientArch: kotlin.String? = null,
-
-    @SerialName(value = "clientOS") val clientOS: kotlin.String? = null,
-
-    @SerialName(value = "clientVersion") val clientVersion: kotlin.String? = null
+    @SerialName(value = "list") @Required val list: kotlin.collections.List<AniAnimeSchedule>
 
 )
 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniLatestVersionInfo.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniLatestVersionInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniOnAirAnimeInfo.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniOnAirAnimeInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -31,7 +31,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * @param aliases
+ * @param aliases 
  * @param bangumiId 
  * @param name 
  * @param begin 

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniRefreshBangumiTokenRequest.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniRefreshBangumiTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniReleaseUpdatesDetailedResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniReleaseUpdatesDetailedResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniReleaseUpdatesResponse.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniReleaseUpdatesResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniSubjectRelations.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniSubjectRelations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -32,7 +32,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * @param sequelSubjects
+ * @param sequelSubjects 
  * @param seriesMainSubjectIds 
  * @param subjectId 
  */

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniTrendingSubject.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniTrendingSubject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniTrends.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniTrends.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/client/src/commonMain/gen/me/him188/ani/client/models/AniUpdateInfo.kt
+++ b/client/src/commonMain/gen/me/him188/ani/client/models/AniUpdateInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.

--- a/datasource/api/src/commonMain/kotlin/EpisodeSort.kt
+++ b/datasource/api/src/commonMain/kotlin/EpisodeSort.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -181,7 +181,7 @@ fun EpisodeSort(raw: String): EpisodeSort {
     }
 }
 
-fun EpisodeSort(int: Int, type: EpisodeType = MainStory): EpisodeSort {
+fun EpisodeSort(int: Int, type: EpisodeType? = MainStory): EpisodeSort {
     return EpisodeSort(BigNum(int), type)
 }
 

--- a/datasource/api/src/commonMain/kotlin/PackedDate.kt
+++ b/datasource/api/src/commonMain/kotlin/PackedDate.kt
@@ -106,7 +106,11 @@ fun PackedDate.toStringExcludingSameYear(): String = when {
 
 fun PackedDate.toLocalDateOrNull(): LocalDate? {
     if (isInvalid) return null
-    return LocalDate(year, month, day)
+    return try {
+        LocalDate(year, month, day) // May throw IAE
+    } catch (e: IllegalArgumentException) {
+        null
+    }
 }
 
 fun PackedDate?.isNullOrInvalid(): Boolean = this == null || this.isInvalid

--- a/datasource/api/src/commonMain/kotlin/PackedDate.kt
+++ b/datasource/api/src/commonMain/kotlin/PackedDate.kt
@@ -98,6 +98,8 @@ value class PackedDate(
     }
 }
 
+val UTC9 = TimeZone.of("UTC+9")
+
 fun PackedDate.toStringExcludingSameYear(): String = when {
     isInvalid -> toString()
     year == PackedDate.now().year -> "$month-$day"

--- a/utils/platform/src/commonMain/kotlin/collections/PrimitiveList.kt
+++ b/utils/platform/src/commonMain/kotlin/collections/PrimitiveList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -28,4 +28,12 @@ inline fun <V, M : MutableMap<in Int, in V>> IntList.associateWithTo(
         destination.put(element, valueSelector(element))
     }
     return destination
+}
+
+fun IntList.toIntArray(): IntArray {
+    val array = IntArray(size)
+    forEachIndexed { index, element ->
+        array[index] = element
+    }
+    return array
 }


### PR DESCRIPTION
Design: https://www.figma.com/design/LET1n9mmDa6npDTIlUuJjU/Animeko?node-id=349-9250&t=hBPSAEVlsmuEWPJt-0

- 设计上 item 末尾有个追番状态按钮, 但是比较难实现. 追番状态也就需要获取 subjectCollectionInfo, 而它就会依赖 episodeCollections 等一系列信息. Banugmi 不支持批量按 ID 查询收藏状态, 也就是这个页面会需要发送 100-200 个请求才能支持追番状态. 所以只能先搁置了
- 现在的实现仅依靠三个 ani 服务器查询和一个 graphql 批量查询. 时间表信息无缓存. 
```
2025-01-15 01:22:45,106 [INFO ] AniAuthClient:   GET https://auth.myani.org/v1/schedule/seasons : 200  in 265.015167ms
2025-01-15 01:22:45,690 [INFO ] AniAuthClient:   GET https://auth.myani.org/v1/schedule/season/2025q1 : 200  in 317.837541ms
2025-01-15 01:22:45,690 [INFO ] AniAuthClient:   GET https://auth.myani.org/v1/schedule/season/2024q4 : 200  in 318.032792ms
2025-01-15 01:22:46,346 [INFO ] BangumiClientImpl:  POST https://api.bgm.tv/v0/graphql [Authorized]: 200  in 362.281458ms
```

TODO:
- [x] 错误提示
- [x] PC horizontal pager 滚动到最右边后嵌套的 lazy column 就不能垂直滚了
- [x] 检查 AnimeScheduleHelper 的算法正确性

