### PR TITLE
修复 Jellyfin 条目标题不匹配的问题

### DIFF
--- a/datasource/jellyfin/src/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/BaseJellyfinMediaSource.kt
@@ -119,8 +119,8 @@ abstract class BaseJellyfinMediaSource(config: MediaSourceConfig) : HttpMediaSou
                             originalTitle = originalTitle,
                             publishedTime = 0,
                             properties = MediaProperties(
-                                subjectName = null,
-                                episodeName = null, // TODO: Maybe we can get the names from Jellyfin
+                                subjectName = item.SeasonName,
+                                episodeName = item.Name,
                                 subtitleLanguageIds = listOf("CHS"),
                                 resolution = "1080P",
                                 alliance = mediaSourceId,
@@ -201,6 +201,7 @@ private data class MediaStream(
 @Suppress("PropertyName")
 private data class Item(
     val Name: String,
+    val SeasonName: String? = null,
     val Id: String,
     val OriginalTitle: String? = null, // 日文
     val IndexNumber: Int? = null,


### PR DESCRIPTION
![image_2025-01-22_12-00-22](https://github.com/user-attachments/assets/f02abfb1-9450-468e-8d6e-84a394bd6a5b)

Movie 类型没有 SeasonName，直接传入 null 试了一下工作正常。