### PR TITLE
Compose 1.8

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -37,12 +37,15 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.navigation.MainScenePage
 import me.him188.ani.app.navigation.getIcon
@@ -159,6 +162,7 @@ private fun MainSceneContent(
         modifier,
         layoutType = navigationLayoutType,
     ) {
+        val coroutineScope = rememberCoroutineScope()
         val navigator by rememberUpdatedState(LocalNavigator.current)
         AnimatedContent(
             page,
@@ -237,8 +241,10 @@ private fun MainSceneContent(
                                         // 只有在单面板模式下才显示返回按钮
                                         if (listDetailLayoutParameters.isSinglePane) {
                                             BackNavigationIconButton(
-                                                {
-                                                    listDetailNavigator.navigateBack()
+                                                onNavigateBack = {
+                                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                                        listDetailNavigator.navigateBack()
+                                                    }
                                                 },
                                             )
                                         }
@@ -249,7 +255,9 @@ private fun MainSceneContent(
                             onSelect = { index, item ->
                                 vm.searchPageState.selectedItemIndex = index
                                 vm.viewSubjectDetails(item)
-                                listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+                                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                    listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+                                }
                             },
                             navigator = listDetailNavigator,
                             contentWindowInsets = WindowInsets.safeDrawing, // 不包含 macos 标题栏, 因为左侧有 navigation rail

--- a/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/MainScene.kt
@@ -64,7 +64,7 @@ import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBar
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBarPadding
-import me.him188.ani.app.ui.foundation.layout.isAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.setRequestFullScreen
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
@@ -122,7 +122,7 @@ private fun MainSceneContent(
                         { onNavigateToPage(MainScenePage.Search) },
                         Modifier
                             .desktopTitleBarPadding()
-                            .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.windowHeightSizeClass.isAtLeastMedium) {
+                            .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.isHeightAtLeastMedium) {
                                 // 移动端横屏不增加额外 padding
                                 padding(vertical = 48.dp)
                             },
@@ -134,7 +134,7 @@ private fun MainSceneContent(
                 navigationRailFooter = {
                     NavigationRailItem(
                         modifier = Modifier.padding(bottom = itemSpacing)
-                            .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.windowHeightSizeClass.isAtLeastMedium) {
+                            .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.isHeightAtLeastMedium) {
                                 // 移动端横屏不增加额外 padding
                                 padding(vertical = 16.dp)
                             },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -76,8 +76,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.window.core.layout.WindowHeightSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -105,10 +103,14 @@ import me.him188.ani.app.ui.foundation.effects.OnLifecycleEvent
 import me.him188.ani.app.ui.foundation.effects.ScreenOnEffect
 import me.him188.ani.app.ui.foundation.effects.ScreenRotationEffect
 import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBarPadding
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isHeightCompact
 import me.him188.ani.app.ui.foundation.layout.isSystemInFullscreen
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastExpanded
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 import me.him188.ani.app.ui.foundation.layout.setRequestFullScreen
 import me.him188.ani.app.ui.foundation.layout.setSystemBarVisible
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
@@ -228,14 +230,12 @@ private fun EpisodeSceneContent(
 
     BoxWithConstraints(modifier) {
         val windowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass
-        val width = windowSizeClass.windowWidthSizeClass
-        val height = windowSizeClass.windowHeightSizeClass
 
         val showExpandedUI = when {
-            width == WindowWidthSizeClass.COMPACT && height == WindowHeightSizeClass.COMPACT -> false
-            width == WindowWidthSizeClass.COMPACT && height > WindowHeightSizeClass.COMPACT -> false
-            width > WindowWidthSizeClass.COMPACT && height == WindowHeightSizeClass.COMPACT -> true // #1279
-            windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.EXPANDED -> true // #932
+            windowSizeClass.isWidthCompact && windowSizeClass.isHeightCompact -> false
+            windowSizeClass.isWidthCompact && windowSizeClass.isHeightAtLeastMedium -> false
+            windowSizeClass.isWidthAtLeastMedium && windowSizeClass.isHeightCompact -> true // #1279
+            windowSizeClass.isWidthAtLeastExpanded -> true // #932
             else -> false
         }
         val pageState = vm.pageState.collectAsStateWithLifecycle()

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorFilters.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorFilters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -26,6 +26,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -142,8 +144,9 @@ private fun <T : Any> MediaSelectorFilterChip(
     val selectedState by rememberUpdatedState(selected)
 
     Box {
+        val chipSelected = isSingleValue || selected != null
         InputChip(
-            selected = isSingleValue || selected != null,
+            selected = chipSelected,
             onClick = {
                 if (!isSingleValue) {
                     showDropdown = true
@@ -181,6 +184,11 @@ private fun <T : Any> MediaSelectorFilterChip(
                 }
             },
             modifier = modifier.heightIn(min = 40.dp),
+            border = InputChipDefaults.inputChipBorder(
+                enabled = true, chipSelected,
+                // M3 spec is outlineVariant, but we use outline for prominent visual
+                borderColor = MaterialTheme.colorScheme.outline,
+            ),
         )
 
         DropdownMenu(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultsView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultsView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -36,6 +36,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -362,6 +363,11 @@ private fun MediaSourceResultCard(
                     source.info,
                 )
             },
+            border = InputChipDefaults.inputChipBorder(
+                enabled = true,
+                selected = selected,
+                borderColor = MaterialTheme.colorScheme.outline,
+            ),
         )
     }
 }

--- a/app/shared/src/commonTest/kotlin/ui/framework/AniComposeUiTest.kt
+++ b/app/shared/src/commonTest/kotlin/ui/framework/AniComposeUiTest.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.framework
 
 import androidx.compose.runtime.Composable
@@ -27,14 +36,7 @@ internal abstract class AbstractAniComposeUiTest(override val composeUiTest: Com
         get() = composeUiTest.mainClock
 
     override fun <T> runOnUiThread(action: () -> T): T = composeUiTest.runOnUiThread(action)
-    override fun <T> runOnIdle(action: () -> T): T {
-        waitForIdle()
-        val res = runOnUiThread {
-            action()
-        }
-        waitForIdle()
-        return res
-    }
+    override fun <T> runOnIdle(action: () -> T): T = composeUiTest.runOnIdle(action)
 
     override fun waitForIdle() = composeUiTest.waitForIdle()
     override suspend fun awaitIdle() = composeUiTest.awaitIdle()

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
@@ -144,6 +145,10 @@ class EpisodeVideoControllerTest {
         get() = onNodeWithTag(TAG_DANMAKU_EDITOR, useUnmergedTree = true)
     private val SemanticsNodeInteractionsProvider.danmakuIconButton
         get() = onNodeWithTag(TAG_DANMAKU_ICON_BUTTON, useUnmergedTree = true)
+    private val SemanticsNodeInteractionsProvider.player
+        get() = onNodeWithTag("PLAYER", useUnmergedTree = true)
+    private val SemanticsNodeInteractionsProvider.mediaProgressIndicatorText: SemanticsNodeInteraction
+        get() = onNodeWithTag(TAG_MEDIA_PROGRESS_INDICATOR_TEXT, useUnmergedTree = true)
 
     @Composable
     private fun Player(gestureFamily: GestureFamily, playerControllerState: PlayerControllerState = controllerState) {
@@ -242,6 +247,7 @@ class EpisodeVideoControllerTest {
                     )
                 },
                 gestureFamily = gestureFamily,
+                modifier = Modifier.testTag("PLAYER"),
             )
         }
     }
@@ -587,38 +593,34 @@ class EpisodeVideoControllerTest {
         waitForIdle()
         val root = onAllNodes(isRoot()).onFirst()
 
-        runOnUiThread {
-            mainClock.autoAdvance = false
-            root.performClick()// 显示全部控制器
-        }
-        runOnIdle {
-            mainClock.advanceTimeBy(1000L)
-            waitUntil { topBar.exists() }
-            detachedProgressSlider.assertDoesNotExist()
-        }
+        mainClock.autoAdvance = false
+        root.performClick() // 显示全部控制器
+        mainClock.advanceTimeBy(1000L)
+        waitForIdle()
+
+        topBar.assertExists()
+        detachedProgressSlider.assertDoesNotExist()
 
         mainClock.autoAdvance = false
-        runOnUiThread {
-            progressSlider.performTouchInput {
-                down(centerLeft)
-                moveBy(Offset(centerX, 0f))
-            }
+        root.performTouchInput {
+            down(centerLeft)
+            moveBy(Offset(centerX, 0f))
         }
-        runOnIdle {
-            waitUntil { onNodeWithTag(TAG_MEDIA_PROGRESS_INDICATOR_TEXT, useUnmergedTree = true).exists() }
-            onNodeWithTag(TAG_MEDIA_PROGRESS_INDICATOR_TEXT, useUnmergedTree = true).assertTextEquals("00:48 / 01:40")
+        waitForIdle() // does nothing because autoAdvance is false
+        mainClock.advanceTimeByFrame() // renders the next frame (i.e. update derivedStateOf and Text)
+        mediaProgressIndicatorText.assertTextEquals("00:47 / 01:40")
+        runOnUiThread {
             assertEquals(NORMAL_VISIBLE, controllerState.visibility)
         }
 
         // 松开手指
-        runOnUiThread {
-            root.performTouchInput {
-                up()
-            }
+        root.performTouchInput {
+            up()
         }
+        waitForIdle()
 
         runOnIdle {
-            waitUntil { onNodeWithText("00:48 / 01:40").exists() }
+            waitUntil { onNodeWithText("00:47 / 01:40").exists() }
             assertEquals(NORMAL_VISIBLE, controllerState.visibility)
         }
     }
@@ -1039,20 +1041,18 @@ class EpisodeVideoControllerTest {
             )
         }
 
-        val root = onAllNodes(isRoot()).onFirst()
         // 显示控制器
-        runOnUiThread {
-            mainClock.autoAdvance = false
-            root.performTouchInput {
-                if (gestureFamily == GestureFamily.MOUSE) {
-                    swipe(centerLeft, center)
-                } else {
-                    click()
-                }
+        mainClock.autoAdvance = false
+        if (gestureFamily == GestureFamily.MOUSE) {
+            player.slightlyMoveFromCenterToRight()
+        } else {
+            player.performMouseInput {
+                click()
             }
         }
+        mainClock.advanceTimeBy(1000)
         runOnIdle {
-            mainClock.advanceTimeUntil { topBar.exists() }
+            topBar.assertExists()
             assertEquals(
                 NORMAL_VISIBLE,
                 controllerState.visibility,
@@ -1071,6 +1071,11 @@ class EpisodeVideoControllerTest {
             assertEquals(expectAlwaysOn, controllerState.alwaysOn)
             assertControllerVisible(expectAlwaysOn)
         }
+    }
+
+    private fun SemanticsNodeInteraction.slightlyMoveFromCenterToRight() = performMouseInput {
+        moveTo(center, delayMillis = 0)
+        moveBy(Offset(100f, 0f), delayMillis = 0)
     }
 
     private fun AniComposeUiTest.assertControllerVisible(visible: Boolean) = runOnIdle {

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AdaptiveSearchBar.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AdaptiveSearchBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -17,11 +17,10 @@ import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.utils.platform.isMobile
 
 /**
@@ -40,7 +39,7 @@ fun AdaptiveSearchBar(
     windowInsets: WindowInsets = AniWindowInsets.forSearchBar(),
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    if (currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM
+    if (currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium
         && !LocalPlatform.current.isMobile() // #1104
     ) {
         PopupSearchBar(

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniListDetailPaneScaffold.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniListDetailPaneScaffold.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -26,9 +26,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldDefaults
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -36,6 +34,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -43,6 +42,8 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
 import me.him188.ani.app.ui.foundation.layout.ListDetailAnimatedPane
 import me.him188.ani.app.ui.foundation.layout.LocalSharedTransitionScopeProvider
@@ -105,8 +106,11 @@ fun <T> AniListDetailPaneScaffold(
     listPanePreferredWidth: Dp = Dp.Unspecified,
     layoutParameters: ListDetailLayoutParameters = ListDetailLayoutParameters.calculate(navigator.scaffoldDirective),
 ) {
+    val coroutineScope = rememberCoroutineScope()
     BackHandler(navigator.canNavigateBack()) {
-        navigator.navigateBack()
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) { // start immediately to change state
+            navigator.navigateBack()
+        }
     }
     val layoutParametersState by rememberUpdatedState(layoutParameters)
     val contentWindowInsetsState by rememberUpdatedState(contentWindowInsets)
@@ -124,8 +128,6 @@ fun <T> AniListDetailPaneScaffold(
                                 object : PaneScope {
                                     override val listDetailLayoutParameters: ListDetailLayoutParameters
                                         get() = layoutParametersState
-                                    override val role: ThreePaneScaffoldRole
-                                        get() = threePaneScaffoldScope.role
 
                                     override val paneContentWindowInsets: WindowInsets
                                         get() = when {
@@ -191,8 +193,6 @@ fun <T> AniListDetailPaneScaffold(
                                 object : PaneScope {
                                     override val listDetailLayoutParameters: ListDetailLayoutParameters
                                         get() = layoutParametersState
-                                    override val role: ThreePaneScaffoldRole
-                                        get() = threePaneScaffoldScope.role
 
                                     override val paneContentWindowInsets: WindowInsets
                                         get() = when {
@@ -242,12 +242,6 @@ interface PaneScope {
      */
     @Stable
     val listDetailLayoutParameters: ListDetailLayoutParameters
-
-    /**
-     * @see ListDetailPaneScaffoldRole
-     */
-    @Stable
-    val role: ThreePaneScaffoldRole
 
     /**
      * @see ListDetailLayoutParameters.isSinglePane

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniTopAppBar.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniTopAppBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -42,12 +42,12 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.ui.foundation.interaction.WindowDragArea
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
-import me.him188.ani.app.ui.foundation.layout.isAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastExpanded
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
@@ -92,7 +92,7 @@ fun AniTopAppBar(
     val windowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass
     WindowDragArea {
         val additionalPadding =
-            if (windowSizeClass.windowWidthSizeClass.isAtLeastMedium && windowSizeClass.windowHeightSizeClass.isAtLeastMedium) {
+            if (windowSizeClass.isWidthAtLeastMedium && windowSizeClass.isHeightAtLeastMedium) {
                 8.dp
             } else {
                 0.dp
@@ -127,8 +127,8 @@ fun AniTopAppBar(
                         ),
                 ) {
                     val minSize =
-                        if (windowSizeClass.windowWidthSizeClass.isAtLeastMedium
-                            && windowSizeClass.windowHeightSizeClass.isAtLeastMedium
+                        if (windowSizeClass.isWidthAtLeastMedium
+                            && windowSizeClass.isHeightAtLeastMedium
                         ) {
                             48.dp
                         } else {
@@ -175,7 +175,7 @@ private fun AdaptiveSearchBarLayout(
 ) {
     BoxWithConstraints(modifier) {
         AnimatedContent(
-            calculateSearchBarSize(windowSizeClass.windowWidthSizeClass, maxWidth),
+            calculateSearchBarSize(windowSizeClass, maxWidth),
             Modifier.animateContentSize(),
             transitionSpec = { expandHorizontally(snap()) togetherWith shrinkHorizontally(snap()) },
             contentAlignment = Alignment.CenterEnd,
@@ -217,14 +217,14 @@ private enum class SearchBarSize {
 }
 
 private fun calculateSearchBarSize(
-    windowWidthSizeClass: WindowWidthSizeClass,
+    windowSizeClass: WindowSizeClass,
     maxWidth: Dp,
 ): SearchBarSize {
     return when {
-        windowWidthSizeClass >= WindowWidthSizeClass.EXPANDED && maxWidth >= 360.dp
+        windowSizeClass.isWidthAtLeastExpanded && maxWidth >= 360.dp
             -> SearchBarSize.EXPANDED
 
-        windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM && maxWidth >= 240.dp -> SearchBarSize.MEDIUM
+        windowSizeClass.isWidthAtLeastMedium && maxWidth >= 240.dp -> SearchBarSize.MEDIUM
         else -> SearchBarSize.ICON_BUTTON
     }
 }

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/navigation/AniNavigationSuiteScaffold.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/navigation/AniNavigationSuiteScaffold.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -24,12 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.window.core.layout.WindowHeightSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.ui.foundation.interaction.WindowDragArea
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
 import me.him188.ani.app.ui.foundation.layout.Zero
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isHeightCompact
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastExpanded
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 
 /**
@@ -86,19 +87,19 @@ object AniNavigationSuiteDefaults {
     fun calculateLayoutType(adaptiveInfo: WindowAdaptiveInfo): NavigationSuiteType {
         return with(adaptiveInfo) {
             // ani changed: use NavigationRail on landscape phones
-            if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT
-                && windowSizeClass.windowWidthSizeClass != WindowWidthSizeClass.COMPACT
+            if (windowSizeClass.isHeightCompact
+                && windowSizeClass.isWidthAtLeastMedium
             ) {
                 return NavigationSuiteType.NavigationRail
             }
             // below is original logic
 
             if (windowPosture.isTabletop ||
-                windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT
+                windowSizeClass.isHeightCompact
             ) {
                 NavigationSuiteType.NavigationBar
-            } else if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED ||
-                windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.MEDIUM
+            } else if (windowSizeClass.isWidthAtLeastExpanded ||
+                windowSizeClass.isWidthAtLeastMedium
             ) {
                 NavigationSuiteType.NavigationRail
             } else {

--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/navigation/NavigationSuite.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/navigation/NavigationSuite.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -35,10 +35,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowHeightSizeClass.Companion.MEDIUM
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
 
 /**
  * @see NavigationSuite with Ani modifications:
@@ -122,7 +121,7 @@ fun AniNavigationSuite(
 
                 Spacer(Modifier.weight(1f))
 
-                if (navigationRailFooter != null && currentWindowAdaptiveInfo1().windowSizeClass.windowHeightSizeClass >= MEDIUM) {
+                if (navigationRailFooter != null && currentWindowAdaptiveInfo1().windowSizeClass.isHeightAtLeastMedium) {
                     val itemScope = remember(this) {
                         NavigationRailItemScopeImpl(
                             this,

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/ExplorationPage.kt
@@ -67,7 +67,7 @@ import me.him188.ani.app.ui.foundation.HorizontalScrollControlState
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
 import me.him188.ani.app.ui.foundation.layout.CarouselItemDefaults
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
-import me.him188.ani.app.ui.foundation.layout.isAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.rememberHorizontalScrollControlState
 import me.him188.ani.app.ui.foundation.session.SelfAvatar
@@ -128,7 +128,7 @@ fun ExplorationPage(
                 actions = {
                     actions()
                     if (state.authState.isKnownGuest // #1269 游客模式下无法打开设置界面
-                        || currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass.isAtLeastMedium
+                        || currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium
                     ) {
                         IconButton(onClick = onClickSettings) {
                             Icon(Icons.Rounded.Settings, "设置")

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/followed/FollowedSubjectsLazyRow.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/followed/FollowedSubjectsLazyRow.kt
@@ -43,8 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
-import androidx.window.core.layout.WindowHeightSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.data.models.preference.NsfwMode
 import me.him188.ani.app.data.models.subject.FollowedSubjectInfo
 import me.him188.ani.app.data.models.subject.hasNewEpisodeToPlay
@@ -53,8 +51,10 @@ import me.him188.ani.app.ui.external.placeholder.placeholder
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.layout.BasicCarouselItem
 import me.him188.ani.app.ui.foundation.layout.CarouselItemDefaults
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastExpanded
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.minimumHairlineSize
 import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.widgets.NsfwMask
@@ -219,12 +219,12 @@ data class FollowedSubjectsLayoutParameters(
 object FollowedSubjectsDefaults {
     @Composable
     fun layoutParameters(windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo1()): FollowedSubjectsLayoutParameters {
-        val width = windowAdaptiveInfo.windowSizeClass.windowWidthSizeClass
+        val windowSizeClass = windowAdaptiveInfo.windowSizeClass
         return FollowedSubjectsLayoutParameters(
             imageSize = imageSize(windowAdaptiveInfo),
             horizontalArrangement = when {
-                width >= WindowWidthSizeClass.EXPANDED -> Arrangement.spacedBy(16.dp)
-                width >= WindowWidthSizeClass.MEDIUM -> Arrangement.spacedBy(12.dp)
+                windowSizeClass.isWidthAtLeastExpanded -> Arrangement.spacedBy(16.dp)
+                windowSizeClass.isWidthAtLeastMedium -> Arrangement.spacedBy(12.dp)
                 else -> Arrangement.spacedBy(8.dp)
             },
             shape = MaterialTheme.shapes.large,
@@ -233,11 +233,9 @@ object FollowedSubjectsDefaults {
 
     private fun imageSize(windowAdaptiveInfo: WindowAdaptiveInfo): DpSize {
         val windowSizeClass = windowAdaptiveInfo.windowSizeClass
-        val height = windowSizeClass.windowHeightSizeClass
-        val width = windowSizeClass.windowWidthSizeClass
         val baseSize = when {
-            height >= WindowHeightSizeClass.MEDIUM && width >= WindowWidthSizeClass.EXPANDED -> 160.dp
-            height >= WindowHeightSizeClass.MEDIUM && width >= WindowWidthSizeClass.MEDIUM -> 140.dp
+            windowSizeClass.isHeightAtLeastMedium && windowSizeClass.isWidthAtLeastExpanded -> 160.dp
+            windowSizeClass.isHeightAtLeastMedium && windowSizeClass.isWidthAtLeastMedium -> 140.dp
             else -> 120.dp
         }
         return DpSize(baseSize, (baseSize) / 9 * 16)

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/schedule/SchedulePage.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DayOfWeek
 import me.him188.ani.app.ui.adaptive.AniTopAppBar
@@ -65,8 +64,8 @@ import me.him188.ani.app.ui.adaptive.HorizontalScrollControlScaffoldOnDesktop
 import me.him188.ani.app.ui.foundation.HorizontalScrollControlState
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.pagerTabIndicatorOffset
 import me.him188.ani.app.ui.foundation.rememberHorizontalScrollControlState
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
@@ -337,7 +336,7 @@ data class SchedulePageLayoutParams private constructor(
 
         @Composable
         fun calculate(windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass): SchedulePageLayoutParams {
-            return if (windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM) {
+            return if (windowSizeClass.isWidthAtLeastMedium) {
                 Medium
             } else {
                 Compact

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
-import androidx.window.core.layout.WindowWidthSizeClass
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -61,8 +60,8 @@ import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.interaction.keyboardDirectionToSelectItem
 import me.him188.ani.app.ui.foundation.interaction.keyboardPageToScroll
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.layout.paneVerticalPadding
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
@@ -99,7 +98,7 @@ fun SearchPage(
                 state.suggestionSearchBarState,
                 Modifier
                     .ifThen(
-                        currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM
+                        currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium
                                 || !state.suggestionSearchBarState.expanded,
                     ) { contentPadding },
                 placeholder = { Text("搜索") },

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -84,8 +84,11 @@ fun SearchPage(
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
     navigationIcon: @Composable () -> Unit = {},
 ) {
+    val coroutineScope = rememberCoroutineScope()
     BackHandler(navigator.canNavigateBack()) {
-        navigator.navigateBack()
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            navigator.navigateBack()
+        }
     }
 
     val items = state.items
@@ -141,7 +144,13 @@ fun SearchPage(
         modifier,
         navigationIcon = {
             if (navigator.canNavigateBack()) {
-                BackNavigationIconButton({ navigator.navigateBack() })
+                BackNavigationIconButton(
+                    {
+                        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                            navigator.navigateBack()
+                        }
+                    },
+                )
             } else {
                 navigationIcon()
             }
@@ -293,6 +302,7 @@ internal fun SearchPageLayout(
     contentWindowInsets: WindowInsets = AniWindowInsets.forPageContent(),
     searchBarHeight: Dp = 64.dp,
 ) {
+    val coroutineScope = rememberCoroutineScope()
     AniListDetailPaneScaffold(
         navigator,
         listPaneTopAppBar = {
@@ -301,7 +311,13 @@ internal fun SearchPageLayout(
                 Modifier.fillMaxWidth(),
                 navigationIcon = {
                     if (navigator.canNavigateBack()) {
-                        BackNavigationIconButton({ navigator.navigateBack() })
+                        BackNavigationIconButton(
+                            onNavigateBack = {
+                                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                    navigator.navigateBack()
+                                }
+                            },
+                        )
                     } else {
                         navigationIcon()
                     }

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SubjectItem.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SubjectItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -43,12 +43,11 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowHeightSizeClass
 import androidx.window.core.layout.WindowSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.ui.foundation.AsyncImage
-import me.him188.ani.app.ui.foundation.layout.compareTo
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 
 /**
  * Design: [SubjectItem on Figma](https://www.figma.com/design/LET1n9mmDa6npDTIlUuJjU/Main?node-id=101-877&t=gmFJS6LFQudIIXfK-4)
@@ -171,9 +170,7 @@ class SubjectItemTypography(
     companion object {
         @Composable
         fun calculate(windowSizeClass: WindowSizeClass): SubjectItemTypography {
-            if (windowSizeClass.windowWidthSizeClass > WindowWidthSizeClass.COMPACT
-                && windowSizeClass.windowHeightSizeClass > WindowHeightSizeClass.COMPACT
-            ) {
+            if (windowSizeClass.isWidthAtLeastMedium && windowSizeClass.isHeightAtLeastMedium) {
                 // medium
                 return SubjectItemTypography(
                     titleStyle = MaterialTheme.typography.titleLarge,
@@ -232,9 +229,7 @@ class SubjectItemLayoutParameters(
         @Composable
         @Stable
         fun calculate(windowSizeClass: WindowSizeClass): SubjectItemLayoutParameters {
-            if (windowSizeClass.windowWidthSizeClass > WindowWidthSizeClass.COMPACT
-                && windowSizeClass.windowHeightSizeClass > WindowHeightSizeClass.COMPACT
-            ) {
+            if (windowSizeClass.isWidthAtLeastMedium && windowSizeClass.isHeightAtLeastMedium) {
                 return MEDIUM
             }
             return COMPACT

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/CarouselItem.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/CarouselItem.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowWidthSizeClass
+import androidx.window.core.layout.WindowSizeClass
 import me.him188.ani.app.ui.foundation.text.ProvideTextStyleContentColor
 import me.him188.ani.app.ui.foundation.theme.appColorScheme
 
@@ -152,7 +152,7 @@ object CarouselItemDefaults {
     @Composable
     fun itemSize(): CarouselItemSize {
         val windowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass
-        val preferredWidth = if (windowSizeClass.windowWidthSizeClass >= WindowWidthSizeClass.MEDIUM) {
+        val preferredWidth = if (windowSizeClass.containsWidthDp(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)) {
             300.dp
         } else {
             240.dp

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/ListDetailAnimatedPane.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/ListDetailAnimatedPane.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -11,18 +11,10 @@
 
 package me.him188.ani.app.ui.foundation.layout
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
-import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldScope
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldValue
+import androidx.compose.material3.adaptive.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -32,13 +24,17 @@ import me.him188.ani.app.ui.foundation.theme.EasingDurations
 import me.him188.ani.app.ui.foundation.theme.NavigationMotionScheme
 
 // 把过渡动画改为 fade 而不是带有回弹的 spring
+/**
+ * @see AnimatedPane
+ */
 @ExperimentalMaterial3AdaptiveApi
 @Composable
-fun ThreePaneScaffoldScope.ListDetailAnimatedPane(
+fun ThreePaneScaffoldPaneScope.ListDetailAnimatedPane(
     modifier: Modifier = Modifier,
     useSharedTransition: Boolean = false, // changed: for shared transitions
     content: (@Composable AnimatedVisibilityScope.() -> Unit),
 ) {
+    val role = paneRole
     val keepShowing =
         scaffoldStateTransition.currentState[role] != PaneAdaptedValue.Hidden &&
                 scaffoldStateTransition.targetState[role] != PaneAdaptedValue.Hidden
@@ -47,7 +43,7 @@ fun ThreePaneScaffoldScope.ListDetailAnimatedPane(
     scaffoldStateTransition.AnimatedVisibility(
         visible = { value: ThreePaneScaffoldValue -> value[role] != PaneAdaptedValue.Hidden },
         modifier =
-        modifier
+            modifier
 //            .animateBounds(
 //                animateFraction = animateFraction,
 //                positionAnimationSpec = tween(500, easing = EmphasizedEasing), // changed: custom animation spec
@@ -55,7 +51,7 @@ fun ThreePaneScaffoldScope.ListDetailAnimatedPane(
 //                lookaheadScope = this,
 //                enabled = keepShowing,
 //            )
-            .then(if (keepShowing) Modifier else Modifier.clipToBounds()),
+                .then(if (keepShowing) Modifier else Modifier.clipToBounds()),
         enter = when {
             useSharedTransition -> {
                 fadeIn() + expandVertically()

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/MaterialWindowMarginPaddings.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/MaterialWindowMarginPaddings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowWidthSizeClass
 
 /**
  * 每个窗口 (页面) 距离窗口边缘的间距.
@@ -28,8 +27,9 @@ fun Modifier.materialWindowMarginPadding(): Modifier = composed(
     },
 ) {
     // https://m3.material.io/foundations/layout/applying-layout
-    val values = when (currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass) {
-        WindowWidthSizeClass.COMPACT -> {
+    val windowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass
+    val values = when {
+        windowSizeClass.isWidthCompact -> {
             // https://m3.material.io/foundations/layout/applying-layout/compact#5a83ddd7-137f-4657-ba2d-eb08cac065e7
             MaterialWindowMarginPaddings.COMPACT
         }

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/WindowSizeClasses.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/layout/WindowSizeClasses.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -14,9 +14,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowHeightSizeClass
 import androidx.window.core.layout.WindowSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 
 private object PanePaddings {
     private val compactCompact = PaddingValues(horizontal = 16.dp, vertical = 16.dp)
@@ -25,9 +23,9 @@ private object PanePaddings {
     private val expandedExpanded = PaddingValues(horizontal = 24.dp, vertical = 24.dp)
 
     @Stable
-    fun get(windowWidthSizeClass: WindowWidthSizeClass, windowHeightSizeClass: WindowHeightSizeClass): PaddingValues {
-        val widthIsCompact = windowWidthSizeClass == WindowWidthSizeClass.COMPACT
-        val heightIsCompact = windowHeightSizeClass == WindowHeightSizeClass.COMPACT
+    fun get(windowSizeClass: WindowSizeClass): PaddingValues {
+        val widthIsCompact = windowSizeClass.isWidthCompact
+        val heightIsCompact = windowSizeClass.isHeightCompact
         return when {
             widthIsCompact && heightIsCompact -> compactCompact
             widthIsCompact && !heightIsCompact -> compactExpanded
@@ -40,93 +38,74 @@ private object PanePaddings {
 
 @Stable
 inline val WindowAdaptiveInfo.isWidthCompact: Boolean
-    get() = windowSizeClass.windowWidthSizeClass.isCompact
+    get() = windowSizeClass.isWidthCompact
 
 @Stable
 inline val WindowAdaptiveInfo.isWidthAtLeastMedium: Boolean
-    get() = windowSizeClass.windowWidthSizeClass.isAtLeastMedium
+    get() = windowSizeClass.isWidthAtLeastMedium
+
+@Stable
+inline val WindowAdaptiveInfo.isWidthAtLeastExpanded: Boolean
+    get() = windowSizeClass.isWidthAtLeastExpanded
 
 @Stable
 inline val WindowAdaptiveInfo.isHeightCompact: Boolean
-    get() = windowSizeClass.windowHeightSizeClass.isCompact
+    get() = windowSizeClass.isHeightCompact
 
 @Stable
 inline val WindowAdaptiveInfo.isHeightAtLeastMedium: Boolean
-    get() = windowSizeClass.windowHeightSizeClass.isAtLeastMedium
+    get() = windowSizeClass.isHeightAtLeastMedium
+
 
 @Stable
-inline val WindowWidthSizeClass.isCompact
-    get() = this == WindowWidthSizeClass.COMPACT
+inline val WindowSizeClass.isWidthCompact: Boolean
+    get() = !containsWidthDp(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
 
 @Stable
-inline val WindowWidthSizeClass.isAtLeastMedium
-    get() = this != WindowWidthSizeClass.COMPACT
+inline val WindowSizeClass.isWidthAtLeastMedium: Boolean
+    get() = containsWidthDp(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
 
 @Stable
-inline val WindowHeightSizeClass.isCompact
-    get() = this == WindowHeightSizeClass.COMPACT
+inline val WindowSizeClass.isWidthAtLeastExpanded: Boolean
+    get() = containsWidthDp(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
 
 @Stable
-inline val WindowHeightSizeClass.isAtLeastMedium
-    get() = this != WindowHeightSizeClass.COMPACT
+inline val WindowSizeClass.isHeightCompact: Boolean
+    get() = !containsHeightDp(WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND)
+
+@Stable
+inline val WindowSizeClass.isHeightAtLeastMedium: Boolean
+    get() = containsHeightDp(WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND)
+
 
 @Stable
 val WindowSizeClass.panePadding
-    get() = PanePaddings.get(windowWidthSizeClass, windowHeightSizeClass)
+    get() = PanePaddings.get(this)
 
 @Stable
 val WindowSizeClass.paneHorizontalPadding
-    get() = if (windowWidthSizeClass == WindowWidthSizeClass.COMPACT) 16.dp else 24.dp
+    get() = if (isWidthCompact) 16.dp else 24.dp
 
 @Stable
 val WindowSizeClass.paneVerticalPadding
-    get() = if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) 16.dp else 24.dp
+    get() = if (isHeightCompact) 16.dp else 24.dp
 
 /**
  * 在一个主要的滚动列表中卡片的间距
  */
 @Stable
 val WindowSizeClass.cardHorizontalPadding
-    get() = if (windowWidthSizeClass == WindowWidthSizeClass.COMPACT) 16.dp else 20.dp
+    get() = if (isWidthCompact) 16.dp else 20.dp
 
 /**
  * 在一个主要的滚动列表中卡片的间距
  */
 @Stable
 val WindowSizeClass.cardVerticalPadding
-    get() = if (windowHeightSizeClass == WindowHeightSizeClass.COMPACT) 16.dp else 20.dp
+    get() = if (isHeightCompact) 16.dp else 20.dp
 
 private val zeroInsets = WindowInsets(0.dp) // single instance to be shared
 
 @Stable
 val WindowInsets.Companion.Zero: WindowInsets
     get() = zeroInsets
-
-private val WindowWidthSizeClass.ordinal
-    get() = when (this) {
-        WindowWidthSizeClass.COMPACT -> 0
-        WindowWidthSizeClass.MEDIUM -> 1
-        WindowWidthSizeClass.EXPANDED -> 2
-        else -> {
-            error("Unsupported WindowWidthSizeClass: $this")
-        }
-    }
-
-operator fun WindowWidthSizeClass.compareTo(other: WindowWidthSizeClass): Int {
-    return ordinal.compareTo(other.ordinal)
-}
-
-
-private val WindowHeightSizeClass.ordinal
-    get() = when (this) {
-        WindowHeightSizeClass.COMPACT -> 0
-        WindowHeightSizeClass.MEDIUM -> 1
-        WindowHeightSizeClass.EXPANDED -> 2
-        else -> {
-            error("Unsupported WindowHeightSizeClass: $this")
-        }
-    }
-
-operator fun WindowHeightSizeClass.compareTo(other: WindowHeightSizeClass): Int {
-    return ordinal.compareTo(other.ordinal)
-}

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/theme/AppTheme.kt
@@ -48,7 +48,7 @@ import me.him188.ani.app.ui.foundation.animation.EmphasizedDecelerateEasing
 import me.him188.ani.app.ui.foundation.animation.StandardAccelerate
 import me.him188.ani.app.ui.foundation.animation.StandardDecelerate
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
-import me.him188.ani.app.ui.foundation.layout.isCompact
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 import kotlin.math.roundToInt
 
 /**
@@ -226,7 +226,7 @@ data class NavigationMotionScheme(
 
         @Composable
         fun calculate(windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass): NavigationMotionScheme {
-            val useSlide = windowSizeClass.windowWidthSizeClass.isCompact
+            val useSlide = windowSizeClass.isWidthCompact
 
             val enterTransition: EnterTransition = run {
                 if (useSlide) {

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/layout/WindowAdaptiveInfo.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/layout/WindowAdaptiveInfo.desktop.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -27,6 +27,7 @@ import androidx.window.core.layout.WindowSizeClass
  * @return [WindowAdaptiveInfo] of the provided context
  */
 @Composable
+@Suppress("DEPRECATION") // WindowSizeClass#compute is deprecated
 actual fun currentWindowAdaptiveInfo1(): WindowAdaptiveInfo {
     val backupState = remember { mutableStateOf<WindowAdaptiveInfo?>(null) }
 

--- a/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/EditRssMediaSource.android.kt
+++ b/app/shared/ui-settings/src/androidMain/kotlin/ui/settings/tabs/media/source/EditRssMediaSource.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -14,7 +14,7 @@ import android.content.res.Configuration.UI_MODE_TYPE_NORMAL
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -104,7 +104,7 @@ fun PreviewEditRssMediaSourcePagePhoneTest() = ProvideFoundationCompositionLocal
         edit, test, {},
         navigator = navigator,
     )
-    SideEffect {
+    LaunchedEffect(Unit) {
         navigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
     }
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsPage.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsPage.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -63,6 +64,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import me.him188.ani.app.ui.adaptive.AniListDetailPaneScaffold
 import me.him188.ani.app.ui.adaptive.AniTopAppBar
 import me.him188.ani.app.ui.adaptive.AniTopAppBarDefaults
@@ -95,7 +98,7 @@ import me.him188.ani.app.ui.settings.tabs.theme.ThemeGroup
 import me.him188.ani.utils.platform.hasScrollingBug
 
 /**
- * @see renderPreferenceTab 查看名称
+ * @see getName 查看名称
  */
 typealias SettingsTab = me.him188.ani.app.navigation.SettingsTab
 
@@ -220,6 +223,8 @@ internal fun SettingsPageLayout(
 ) = Surface(color = containerColor) {
     val layoutParametersState by rememberUpdatedState(layoutParameters)
 
+    val coroutineScope = rememberCoroutineScope()
+
     @Stable
     fun SettingsTab?.orDefault(): SettingsTab? {
         return if (layoutParametersState.isSinglePane) {
@@ -233,7 +238,7 @@ internal fun SettingsPageLayout(
 
     val currentTab by remember(navigator) {
         derivedStateOf {
-            navigator.currentDestination?.content.orDefault()
+            navigator.currentDestination?.contentKey.orDefault()
         }
     }
 
@@ -251,7 +256,13 @@ internal fun SettingsPageLayout(
                 title = { AniTopAppBarDefaults.Title("设置") },
                 navigationIcon = {
                     if (navigator.canNavigateBack()) {
-                        BackNavigationIconButton({ navigator.navigateBack() })
+                        BackNavigationIconButton(
+                            onNavigateBack = {
+                                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                    navigator.navigateBack()
+                                }
+                            },
+                        )
                     } else {
                         navigationIcon()
                     }
@@ -281,7 +292,11 @@ internal fun SettingsPageLayout(
                                 icon = { Icon(getIcon(item), contentDescription = null) },
                                 label = { Text(getName(item)) },
                                 selected = item == currentTab,
-                                onClick = { navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, item) },
+                                onClick = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, item)
+                                    }
+                                },
                             )
                         }
                     }
@@ -298,7 +313,7 @@ internal fun SettingsPageLayout(
         // empty because our detailPaneContent already has it
         detailPane = {
             AnimatedContent(
-                navigator.currentDestination?.content,
+                navigator.currentDestination?.contentKey,
                 Modifier
                     .fillMaxSize(),
                 transitionSpec = AniThemeDefaults.standardAnimatedContentTransition,
@@ -313,7 +328,11 @@ internal fun SettingsPageLayout(
                             navigationIcon = {
                                 if (listDetailLayoutParameters.isSinglePane) {
                                     BackNavigationIconButton(
-                                        { navigator.navigateBack(BackNavigationBehavior.PopUntilScaffoldValueChange) },
+                                        {
+                                            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                                navigator.navigateBack(BackNavigationBehavior.PopUntilScaffoldValueChange)
+                                            }
+                                        },
                                     )
                                 }
                             },

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/components/SettingsScope.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/components/SettingsScope.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -39,7 +39,7 @@ import me.him188.ani.app.ui.foundation.theme.weaken
 object SettingsDefaults {
     val groupBackgroundColor
         @Composable
-        get() = Color.Unspecified
+        get() = MaterialTheme.colorScheme.surfaceContainerLow
 
     @Composable
     fun listItemColors() = ListItemDefaults.colors(containerColor = groupBackgroundColor)

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/components/SettingsScope.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/components/SettingsScope.kt
@@ -39,7 +39,7 @@ import me.him188.ani.app.ui.foundation.theme.weaken
 object SettingsDefaults {
     val groupBackgroundColor
         @Composable
-        get() = MaterialTheme.colorScheme.surfaceContainerLow
+        get() = Color.Transparent
 
     @Composable
     fun listItemColors() = ListItemDefaults.colors(containerColor = groupBackgroundColor)

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/EditMediaSourceTestDataCardDefaults.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/EditMediaSourceTestDataCardDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.ui.foundation.effects.moveFocusOnEnter
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
-import me.him188.ani.app.ui.foundation.layout.isCompact
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 
 @Stable
 object EditMediaSourceTestDataCardDefaults {
@@ -52,7 +52,7 @@ object EditMediaSourceTestDataCardDefaults {
         content: @Composable FlowRowScope.() -> Unit
     ) {
         BoxWithConstraints {
-            val isCompact = currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass.isCompact
+            val isCompact = currentWindowAdaptiveInfo1().windowSizeClass.isWidthCompact
             androidx.compose.foundation.layout.FlowRow(
                 modifier.padding(all = 16.dp).padding(bottom = 4.dp).focusGroup(),
                 verticalArrangement = if (isCompact) {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.window.core.layout.WindowWidthSizeClass
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import me.him188.ani.app.domain.mediasource.codec.MediaSourceCodecManager
@@ -58,6 +57,7 @@ import me.him188.ani.app.ui.foundation.layout.PaddingValuesSides
 import me.him188.ani.app.ui.foundation.layout.ThreePaneScaffoldValueConverter.ExtraPaneForNestedDetails
 import me.him188.ani.app.ui.foundation.layout.convert
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.only
 import me.him188.ani.app.ui.foundation.layout.panePadding
 import me.him188.ani.app.ui.foundation.navigation.BackHandler
@@ -288,7 +288,7 @@ fun EditRssMediaSourcePage(
                 ListDetailAnimatedPane {
                     Crossfade(testState.viewingItem) { item ->
                         item ?: return@Crossfade
-                        if (currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass != WindowWidthSizeClass.COMPACT) {
+                        if (currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium) {
                             SideSheetPane(
                                 onClose = {
                                     coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/EditRssMediaSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -41,10 +41,13 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import me.him188.ani.app.domain.mediasource.codec.MediaSourceCodecManager
 import me.him188.ani.app.domain.mediasource.rss.RssMediaSource
 import me.him188.ani.app.domain.mediasource.rss.RssMediaSourceArguments
@@ -162,13 +165,15 @@ fun EditRssMediaSourcePage(
     testState: RssTestPaneState,
     mediaDetailsColumn: @Composable (Media) -> Unit,
     modifier: Modifier = Modifier,
-    navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
+    navigator: ThreePaneScaffoldNavigator<*> = rememberListDetailPaneScaffoldNavigator(),
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
     navigationIcon: @Composable () -> Unit = {},
 ) {
     LaunchedEffect(Unit) {
         testState.searcher.observeTestDataChanges(testState.testDataState)
     }
+
+    val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
         modifier
@@ -191,7 +196,13 @@ fun EditRssMediaSourcePage(
                     },
                     navigationIcon = {
                         if (navigator.canNavigateBack()) {
-                            BackNavigationIconButton({ navigator.navigateBack() })
+                            BackNavigationIconButton(
+                                onNavigateBack = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        navigator.navigateBack()
+                                    }
+                                },
+                            )
                         } else {
                             navigationIcon()
                         }
@@ -200,7 +211,13 @@ fun EditRssMediaSourcePage(
                     windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                     actions = {
                         if (navigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] == PaneAdaptedValue.Hidden) {
-                            TextButton({ navigator.navigateTo(ListDetailPaneScaffoldRole.Detail) }) {
+                            TextButton(
+                                onClick = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        navigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+                                    }
+                                },
+                            ) {
                                 Text("测试")
                             }
                         }
@@ -230,7 +247,9 @@ fun EditRssMediaSourcePage(
         contentWindowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
     ) { paddingValues ->
         BackHandler(navigator.canNavigateBack()) {
-            navigator.navigateBack()
+            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                navigator.navigateBack()
+            }
         }
 
         val panePadding = currentWindowAdaptiveInfo1().windowSizeClass.panePadding
@@ -251,7 +270,11 @@ fun EditRssMediaSourcePage(
                 ListDetailAnimatedPane {
                     RssTestPane(
                         testState,
-                        { navigator.navigateTo(ListDetailPaneScaffoldRole.Extra) },
+                        onNavigateToDetails = {
+                            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                navigator.navigateTo(ListDetailPaneScaffoldRole.Extra)
+                            }
+                        },
                         Modifier.fillMaxSize(),
                         contentPadding = panePaddingVertical,
                     )
@@ -267,7 +290,11 @@ fun EditRssMediaSourcePage(
                         item ?: return@Crossfade
                         if (currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass != WindowWidthSizeClass.COMPACT) {
                             SideSheetPane(
-                                onClose = { navigator.navigateBack() },
+                                onClose = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        navigator.navigateBack()
+                                    }
+                                },
                                 Modifier.padding(panePaddingVertical),
                             ) {
                                 RssDetailPane(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/edit/MediaSourceHeadline.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/rss/edit/MediaSourceHeadline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -28,10 +28,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.LocalIsPreviewing
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 
 @Immutable
 internal class MediaSourceHeadlineStyle(
@@ -42,8 +42,9 @@ internal class MediaSourceHeadlineStyle(
 
 @Composable
 internal fun computeMediaSourceHeadlineStyle(): MediaSourceHeadlineStyle {
-    return when (currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass) {
-        WindowWidthSizeClass.COMPACT -> {
+    val windowSizeClass = currentWindowAdaptiveInfo1().windowSizeClass
+    return when {
+        windowSizeClass.isWidthCompact -> {
             MediaSourceHeadlineStyle(
                 imageSize = DpSize(96.dp, 96.dp),
                 titleTextStyle = MaterialTheme.typography.headlineMedium,

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/torrent/peer/PeerFilterSettings.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/torrent/peer/PeerFilterSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -40,6 +41,8 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import me.him188.ani.app.ui.adaptive.AniListDetailPaneScaffold
 import me.him188.ani.app.ui.adaptive.AniTopAppBar
 import me.him188.ani.app.ui.adaptive.AniTopAppBarDefaults
@@ -53,9 +56,10 @@ import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 fun PeerFilterSettingsPage(
     state: PeerFilterSettingsState,
     modifier: Modifier = Modifier,
-    navigator: ThreePaneScaffoldNavigator<Nothing> = rememberListDetailPaneScaffoldNavigator(),
+    navigator: ThreePaneScaffoldNavigator<Any> = rememberListDetailPaneScaffoldNavigator(),
     navigationIcon: @Composable () -> Unit = {},
 ) {
+    val coroutineScope = rememberCoroutineScope()
     Surface(color = AniThemeDefaults.pageContentBackgroundColor) {
         AniListDetailPaneScaffold(
             navigator = navigator,
@@ -67,7 +71,13 @@ fun PeerFilterSettingsPage(
                     windowInsets = paneContentWindowInsets.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
                     navigationIcon = {
                         if (navigator.canNavigateBack()) {
-                            BackNavigationIconButton({ navigator.navigateBack() })
+                            BackNavigationIconButton(
+                                onNavigateBack = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        navigator.navigateBack()
+                                    }
+                                },
+                            )
                         } else {
                             navigationIcon()
                         }
@@ -78,7 +88,11 @@ fun PeerFilterSettingsPage(
                 PeerFilterEditPane(
                     state = state,
                     showIpBlockingItem = listDetailLayoutParameters.isSinglePane,
-                    onClickIpBlockSettings = { navigator.navigateTo(ThreePaneScaffoldRole.Primary) },
+                    onClickIpBlockSettings = {
+                        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                            navigator.navigateTo(ThreePaneScaffoldRole.Primary)
+                        }
+                    },
                     modifier = Modifier
                         .paneContentPadding(
                             extraStart = -SettingsScope.itemHorizontalPadding,
@@ -98,9 +112,11 @@ fun PeerFilterSettingsPage(
                         state = state,
                         navigationIcon = {
                             BackNavigationIconButton(
-                                {
-                                    if (navigator.canNavigateBack()) {
-                                        navigator.navigateBack()
+                                onNavigateBack = {
+                                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                        if (navigator.canNavigateBack()) {
+                                            navigator.navigateBack()
+                                        }
                                     }
                                 },
                             )

--- a/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/collection/SubjectCollectionAction.android.kt
+++ b/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/collection/SubjectCollectionAction.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -12,6 +12,7 @@ package me.him188.ani.app.ui.subject.collection
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,13 +24,15 @@ import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 @Composable
 @Preview
 fun PreviewCollectionActionButton() = ProvideFoundationCompositionLocalsForPreview {
-    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Column {
-            for (entry in UnifiedCollectionType.entries) {
-                SubjectCollectionTypeButton(
-                    type = entry,
-                    onEdit = {},
-                )
+    Surface {
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Column {
+                for (entry in UnifiedCollectionType.entries) {
+                    SubjectCollectionTypeButton(
+                        type = entry,
+                        onEdit = {},
+                    )
+                }
             }
         }
     }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
@@ -93,7 +93,7 @@ import me.him188.ani.app.ui.adaptive.AniTopAppBarDefaults
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.AniWindowInsets
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
-import me.him188.ani.app.ui.foundation.layout.isAtLeastMedium
+import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.session.SelfAvatar
 import me.him188.ani.app.ui.foundation.session.SessionTipsArea
@@ -198,7 +198,7 @@ fun CollectionPage(
     CollectionPageLayout(
         settingsIcon = {
             if (state.authState.isKnownGuest // #1269 游客模式下无法打开设置界面
-                || currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass.isAtLeastMedium
+                || currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium
             ) {
                 IconButton(onClick = onClickSettings) {
                     Icon(Icons.Rounded.Settings, "设置")

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -53,12 +53,12 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
-import androidx.window.core.layout.WindowWidthSizeClass
 import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
 import me.him188.ani.app.domain.foundation.LoadError
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 import me.him188.ani.app.ui.search.LoadErrorCard
@@ -84,7 +84,7 @@ fun SubjectCollectionsColumn(
     gridState: LazyGridState = rememberLazyGridState(),
     enableAnimation: Boolean = true,
 ) {
-    val isCompact = currentWindowAdaptiveInfo1().windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT
+    val isCompact = currentWindowAdaptiveInfo1().windowSizeClass.isWidthCompact
     val spacedBy = if (isCompact) 16.dp else 24.dp
 
     LazyVerticalGrid(

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditableSubjectCollectionTypeButton.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditableSubjectCollectionTypeButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -147,8 +147,8 @@ fun EditableSubjectCollectionTypeButton(
         onEdit = {
             state.setSelfCollectionType(it)
         },
-        enabled = !presentation.isSetSelfCollectionTypeWorking,
         modifier = modifier.placeholder(presentation.isPlaceholder),
+        enabled = !presentation.isSetSelfCollectionTypeWorking,
     )
 }
 

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/SubjectCollectionTypeButton.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/SubjectCollectionTypeButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -37,7 +36,7 @@ object SubjectCollectionTypeButtonDefaults {
     )
 
     @Composable
-    fun collectedBorder() = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(0.612f))
+    fun collectedBorder() = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
 }
 
 /**
@@ -56,8 +55,6 @@ fun SubjectCollectionTypeButton(
     onEdit: (newType: UnifiedCollectionType) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    collectedColors: ButtonColors = SubjectCollectionTypeButtonDefaults.collectedButtonColors(),
-    collectedBorder: BorderStroke = SubjectCollectionTypeButtonDefaults.collectedBorder(),
 ) {
     val action = remember(type) {
         SubjectCollectionActionsForCollect.find { it.type == type }
@@ -72,9 +69,15 @@ fun SubjectCollectionTypeButton(
         if (type != UnifiedCollectionType.NOT_COLLECTED) {
             OutlinedButton(
                 onClick = onClick,
-                colors = collectedColors,
-                border = collectedBorder,
                 enabled = enabled,
+//                border = BorderStroke(
+//                    width = 1.dp,
+//                    color = if (enabled) {
+//                        MaterialTheme.colorScheme.outline
+//                    } else {
+//                        MaterialTheme.colorScheme.outline.copy(alpha = 0.1f)
+//                    },
+//                ),
             ) {
                 if (action != null) {
                     action.icon()

--- a/app/shared/video-player/src/commonMain/kotlin/ui/guesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/guesture/PlayerGestureHost.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import me.him188.ani.app.tools.rememberUiMonoTasker
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.effects.ComposeKey
@@ -90,6 +91,7 @@ import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.isSystemInFullscreen
 import me.him188.ani.app.utils.fixToString
+import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.guesture.GestureIndicatorState.State.BRIGHTNESS
 import me.him188.ani.app.videoplayer.ui.guesture.GestureIndicatorState.State.FAST_BACKWARD
@@ -523,11 +525,10 @@ fun PlayerGestureHost(
                         val scope = rememberUiMonoTasker()
                         // 没有人请求 alwaysOn 时自动隐藏控制器
                         LaunchedEffect(true) {
-                            snapshotFlow { controllerState.alwaysOn }.collect {
-                                if (!it) {
-                                    controllerState.toggleFullVisible(true)
-                                    keyboardFocus.requestFocus()
-                                    scope.launch {
+                            snapshotFlow { controllerState.alwaysOn }.collectLatest { alwaysOn ->
+                                if (alwaysOn) return@collectLatest
+                                snapshotFlow { controllerState.visibility != ControllerVisibility.Invisible }.collectLatest {
+                                    if (!it) {
                                         delay(VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION)
                                         controllerState.toggleFullVisible(false)
                                     }

--- a/danmaku/ui/src/androidMain/kotlin/DanmakuHost.android.kt
+++ b/danmaku/ui/src/androidMain/kotlin/DanmakuHost.android.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.window.core.layout.WindowWidthSizeClass
+import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -426,7 +426,7 @@ private fun DanmakuConfig(
                 )
 
                 val isDesktop =
-                    currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass != WindowWidthSizeClass.COMPACT
+                    currentWindowAdaptiveInfo().windowSizeClass.containsWidthDp(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
                 val displayDensityRange = remember(isDesktop) {
                     // 100% .. 0%
                     36.dp..(if (isDesktop) 720.dp else 240.dp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ koin = "3.5.6" # https://github.com/InsertKoinIO/koin/releases
 slf4j = "2.0.16"
 jsoup = "1.18.1" # https://github.com/jhy/jsoup/releases 
 android-gradle-plugin = "8.6.1"
-datastore = "1.1.1" # https://developer.android.com/jetpack/androidx/releases/datastore
+datastore = "1.1.2" # https://developer.android.com/jetpack/androidx/releases/datastore
 coil = "3.0.4" # https://github.com/coil-kt/coil/releases
 logback = "1.5.8"
 ksp = "2.1.0-1.0.29" # https://github.com/google/ksp/releases
@@ -35,7 +35,7 @@ antlr-kotlin = "1.0.0"
 oshai-kotlin-logging = "7.0.0" # Only for native. On JVM we use slf4j directly.
 ipaddress-parser = "5.5.1"
 androidx-annotation = "1.9.1"
-androidx-media3 = "1.4.1"
+androidx-media3 = "1.5.1"
 androidx-lifecycle = "2.8.7"
 paging = "3.3.5" # https://developer.android.com/jetpack/androidx/releases/paging
 turbine = "1.2.0" # https://github.com/cashapp/turbine/releases/
@@ -51,14 +51,14 @@ aws = "2.25.49"
 
 # Compose
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
-compose-material3 = "1.3.1"
-jetpack-compose = "1.7.6"
+compose-material3 = "1.4.0-alpha04"
+jetpack-compose = "1.8.0-alpha07"
 # https://github.com/JetBrains/compose-multiplatform/releases
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#use-a-developer-version-of-compose-multiplatform-compiler
-compose-multiplatform = "1.7.1"
-compose-lifecycle = "2.8.4"
-compose-navigation = "2.8.0-alpha10"
-compose-material3-adaptive = "1.0.1"
+compose-multiplatform = "1.8.0-alpha02"
+compose-lifecycle = "2.9.0-alpha02"
+compose-navigation = "2.8.0-alpha12"
+compose-material3-adaptive = "1.1.0-alpha02"
 
 # https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/compiler/compiler/
 #compose-multiplatform-compiler = "1.5.11-kt-2.0.0-RC1" # used by buildscript, don't remove


### PR DESCRIPTION
CMP 1.8.0-alpha02

显著变更：
- 没有发现 bug
- MaterialTheme.motionScheme
- currentWindowAdaptiveInfo 变了，判断大小方式有变
- ListDetail 框架代码变了，没有实际行为变更，但有可能支持了 predictive back
- chips boarder 变为 outlineVariant（M3 规范更新），只影响条目详情里的 tags
- ui test 行为更加可预测, 例如测试手指滑动屏幕调整播放进度:
https://github.com/open-ani/animeko/blob/e53770449e375e6a723671c151a3ce417faa533f/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt#L604-L614


need #1556