### PR TITLE
Enable android for all modules

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 /*
@@ -20,10 +29,15 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     kotlin("plugin.serialization")
     idea
     `ani-mpp-lib-targets`
     id("org.openapi.generator") version "7.6.0"
+}
+
+android {
+    namespace = "me.him188.ani.client"
 }
 
 val generatedRoot = "generated/openapi"

--- a/danmaku/api/build.gradle.kts
+++ b/danmaku/api/build.gradle.kts
@@ -1,7 +1,21 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     kotlin("plugin.serialization")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.danmaku.api"
 }
 
 kotlin {

--- a/danmaku/dandanplay/build.gradle.kts
+++ b/danmaku/dandanplay/build.gradle.kts
@@ -1,7 +1,21 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     kotlin("plugin.serialization")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.danmaku.dandanplay"
 }
 
 kotlin {

--- a/datasource/bangumi/build.gradle.kts
+++ b/datasource/bangumi/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -29,10 +29,15 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     kotlin("plugin.serialization")
     idea
     `ani-mpp-lib-targets`
     id("org.openapi.generator") version "7.6.0"
+}
+
+android {
+    namespace = "me.him188.ani.datasources.bangumi"
 }
 
 val generatedRoot = "generated/openapi"

--- a/datasource/bt/mikan/build.gradle.kts
+++ b/datasource/bt/mikan/build.gradle.kts
@@ -9,15 +9,11 @@
 
 plugins {
     kotlin("multiplatform")
-    id("com.android.library")
+    // no android because commonTest needs resources that are not supported by android
     `ani-mpp-lib-targets`
     kotlin("plugin.serialization")
     id("org.jetbrains.kotlinx.atomicfu")
     `flatten-source-sets`
-}
-
-android {
-    namespace = "me.him188.ani.datasource.bt.mikan"
 }
 
 kotlin {

--- a/datasource/bt/mikan/build.gradle.kts
+++ b/datasource/bt/mikan/build.gradle.kts
@@ -1,27 +1,23 @@
 /*
- * Ani
- * Copyright (C) 2022-2024 Him188
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     kotlin("plugin.serialization")
     id("org.jetbrains.kotlinx.atomicfu")
     `flatten-source-sets`
+}
+
+android {
+    namespace = "me.him188.ani.datasource.bt.mikan"
 }
 
 kotlin {

--- a/torrent/api/build.gradle.kts
+++ b/torrent/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,8 +9,13 @@
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     id("org.jetbrains.kotlinx.atomicfu")
+}
+
+android {
+    namespace = "me.him188.ani.utils.torrent.api"
 }
 
 kotlin {

--- a/utils/bbcode/build.gradle.kts
+++ b/utils/bbcode/build.gradle.kts
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 
 /*
@@ -20,9 +29,14 @@ import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     id("com.strumenta.antlr-kotlin")
     idea
+}
+
+android {
+    namespace = "me.him188.ani.utils.bbcode"
 }
 
 val generatedRoot = layout.buildDirectory.dir("gen").get().asFile

--- a/utils/coroutines/build.gradle.kts
+++ b/utils/coroutines/build.gradle.kts
@@ -1,25 +1,21 @@
 /*
- * Ani
- * Copyright (C) 2022-2024 Him188
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     id("org.jetbrains.kotlinx.atomicfu")
+}
+
+android {
+    namespace = "me.him188.ani.utils.coroutines"
 }
 
 kotlin {

--- a/utils/intellij-annotations/build.gradle.kts
+++ b/utils/intellij-annotations/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -11,7 +11,12 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.utils.intellij.annotations"
 }
 
 kotlin {

--- a/utils/ip-parser/build.gradle.kts
+++ b/utils/ip-parser/build.gradle.kts
@@ -9,7 +9,12 @@
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.utils.ip.parser"
 }
 
 kotlin {

--- a/utils/jsonpath/build.gradle.kts
+++ b/utils/jsonpath/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,8 +9,13 @@
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "me.him188.ani.utils.jsonpath"
 }
 
 kotlin {

--- a/utils/ktor-client/build.gradle.kts
+++ b/utils/ktor-client/build.gradle.kts
@@ -9,8 +9,13 @@
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization")
+    id("com.android.library")
     `ani-mpp-lib-targets`
+    kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "me.him188.ani.utils.ktor.client"
 }
 
 kotlin {

--- a/utils/logging/build.gradle.kts
+++ b/utils/logging/build.gradle.kts
@@ -1,26 +1,22 @@
 /*
- * Ani
- * Copyright (C) 2022-2024 Him188
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.utils.logging"
 }
 
 dependencies {

--- a/utils/serialization/build.gradle.kts
+++ b/utils/serialization/build.gradle.kts
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 /*
@@ -20,8 +29,13 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "me.him188.ani.utils.serialization"
 }
 
 dependencies {

--- a/utils/testing/build.gradle.kts
+++ b/utils/testing/build.gradle.kts
@@ -9,7 +9,12 @@
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
+}
+
+android {
+    namespace = "me.him188.ani.utils.testing"
 }
 
 kotlin {

--- a/utils/xml/build.gradle.kts
+++ b/utils/xml/build.gradle.kts
@@ -9,8 +9,13 @@
 
 plugins {
     kotlin("multiplatform")
+    id("com.android.library")
     `ani-mpp-lib-targets`
     kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "me.him188.ani.utils.xml"
 }
 
 kotlin {


### PR DESCRIPTION
给 utils, client, datasource, danamku 模块增加 android 目标.

好处:
- 让所有模块代码都通过 instrumented test.
- 确保安卓端是使用安卓 SDK 编译, 而避免访问 JDK 的代码. 

坏处:
- 增加 CI 编译时间. 等 CI 编译完成后比较一下
- 增加本地编译时间, 但本 PR 只涉及基础模块, 实际开发时都会使用以前编译好的缓存. 只有全量/无缓存编译场景才会体感到变慢. 而这种情况本来就得全量编译 (数分钟), 增加了 30 秒也不是很不可以接受.
- 略微增加项目导入时间 (似乎增加了几秒, M2 Max)

注意:
- mikan 虽然是多平台项目, 但它要读取 resources, 而目前 KMP 并不支持 commonTest resource, 就先不改了.
