### PR TITLE
[Fix] Custom Theme

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-val DEFAULT_SEED_COLOR = Color(0xFF6200EE)
+val DEFAULT_SEED_COLOR = Color(0xFF4F378B)
 
 @Serializable
 enum class DarkMode {

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
@@ -27,12 +27,14 @@ enum class DarkMode {
 data class ThemeSettings(
     val darkMode: DarkMode = DarkMode.AUTO,
     val useDynamicTheme: Boolean = false, // only supported on Android with Build.VERSION.SDK_INT >= 31
+    // TODO: Default "true" if supported (on Android, Build.VERSION.SDK_INT >= 31)
     val useBlackBackground: Boolean = false,
     val seedColorValue: ULong = DEFAULT_SEED_COLOR.value,
     @Suppress("PropertyName") @Transient val _placeholder: Int = 0,
 ) {
     @Transient
     val seedColor: Color = Color(seedColorValue)
+
     companion object {
         @Stable
         val Default = ThemeSettings()

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/ThemeSettings.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-val DEFAULT_SEED_COLOR = Color.Unspecified
+val DEFAULT_SEED_COLOR = Color(0xFF6200EE)
 
 @Serializable
 enum class DarkMode {

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -294,7 +294,7 @@ private fun PreviewVideoScaffoldImpl(
 //                    ProgressSlider(progressSliderState)
 //                },
 //                danmakuEditor = {
-//                    AniTheme(forceDarkTheme = true) {
+//                    AniTheme(isDark = true) {
 //                        var text by rememberSaveable { mutableStateOf("") }
 //                        var sending by remember { mutableStateOf(false) }
 //                        LaunchedEffect(key1 = sending) {

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/video/TorrentMediaCacheProgressState.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/video/TorrentMediaCacheProgressState.android.kt
@@ -37,7 +37,7 @@ import kotlin.time.Duration.Companion.seconds
 // Try interactive preview to see cache progress change
 @Preview
 @Composable
-fun PreviewMediaProgressSliderInteractive() = ProvideCompositionLocalsForPreview {
+fun PreviewMediaProgressSliderInteractive() = ProvideCompositionLocalsForPreview(isDark = true) {
     var currentPositionMillis by remember { mutableLongStateOf(2000) }
     val totalDurationMillis by remember { mutableLongStateOf(30_000) }
     val pieces = remember {
@@ -92,7 +92,7 @@ private fun buildPiecesWithStep(
 @Composable
 fun PreviewMediaProgressSliderNonConsecutiveCacheImpl(
     pieces: PieceList,
-) = ProvideFoundationCompositionLocalsForPreview {
+) = ProvideFoundationCompositionLocalsForPreview(isDark = true) {
     val cacheProgress = remember {
         TorrentMediaCacheProgressProvider(
             pieces,

--- a/app/shared/src/commonMain/kotlin/ui/foundation/Previewing.kt
+++ b/app/shared/src/commonMain/kotlin/ui/foundation/Previewing.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.ui.foundation
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
@@ -63,7 +64,7 @@ import org.openani.mediamp.MediampPlayerFactory
 @Composable
 fun ProvideCompositionLocalsForPreview(
     module: Module.() -> Unit = {},
-    isDark: Boolean = false,
+    isDark: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
     ProvideFoundationCompositionLocalsForPreview(isDark) {
@@ -132,7 +133,7 @@ fun ProvideCompositionLocalsForPreview(
             }
             NavHost(navController, startDestination = "test") { // provide ViewModelStoreOwner
                 composable("test") {
-                    AniTheme {
+                    AniTheme(isDark = isDark) {
                         content()
                     }
                 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -153,7 +153,7 @@ internal fun EpisodeVideoImpl(
         }
     }
 
-    AniTheme {
+    AniTheme(isDark = true) {
         VideoScaffold(
             expanded = expanded,
             modifier = modifier

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
@@ -82,9 +82,7 @@ class EpisodeVideoCursorTest {
 
     @Composable
     private fun Player(gestureFamily: GestureFamily = GestureFamily.MOUSE) {
-        ProvideCompositionLocalsForPreview(
-            isDark = true,
-        ) {
+        ProvideCompositionLocalsForPreview(isDark = true) {
             val scope = rememberCoroutineScope()
             val playerState = remember {
                 DummyMediampPlayer(scope.coroutineContext)

--- a/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/theme/AppTheme.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/theme/AppTheme.android.kt
@@ -15,10 +15,8 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
@@ -42,35 +40,27 @@ actual fun appColorScheme(
             dynamicLightColorScheme(LocalContext.current)
         }
     } else {
-        if (seedColor == Color.Unspecified) {
-            if (isDark) {
-                darkColorScheme()
-            } else {
-                lightColorScheme()
-            }
-        } else {
-            dynamicColorScheme(
-                primary = seedColor,
-                isDark = isDark,
-                isAmoled = useBlackBackground,
-                style = PaletteStyle.TonalSpot,
-                modifyColorScheme = { colorScheme ->
-                    if (useBlackBackground && isDark) {
-                        colorScheme.copy(
-                            background = Color.Black,
-                            onBackground = Color.White,
+        dynamicColorScheme(
+            primary = seedColor,
+            isDark = isDark,
+            isAmoled = useBlackBackground,
+            style = PaletteStyle.TonalSpot,
+            modifyColorScheme = { colorScheme ->
+                if (useBlackBackground && isDark) {
+                    colorScheme.copy(
+                        background = Color.Black,
+                        onBackground = Color.White,
 
-                            surface = Color.Black,
-                            onSurface = Color.White,
-                            surfaceContainerLowest = Color.Black,
+                        surface = Color.Black,
+                        onSurface = Color.White,
+                        surfaceContainerLowest = Color.Black,
 
-                            surfaceVariant = Color.Black,
-                            onSurfaceVariant = Color.White,
-                        )
-                    } else colorScheme
-                },
-            )
-        }
+                        surfaceVariant = Color.Black,
+                        onSurfaceVariant = Color.White,
+                    )
+                } else colorScheme
+            },
+        )
     }
 }
 

--- a/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/theme/AppTheme.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/theme/AppTheme.android.kt
@@ -15,7 +15,6 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -76,23 +75,12 @@ actual fun appColorScheme(
 }
 
 @Composable
-actual fun AniTheme(
-    isDark: Boolean,
-    content: @Composable () -> Unit,
-) {
-    MaterialTheme(
-        colorScheme = appColorScheme(isDark = isDark),
-        content = content,
-    )
-}
-
-@Composable
 fun SystemBarColorEffect(
     isDark: Boolean = when (LocalThemeSettings.current.darkMode) {
         DarkMode.LIGHT -> false
         DarkMode.DARK -> true
         DarkMode.AUTO -> isSystemInDarkTheme()
-    }
+    },
 ) {
     // Set statusBarStyle & navigationBarStyle
     val activity = LocalContext.current.findActivity() as? ComponentActivity

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/PreviewFoundation.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/PreviewFoundation.kt
@@ -90,7 +90,7 @@ inline fun ProvideFoundationCompositionLocalsForPreview(
             aniNavigator.setNavController(navController)
         }
         ProvidePlatformCompositionLocalsForPreview {
-            AniTheme {
+            AniTheme(isDark = isDark) {
                 content()
             }
         }

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
@@ -69,7 +69,7 @@ expect fun appColorScheme(
 
 /**
  * AniApp MaterialTheme.
- * @param isDark Override [DarkMode] in specific situations.
+ * @param isDark Used for overriding [DarkMode] in specific situations.
  */
 @Composable
 fun AniTheme(

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
@@ -52,7 +52,7 @@ import me.him188.ani.app.ui.foundation.layout.isCompact
 import kotlin.math.roundToInt
 
 /**
- * Create a [ColorScheme] based on the current theme settings.
+ * Create a [ColorScheme] based on the current [ThemeSettings].
  * You should prefer [AniTheme] if possible.
  */
 @Composable
@@ -64,21 +64,27 @@ expect fun appColorScheme(
         DarkMode.LIGHT -> false
         DarkMode.DARK -> true
         DarkMode.AUTO -> isSystemInDarkTheme()
-    }
+    },
 ): ColorScheme
 
 /**
- * 覆盖主题颜色.
+ * AniApp MaterialTheme.
+ * @param isDark Override [DarkMode] in specific situations.
  */
 @Composable
-expect fun AniTheme(
+fun AniTheme(
     isDark: Boolean = when (LocalThemeSettings.current.darkMode) {
         DarkMode.LIGHT -> false
         DarkMode.DARK -> true
         DarkMode.AUTO -> isSystemInDarkTheme()
     },
-    content: @Composable () -> Unit
-)
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colorScheme = appColorScheme(isDark = isDark),
+        content = content,
+    )
+}
 
 @Stable
 object AniThemeDefaults {

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
@@ -10,7 +10,6 @@
 package me.him188.ani.app.ui.foundation.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -54,15 +53,4 @@ actual fun appColorScheme(
             },
         )
     }
-}
-
-@Composable
-actual fun AniTheme(
-    isDark: Boolean,
-    content: @Composable () -> Unit,
-) {
-    MaterialTheme(
-        colorScheme = appColorScheme(isDark = isDark),
-        content = content,
-    )
 }

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
@@ -10,8 +10,6 @@
 package me.him188.ani.app.ui.foundation.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.materialkolor.PaletteStyle
@@ -24,33 +22,25 @@ actual fun appColorScheme(
     useBlackBackground: Boolean,
     isDark: Boolean,
 ): ColorScheme {
-    return if (seedColor == Color.Unspecified) {
-        if (isDark) {
-            darkColorScheme()
-        } else {
-            lightColorScheme()
-        }
-    } else {
-        dynamicColorScheme(
-            primary = seedColor,
-            isDark = isDark,
-            isAmoled = useBlackBackground,
-            style = PaletteStyle.TonalSpot,
-            modifyColorScheme = { colorScheme ->
-                if (useBlackBackground && isDark) {
-                    colorScheme.copy(
-                        background = Color.Black,
-                        onBackground = Color.White,
+    return dynamicColorScheme(
+        primary = seedColor,
+        isDark = isDark,
+        isAmoled = useBlackBackground,
+        style = PaletteStyle.TonalSpot,
+        modifyColorScheme = { colorScheme ->
+            if (useBlackBackground && isDark) {
+                colorScheme.copy(
+                    background = Color.Black,
+                    onBackground = Color.White,
 
-                        surface = Color.Black,
-                        onSurface = Color.White,
-                        surfaceContainerLowest = Color.Black,
+                    surface = Color.Black,
+                    onSurface = Color.White,
+                    surfaceContainerLowest = Color.Black,
 
-                        surfaceVariant = Color.Black,
-                        onSurfaceVariant = Color.White,
-                    )
-                } else colorScheme
-            },
-        )
-    }
+                    surfaceVariant = Color.Black,
+                    onSurfaceVariant = Color.White,
+                )
+            } else colorScheme
+        },
+    )
 }

--- a/app/shared/ui-foundation/src/iosMain/kotlin/ui/foundation/theme/AppTheme.ios.kt
+++ b/app/shared/ui-foundation/src/iosMain/kotlin/ui/foundation/theme/AppTheme.ios.kt
@@ -10,7 +10,6 @@
 package me.him188.ani.app.ui.foundation.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -54,15 +53,4 @@ actual fun appColorScheme(
             },
         )
     }
-}
-
-@Composable
-actual fun AniTheme(
-    isDark: Boolean,
-    content: @Composable () -> Unit,
-) {
-    MaterialTheme(
-        colorScheme = appColorScheme(isDark = isDark),
-        content = content,
-    )
 }

--- a/app/shared/ui-foundation/src/iosMain/kotlin/ui/foundation/theme/AppTheme.ios.kt
+++ b/app/shared/ui-foundation/src/iosMain/kotlin/ui/foundation/theme/AppTheme.ios.kt
@@ -10,8 +10,6 @@
 package me.him188.ani.app.ui.foundation.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.materialkolor.PaletteStyle
@@ -24,33 +22,25 @@ actual fun appColorScheme(
     useBlackBackground: Boolean,
     isDark: Boolean,
 ): ColorScheme {
-    return if (seedColor == Color.Unspecified) {
-        if (isDark) {
-            darkColorScheme()
-        } else {
-            lightColorScheme()
-        }
-    } else {
-        dynamicColorScheme(
-            primary = seedColor,
-            isDark = isDark,
-            isAmoled = useBlackBackground,
-            style = PaletteStyle.TonalSpot,
-            modifyColorScheme = { colorScheme ->
-                if (useBlackBackground && isDark) {
-                    colorScheme.copy(
-                        background = Color.Black,
-                        onBackground = Color.White,
+    return dynamicColorScheme(
+        primary = seedColor,
+        isDark = isDark,
+        isAmoled = useBlackBackground,
+        style = PaletteStyle.TonalSpot,
+        modifyColorScheme = { colorScheme ->
+            if (useBlackBackground && isDark) {
+                colorScheme.copy(
+                    background = Color.Black,
+                    onBackground = Color.White,
 
-                        surface = Color.Black,
-                        onSurface = Color.White,
-                        surfaceContainerLowest = Color.Black,
+                    surface = Color.Black,
+                    onSurface = Color.White,
+                    surfaceContainerLowest = Color.Black,
 
-                        surfaceVariant = Color.Black,
-                        onSurfaceVariant = Color.White,
-                    )
-                } else colorScheme
-            },
-        )
-    }
+                    surfaceVariant = Color.Black,
+                    onSurfaceVariant = Color.White,
+                )
+            } else colorScheme
+        },
+    )
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/theme/ThemePreferences.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/theme/ThemePreferences.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.isUnspecified
 import com.materialkolor.hct.Hct
 import me.him188.ani.app.data.models.preference.DarkMode
 import me.him188.ani.app.data.models.preference.ThemeSettings
@@ -175,6 +174,6 @@ private fun ColorButton(
                 ),
             )
         },
-        baseColor = if (color.isUnspecified) Color(0xFF6200EE) else color,
+        baseColor = color,
     )
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/theme/ThemePreferences.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/theme/ThemePreferences.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import com.materialkolor.hct.Hct
+import me.him188.ani.app.data.models.preference.DEFAULT_SEED_COLOR
 import me.him188.ani.app.data.models.preference.DarkMode
 import me.him188.ani.app.data.models.preference.ThemeSettings
 import me.him188.ani.app.ui.foundation.LocalPlatform
@@ -38,7 +39,9 @@ import me.him188.ani.utils.platform.isAndroid
 import me.him188.ani.utils.platform.isDesktop
 
 private val colorList =
-    listOf(Color.Unspecified) + ((4..10) + (1..3)).map { it * 35.0 }.map { Color(Hct.from(it, 40.0, 40.0).toInt()) }
+    ((4..10) + (1..3)).map { it * 35.0 }.map { Color(Hct.from(it, 40.0, 40.0).toInt()) }.toMutableList().apply {
+        add(5, DEFAULT_SEED_COLOR)
+    }
 
 @Composable
 fun SettingsScope.ThemeGroup(
@@ -173,6 +176,7 @@ private fun ColorButton(
                     useDynamicTheme = false,
                 ),
             )
+
         },
         baseColor = color,
     )

--- a/app/shared/video-player/src/commonMain/kotlin/ui/guesture/GestureLock.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/guesture/GestureLock.kt
@@ -55,7 +55,7 @@ fun GestureLock(
 //        modifier = modifier,
 //        containerColor = background,
 //    ) {
-//        CompositionLocalProvider(LocalContentColor provides aniColorTheme(isDark = true).contentColorFor(background)) {
+//        CompositionLocalProvider(LocalContentColor provides appColorScheme(isDark = true).contentColorFor(background)) {
 //            if (isLocked) {
 //                Icon(Icons.Outlined.LockOpen, contentDescription = "Lock screen")
 //            } else {


### PR DESCRIPTION
修复 #1473 的一些问题。

---

- Fix Preview

- Revert & Fix Problems caused by `Color.Unspecified`：

1. `useBlackBackground` 在 `Color.Unspecified` 下失效。

![image](https://github.com/user-attachments/assets/a4d944d2-b170-4f0c-b6ac-4f1d8898fe0a)
![image](https://github.com/user-attachments/assets/cd810c63-af04-48bf-a9d4-0f4a712482f9)

2. 第一个 ColorButton 会是紫色显得很突兀。调整顺序。

或者不用 Hct 生成颜色了，不按 Material Design 标准也行。直接定义 Color hex 方便且直观。

@Him188 为什么那么想要 `darkColorScheme`？

---

可以直接在我的分支上修改，这样效率高，但是在合并 PR 前请向 Author 请求 review。