### PR TITLE
ServiceConnectionTester & SingleTaskExecutor

### DIFF
--- a/app/shared/app-data/build.gradle.kts
+++ b/app/shared/app-data/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         implementation(projects.utils.coroutines)
         api(projects.danmaku.danmakuUiConfig)
         api(projects.utils.xml)
+        api(projects.utils.coroutines)
         api(projects.client)
         api(projects.utils.ipParser)
         api(projects.utils.jsonpath)

--- a/app/shared/app-data/src/commonMain/kotlin/domain/settings/ServiceConnectionTester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/settings/ServiceConnectionTester.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.settings
+
+import io.ktor.http.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import me.him188.ani.app.domain.settings.ServiceConnectionTester.Service
+import me.him188.ani.app.domain.settings.ServiceConnectionTester.TestState
+import me.him188.ani.client.apis.TrendsAniApi
+import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.bangumi.BangumiClient
+import me.him188.ani.utils.coroutines.SingleTaskExecutor
+import me.him188.ani.utils.ktor.ApiInvoker
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.measureTimedValue
+
+/**
+ * Orchestrates the concurrent testing of multiple [Service] instances.
+ *
+ * Each [Service] is tested asynchronously when [testAll] is called. The state of each service
+ * transitions through [TestState] according to the outcome of its [Service.test] function.
+ *
+ * - If [testAll] is called again while a previous test run is still in progress,
+ *   the existing tasks are canceled and set to [TestState.Idle], and new tasks begin.
+ * - If the caller's coroutine (that invokes [testAll]) is canceled, all testing coroutines
+ *   are also canceled, and their states revert to [TestState.Idle].
+ * - [stopAll] can be invoked manually to cancel any ongoing tests and reset all states to [TestState.Idle].
+ *
+ * This class is **thread-safe** and can be called from multiple coroutines/threads concurrently.
+ *
+ * @param defaultDispatcher coroutine dispatcher to run the tests ([Service.test]) and results aggregation.
+ *
+ * @see ServiceConnectionTesters.createDefault
+ */
+class ServiceConnectionTester(
+    services: List<Service>,
+    private val defaultDispatcher: CoroutineContext = Dispatchers.Default,
+) {
+    private val services = services.map { ServiceImpl(it) }
+
+    /**
+     * A [Flow] of [Results], which contains the current [TestState] of all [Service]s being tested.
+     */
+    val results: Flow<Results> =
+        combine(this.services.map { service -> service.state.map { service.service to it } }) { states ->
+            Results(states.toMap(LinkedHashMap())) // retain order
+        }.shareIn(
+            CoroutineScope(defaultDispatcher), // note: we can't use backgroundScope here because backgroundScope may have a Job, which is not accepted by shareIn.
+            started = SharingStarted.WhileSubscribed(), replay = 0,
+        )
+
+    private val singleTaskExecutor = SingleTaskExecutor(defaultDispatcher)
+
+    /**
+     * Start testing all services and suspend until all services are tested.
+     *
+     * Lifecycle of the testing task is bounded by this function.
+     * That is, is this function is cancelled, all testing coroutines are also cancelled.
+     * Calling this function the second time will cancel the previous call.
+     */
+    suspend fun testAll() {
+        singleTaskExecutor.invoke {
+            for (service in services) {
+                launch {
+                    service.test()
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop all testing.
+     *
+     * This cancels all testing coroutines and results running services' states to [TestState.Idle],
+     * but does not clear the completed states.
+     */
+    fun stopAll() {
+        singleTaskExecutor.cancelCurrent()
+    }
+
+    class Service(
+        /**
+         * 给调用方识别的 ID. [ServiceConnectionTester] 不会使用此 ID.
+         */
+        val id: String,
+        /**
+         * Test if this service is available.
+         *
+         * This function is not allowed to throw exceptions, otherwise it will become [TestState.Error] and is considered a bug.
+         */
+        val test: suspend () -> Boolean,
+    )
+
+    sealed class TestState {
+        // also initial state
+        data object Idle : TestState()
+
+        data object Testing : TestState()
+        data class Success(
+            val time: Duration,
+        ) : TestState()
+
+        /**
+         * Indicates a normal failure, e.g., HTTP status code is not 200.
+         */
+        data object Failed : TestState()
+
+        /**
+         * Indicates an unexpected error, e.g., an exception is thrown.
+         * This should be considered a bug.
+         */
+        data class Error(
+            val e: Throwable,
+        ) : TestState()
+    }
+
+    class Results internal constructor(
+        internal val states: Map<Service, TestState>,
+    ) {
+        val idToStateMap: Map<String, TestState> by lazy { states.mapKeys { it.key.id } }
+
+        fun findStateById(id: String): TestState? = states.keys.find { it.id == id }?.let { states[it] }
+    }
+
+    private class ServiceImpl(
+        val service: Service,
+    ) {
+        private val _state: MutableStateFlow<TestState> = MutableStateFlow(TestState.Idle)
+        val state: StateFlow<TestState> = _state.asStateFlow()
+        private val lock = Mutex()
+
+        /**
+         * Test the service.
+         *
+         * This function must be called by only one coroutine at a time, otherwise it throws.
+         *
+         * If the coroutine is cancelled, the state is re-set to [TestState.Idle] and the [CancellationException] is propagated.
+         */
+        suspend fun test() {
+            // Note that we set `owner=this` (which is always the same), 
+            // so that the lock basically ensures the function is always called by a single coroutine at a time.
+            // This is a strong assertion to ensure the `testAll` algorithm works correctly.
+            lock.withLock(owner = this) {
+                _state.value = TestState.Testing
+                try {
+                    val (res, t) = measureTimedValue { service.test() }
+                    _state.value = if (res) TestState.Success(t) else TestState.Failed
+                } catch (e: CancellationException) {
+                    _state.value = TestState.Idle
+                    throw e
+                } catch (e: Throwable) {
+                    _state.value = TestState.Error(e)
+                }
+            }
+        }
+
+        fun resetToIdle() {
+            _state.value = TestState.Idle
+        }
+    }
+}
+
+
+object ServiceConnectionTesters {
+    const val ID_BANGUMI = "BANGUMI"
+    const val ID_BANGUMI_NEXT = "BANGUMI_NEXT"
+    const val ID_ANI = "ANI"
+
+    fun createDefault(
+        bangumiClient: BangumiClient,
+        aniClient: ApiInvoker<TrendsAniApi>,
+        defaultDispatcher: CoroutineContext = Dispatchers.Default,
+    ): ServiceConnectionTester {
+        return ServiceConnectionTester(
+            listOf(
+                Service(ID_BANGUMI) {
+                    bangumiClient.testConnection() == ConnectionStatus.SUCCESS
+                },
+                Service(ID_BANGUMI_NEXT) {
+                    // TODO: test bangumi next
+                    bangumiClient.testConnection() == ConnectionStatus.SUCCESS
+                },
+                Service(ID_ANI) {
+                    runCatching {
+                        // Note, we may have `expectSuccess = true` so on failure it will throw an exception.
+                        aniClient.invoke {
+                            getTrends().response.status.isSuccess()
+                        }
+                    }.getOrElse { false }
+                },
+            ),
+            defaultDispatcher,
+        )
+
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/settings/ServiceConnectionTesterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/settings/ServiceConnectionTesterTest.kt
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.settings
+
+import app.cash.turbine.test
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class ServiceConnectionTesterTest {
+    /**
+     * Helper to produce a [ServiceConnectionTester.Service]. Instead of using [testDelay] and
+     * `delay(...)`, we await on [signal] to control exactly when the test finishes.
+     *
+     * [onTestCalled] gives us access to the dispatcher for testing or capturing additional info.
+     *
+     * If [signal] is null, the test immediately proceeds. Otherwise, the test suspends until
+     * `signal.await()` returns.
+     */
+    private fun createService(
+        id: String,
+        shouldThrow: Boolean = false,
+        shouldFail: Boolean = false,
+        onTestCalled: suspend (ContinuationInterceptor) -> Unit = {},
+        signal: CompletableDeferred<Unit>? = null,
+    ): ServiceConnectionTester.Service {
+        return ServiceConnectionTester.Service(
+            id = id,
+            test = {
+                onTestCalled(currentContinuationInterceptor())
+                // If a signal is provided, wait for it. Otherwise proceed immediately.
+                signal?.await()
+
+                if (shouldThrow) {
+                    throw IllegalStateException("Test error")
+                }
+                !shouldFail
+            }
+        )
+    }
+
+    private suspend fun currentContinuationInterceptor() =
+        currentCoroutineContext()[ContinuationInterceptor]!!
+
+    // region Single service tests
+
+    @Test
+    fun `testAll - single service success`() = runTest {
+        val service = createService("service-id")
+        val tester = ServiceConnectionTester(
+            services = listOf(service),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        // Should complete without throwing:
+        tester.testAll()
+
+        val results = tester.results.first()
+        val state = results.states[service]
+        assertTrue(state is ServiceConnectionTester.TestState.Success)
+    }
+
+    @Test
+    fun `testAll - single service failure`() = runTest {
+        val service = createService("fail-service", shouldFail = true)
+        val tester = ServiceConnectionTester(
+            services = listOf(service),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.testAll()
+
+        val results = tester.results.first()
+        val state = results.states[service]
+        assertTrue(state is ServiceConnectionTester.TestState.Failed)
+    }
+
+    @Test
+    fun `testAll - single service error`() = runTest {
+        val service = createService("error-service", shouldThrow = true)
+        val tester = ServiceConnectionTester(
+            services = listOf(service),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.testAll()
+
+        val results = tester.results.first()
+        val state = results.states[service]
+        assertTrue(state is ServiceConnectionTester.TestState.Error)
+        assertTrue(state.e is IllegalStateException)
+    }
+
+    // endregion
+
+    // region Multiple services
+
+    @Test
+    fun `testAll - multiple services mixed results`() = runTest {
+        val okService = createService("ok")
+        val failService = createService("fail", shouldFail = true)
+        val errorService = createService("error", shouldThrow = true)
+
+        val tester = ServiceConnectionTester(
+            services = listOf(okService, failService, errorService),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.testAll()
+
+        val results = tester.results.first()
+        assertTrue(results.states[okService] is ServiceConnectionTester.TestState.Success)
+        assertTrue(results.states[failService] is ServiceConnectionTester.TestState.Failed)
+        assertTrue(results.states[errorService] is ServiceConnectionTester.TestState.Error)
+    }
+
+    // endregion
+
+    // region Cancellation tests
+
+    @Test
+    fun `testAll - cancel during testing - states revert to Idle`() = runTest {
+        // Use a signal so the service doesn't complete until we allow it.
+        val serviceSignal = CompletableDeferred<Unit>()
+        val longRunningService = createService(
+            "long-run",
+            signal = serviceSignal,
+        ) // never completes unless we .complete() the signal
+
+        val tester = ServiceConnectionTester(
+            services = listOf(longRunningService),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        // Collect from the results to see when it enters Testing state
+        // Then cancel.
+        tester.results.test {
+            // Initial = Idle
+            val initial = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Idle, initial.states[longRunningService])
+
+            // Start testAll in a separate job
+            val job = launch(start = CoroutineStart.UNDISPATCHED) {
+                tester.testAll()
+            }
+
+            // Next emission => Testing
+            val testing = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Testing, testing.states[longRunningService])
+
+            // Now cancel
+            job.cancelAndJoin()
+
+            // After cancel, we should get a new emission => Idle
+            val final = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Idle, final.states[longRunningService])
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `stopAll - states are kept intact`() = runTest {
+        val service1 = createService("s1")
+        val service2 = createService("s2", shouldFail = true)
+
+        val tester = ServiceConnectionTester(
+            services = listOf(service1, service2),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.testAll()
+        val results = tester.results.first()
+        assertNotEquals(ServiceConnectionTester.TestState.Idle, results.states[service1])
+        assertNotEquals(ServiceConnectionTester.TestState.Idle, results.states[service2])
+
+        // now call stopAll
+        tester.stopAll()
+        val newResults = tester.results.first()
+        assertEquals(results.states, newResults.states)
+    }
+
+    // endregion
+
+    // region Flow emission tests
+
+    @Test
+    fun `results flow - verifies states update in real-time`() = runTest {
+        // We'll hold the service completion until we decide to finish.
+        val serviceSignal = CompletableDeferred<Unit>()
+        val service = createService(
+            "service",
+            signal = serviceSignal,
+        )
+        val tester = ServiceConnectionTester(
+            services = listOf(service),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.results.test {
+            // Initially, Idle
+            val initial = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Idle, initial.states[service])
+
+            // Launch testAll
+            val job = launch(start = CoroutineStart.UNDISPATCHED) { tester.testAll() }
+
+            // Next => Testing
+            val testing = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Testing, testing.states[service])
+
+            // Now signal the service to complete
+            serviceSignal.complete(Unit)
+
+            // Next => Success
+            val final = awaitItem()
+            assertTrue(final.states[service] is ServiceConnectionTester.TestState.Success)
+
+            job.cancelAndJoin()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `results flow - verifies multiple states update in real-time`() = runTest {
+        // Two signals for two services
+        val service1Signal = CompletableDeferred<Unit>()
+        val service2Signal = CompletableDeferred<Unit>()
+
+        val service1 = createService("service1", signal = service1Signal)
+        val service2 = createService("service2", signal = service2Signal)
+
+        val tester = ServiceConnectionTester(
+            services = listOf(service1, service2),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.results.test {
+            // Initially, Idle for both
+            val initial = awaitItem()
+            assertEquals(ServiceConnectionTester.TestState.Idle, initial.states[service1])
+            assertEquals(ServiceConnectionTester.TestState.Idle, initial.states[service2])
+
+            // Start the testAll
+            val job = launch(start = CoroutineStart.UNDISPATCHED) { tester.testAll() }
+
+            // We might receive several emissions as services go from Idle -> Testing
+            // Let's wait until we see both in Testing
+            var bothAreTesting = false
+            while (!bothAreTesting) {
+                val next = awaitItem()
+                val s1State = next.states[service1]
+                val s2State = next.states[service2]
+                if (s1State == ServiceConnectionTester.TestState.Testing &&
+                    s2State == ServiceConnectionTester.TestState.Testing
+                ) {
+                    bothAreTesting = true
+                }
+            }
+
+            // Now complete service2, to verify it finishes first
+            service2Signal.complete(Unit)
+
+            // Next emission => service2 => Success, service1 => still Testing
+            val afterService2 = awaitItem()
+            assertTrue(afterService2.states[service2] is ServiceConnectionTester.TestState.Success)
+            assertTrue(afterService2.states[service1] is ServiceConnectionTester.TestState.Testing)
+
+            // Finally complete service1
+            service1Signal.complete(Unit)
+
+            // Next emission => service1 => Success, service2 => Success
+            val final = awaitItem()
+            assertTrue(final.states[service1] is ServiceConnectionTester.TestState.Success)
+            assertTrue(final.states[service2] is ServiceConnectionTester.TestState.Success)
+
+            job.cancelAndJoin()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // endregion
+
+    // region Dispatcher checks
+
+    @Test
+    fun `testAll - uses provided defaultDispatcher`() = runTest {
+        val interceptorFlow = MutableStateFlow<ContinuationInterceptor?>(null)
+        val service = createService(
+            id = "capture-dispatcher",
+            onTestCalled = { interceptor ->
+                interceptorFlow.value = interceptor
+            }
+        )
+
+        val tester = ServiceConnectionTester(
+            services = listOf(service),
+            defaultDispatcher = currentContinuationInterceptor(),
+        )
+
+        tester.testAll()
+
+        // Service test has finished, check which dispatcher captured
+        assertEquals(currentContinuationInterceptor(), interceptorFlow.value)
+    }
+
+    // endregion
+}

--- a/app/shared/app-platform/src/commonMain/kotlin/tools/MonoTasker.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/tools/MonoTasker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -32,16 +32,25 @@ import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
+/**
+ * Note: This function is not thread safe. For thread-safe variant, you may consider `SingleTaskExecutor`.
+ */
 @Stable
 interface MonoTasker {
     val isRunning: StateFlow<Boolean>
 
+    /**
+     * Note: This function is not thread safe.
+     */
     fun launch(
         context: CoroutineContext = EmptyCoroutineContext,
         start: CoroutineStart = CoroutineStart.DEFAULT,
         block: suspend CoroutineScope.() -> Unit
     ): Job
 
+    /**
+     * Note: This function is not thread safe.
+     */
     fun <R> async(
         context: CoroutineContext = EmptyCoroutineContext,
         start: CoroutineStart = CoroutineStart.DEFAULT,
@@ -50,6 +59,8 @@ interface MonoTasker {
 
     /**
      * 等待上一个任务完成后再执行
+     *
+     * Note: This function is not thread safe.
      */
     fun launchNext(
         context: CoroutineContext = EmptyCoroutineContext,
@@ -57,10 +68,19 @@ interface MonoTasker {
         block: suspend CoroutineScope.() -> Unit
     )
 
+    /**
+     * Note: This function is not thread safe.
+     */
     fun cancel(cause: CancellationException? = null)
 
+    /**
+     * Note: This function is not thread safe.
+     */
     suspend fun cancelAndJoin()
 
+    /**
+     * Note: This function is not thread safe.
+     */
     suspend fun join()
 }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/ConnectionTester.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/framework/ConnectionTester.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.settings.framework
 
 import androidx.compose.foundation.layout.Arrangement
@@ -25,11 +34,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import me.him188.ani.app.domain.settings.ServiceConnectionTester
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTimedValue
 
 
+/**
+ * @suppress soft deprecated. use [ServiceConnectionTester] instead.
+ */
 @Immutable
 enum class ConnectionTestResult {
     SUCCESS,
@@ -40,8 +53,14 @@ enum class ConnectionTestResult {
 fun Boolean.toConnectionTestResult() =
     if (this) ConnectionTestResult.SUCCESS else ConnectionTestResult.FAILED
 
+/**
+ * @suppress soft deprecated. use [ServiceConnectionTester] instead.
+ */
 typealias ConnectionTester = Tester<ConnectionTestResult>
 
+/**
+ * @suppress soft deprecated. use [ServiceConnectionTester] instead.
+ */
 fun ConnectionTester(
     id: String,
     testConnection: suspend () -> ConnectionTestResult,
@@ -53,6 +72,9 @@ fun ConnectionTester(
     },
 )
 
+/**
+ * @suppress soft deprecated. use [ServiceConnectionTester] instead.
+ */
 @Stable
 open class Tester<T>(
     val id: String,
@@ -96,6 +118,9 @@ open class Tester<T>(
     }
 }
 
+/**
+ * @suppress deprecated.
+ */
 @Composable
 fun ConnectionTesterResultIndicator(
     tester: ConnectionTester,

--- a/utils/coroutines/src/commonMain/kotlin/SingleTaskExecutor.kt
+++ b/utils/coroutines/src/commonMain/kotlin/SingleTaskExecutor.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.utils.coroutines
+
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.*
+import me.him188.ani.utils.platform.annotations.TestOnly
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * A task executor that ensures there will be only one 'instance' of [invoke] running at a time.
+ * Previous tasks will be canceled if a new task is submitted.
+ *
+ * This class is thread-safe.
+ */
+interface SingleTaskExecutor {
+    /**
+     * Invokes [block] in a coroutine. Suspends until [block] completes, and returns its result.
+     * Previous [invoke] will be canceled when [invoke] is called again.
+     */
+    suspend operator fun <R> invoke(
+        coroutineContext: CoroutineContext = EmptyCoroutineContext,
+        block: suspend CoroutineScope.() -> R,
+    ): R
+
+    fun cancelCurrent()
+}
+
+/**
+ * Creates a [SingleTaskExecutor] that uses the provided [parentCoroutineContext].
+ *
+ * @param parentCoroutineContext The context to run tasks with. If the scope is canceled, [SingleTaskExecutor.invoke] will be cancelled,
+ * and further tasks will not be started (also throws [CancellationException]).
+ * This could either have a [Job] or a `SupervisorJob`, or no job, and the implementation will always throw [CancellationException] if the scope is canceled.
+ */
+fun SingleTaskExecutor(parentCoroutineContext: CoroutineContext = EmptyCoroutineContext): SingleTaskExecutor =
+    AtomicSingleTaskExecutor(parentCoroutineContext)
+
+/**
+ * A task executor that ensures only one task is running at a time.
+ * Previous tasks will be canceled if a new task is submitted.
+ *
+ * This class is **thread-safe** and optimized for **low contention** environments.
+ */
+class AtomicSingleTaskExecutor(
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+) : SingleTaskExecutor {
+    private val _job = atomic<Job?>(null)
+    private val scope = CoroutineScope(coroutineContext) // This scope may not have a Job.
+
+    @TestOnly
+    internal fun getJob(): Job? = _job.value
+
+    override suspend fun <R> invoke(
+        coroutineContext: CoroutineContext,
+        block: suspend CoroutineScope.() -> R,
+    ): R {
+        // Atomically, create a new job and start it.
+
+        // 1. Cancel previous job
+        val previousJob = _job.value
+        previousJob?.cancel()
+
+        // 2. Create a new job but does not start it
+        val newJob = scope.async(
+            coroutineContext + currentCoroutineContext()[Job]!!,
+            start = CoroutineStart.LAZY,
+            block = block,
+        )
+
+        // 3. Atomically set the new job
+        if (_job.compareAndSet(previousJob, newJob) // This CAS may fail, because of other thread executing step 6.
+        ) {
+            // 4. Successful, _job is made visible to all threads.
+            // Now we are safe to start the job.
+            if (newJob.start()) {
+                // Job started, all done.
+            } else {
+                // Some other thread executed step 1, and it have already canceled our newJob.
+                // Then that thread will start the new job.
+                newJob.checkCancelledAndThrowCancellation()
+            }
+            // Post condition: newJob is started.
+
+            // 5. Wait for the job to complete
+            try {
+                return newJob.await()
+            } finally {
+                // 6. If no other thread has set a new job, we can free our job. (help GC)
+                _job.compareAndSet(newJob, null)
+            }
+        } else {
+            // 7. Failed race, a newer invocation overshadowed us; cancel our job and exit.
+            newJob.cancel()
+            newJob.checkCancelledAndThrowCancellation()
+        }
+    }
+
+    override fun cancelCurrent() {
+        val previousJob = _job.value
+        previousJob?.cancel()
+        _job.compareAndSet(previousJob, null)
+    }
+
+    private suspend fun Job.checkCancelledAndThrowCancellation(): Nothing {
+        check(isCancelled) { "newJob is not cancelled" }
+        throwCancellation()
+    }
+
+    private suspend fun Job.throwCancellation(): Nothing {
+        // Should throw CancellationException if the scope has a normal Job.
+        // If the scope has a SupervisorJob, this will not throw.
+        join()
+
+        // If the scope has a SupervisorJob, we should throw CancellationException manually.
+        throw CancellationException("AtomicSingleTaskExecutor.invoke is superseded by a new invocation")
+    }
+}

--- a/utils/coroutines/src/commonTest/kotlin/AtomicSingleTaskExecutorTest.kt
+++ b/utils/coroutines/src/commonTest/kotlin/AtomicSingleTaskExecutorTest.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.utils.coroutines
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+class AtomicSingleTaskExecutorTest {
+    @Suppress("TestFunctionName")
+    private fun AtomicSingleTaskExecutor(scope: TestScope): AtomicSingleTaskExecutor =
+        AtomicSingleTaskExecutor(scope.coroutineContext)
+
+    /**
+     * Basic test: single invocation should run to completion
+     * and `_job` is set to null afterward.
+     */
+    @Test
+    fun `invoke - single call - runs to completion`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+
+        var sideEffect = false
+        executor.invoke {
+            sideEffect = true
+        }
+
+        assertTrue(sideEffect, "The block should have executed.")
+        assertNull(executor.getJob(), "Job should be cleared after completion.")
+    }
+
+    /**
+     * A second invocation should cancel the first if it's still running.
+     * The first job is long-running; the second job is short.
+     * We expect the second job to finish successfully, and the first to be canceled.
+     */
+    @Test
+    fun `invoke - second call cancels first if still running`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+
+        // Start a job that takes a while (won't complete in normal test time).
+        val job1Started = CompletableDeferred<Unit>()
+        val job1Done = async(start = CoroutineStart.UNDISPATCHED) {
+            executor.invoke {
+                job1Started.complete(Unit) // signal we started
+                awaitCancellation()
+            }
+            @Suppress("UNREACHABLE_CODE")
+            fail("Job should have been canceled.")
+        }
+
+        // Ensure job1 has started.
+        job1Started.await()
+
+        // Now call invoke again; it should cancel job1.
+        var secondTaskRan = false
+        executor.invoke {
+            secondTaskRan = true
+        }
+
+        // job1 should be canceled once second invocation arrives
+        assertTrue(job1Done.isCancelled, "First job should be canceled.")
+        assertTrue(secondTaskRan, "Second invocation should have run to completion.")
+        assertNull(executor.getJob(), "Job should be cleared after second call completes.")
+    }
+
+    /**
+     * Multiple concurrent calls arrive almost at once.
+     * The newest call should overshadow the older ones, so only the last call completes.
+     * We test that only the newest job truly finishes the block, while earlier ones are canceled.
+     */
+    @Test
+    fun `invoke - multiple concurrent calls - newest overshadows older`() = runTest(StandardTestDispatcher()) {
+        val testScope = this
+        val executor = AtomicSingleTaskExecutor(testScope)
+
+        val started = mutableListOf<Int>()
+        val finished = mutableListOf<Int>()
+
+        suspend fun runIndexedTask(index: Int) {
+            executor.invoke {
+                started += index
+                // small delay so that older tasks can get canceled if overshadowed
+                delay(100.milliseconds)
+                finished += index
+            }
+        }
+
+        // Launch 5 concurrent tasks. The last (5) is expected to overshadow the rest.
+        val tasks = (1..5).map { i ->
+            testScope.async {
+                runIndexedTask(i)
+            }
+        }
+
+        // Advance time until all tasks are settled
+        testScope.advanceUntilIdle()
+        tasks.forEach { it.join() }
+
+        // Because the newest overshadow older tasks, only #5 is guaranteed to finish
+        // (others might start but should be canceled before finishing).
+        println("Tasks started: $started")   // might contain [1, 2, 3, 4, 5] or a subset
+        println("Tasks finished: $finished") // should contain only [5] in a typical "latest wins"
+
+        // We only do a strong check that 5 definitely finished:
+        assertTrue(5 in finished, "Newest invocation (5) must finish.")
+        // Usually we'd check that 1..4 are not in finished, but concurrency can vary.
+        // It's typical in 'latest-wins' that older calls are canceled.
+        assertNull(executor.getJob(), "Job should be cleared after everything finishes.")
+    }
+
+    /**
+     * If a job runs and completes normally, we confirm `_job` is nulled out afterward.
+     */
+    @Test
+    fun `invoke - job is cleared after normal completion`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+        assertNull(executor.getJob(), "Initially, no job should be set.")
+
+        executor.invoke {
+            // quick block
+        }
+        // After the above call completes, `_job` should be set back to null.
+        assertNull(executor.getJob(), "Job should be cleared after normal completion.")
+    }
+
+    /**
+     * Test that older invocations do not overshadow newer invocations,
+     * if they are still in the process of CAS.
+     *
+     * We'll artificially stall the old invocation before it does CAS
+     * and ensure the new invocation "wins."
+     * Then confirm the older one cancels its new job attempt rather than overshadowing.
+     */
+    @Test
+    fun `invoke - old invocation does not overshadow new invocation`() = runTest(StandardTestDispatcher()) {
+        // We'll artificially force concurrency by using separate coroutines.
+        val executor = AtomicSingleTaskExecutor(this)
+
+        var olderRan = false
+        var newerRan = false
+
+        val older = async {
+            // Start "older" task
+            executor.invoke {
+                olderRan = true
+                delay(500) // Simulate some heavier work
+            }
+        }
+
+        // Give older a chance to run a bit
+        delay(100)
+
+        // Now the "newer" invocation
+        val newer = async(start = CoroutineStart.UNDISPATCHED) {
+            executor.invoke {
+                newerRan = true
+                // short task
+            }
+        }
+
+        advanceUntilIdle()
+        // Wait for both to complete
+        assertFailsWith<CancellationException> {
+            older.await()
+        }
+        newer.await()
+
+        // The key: older will be canceled once the new call arrives.
+        // But the block's first line (`olderRan = true`) might have run already if older began early.
+        // The final question is: did older overshadow the new job? It shouldn't have.
+        // So we definitely want the 'newerRan = true' to hold.
+        assertTrue(newerRan, "The newer invocation should definitely run.")
+        // older might have begun execution, but once overshadowed, it can't re-CAS
+        // to set a new job again. So it won't prevent the newer from finishing.
+        // There's no strict outcome on `olderRan`: it might have run partially.
+        // But let's check it is likely canceled mid-execution:
+        // The key correctness is that the new invocation was able to run and finish.
+    }
+
+
+    @Test
+    fun `cancelCurrent - no active job - does nothing`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+        // Initially no job is running
+        assertNull(executor.getJob(), "No job should be set initially.")
+
+        // Cancel when no job is present
+        executor.cancelCurrent()
+        assertNull(executor.getJob(), "Still no job after cancel.")
+    }
+
+    @Test
+    fun `cancelCurrent - running job gets canceled`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+        val jobRunningStarted = async(start = CoroutineStart.UNDISPATCHED) {
+            executor.invoke {
+                // Simulate long-running job
+                awaitCancellation()
+            }
+        }
+
+        // Confirm a job is indeed set
+        val jobBeforeCancel = executor.getJob()
+        assertNotNull(jobBeforeCancel, "A job should be running before cancel.")
+
+        // Cancel the executor
+        executor.cancelCurrent()
+        assertNull(executor.getJob(), "Job should be cleared after cancel.")
+
+        // The running job should be canceled
+        jobRunningStarted.join()
+        assertTrue(jobRunningStarted.isCancelled, "Long-running job should be canceled.")
+    }
+
+    @Test
+    fun `cancelCurrent - already completed job - does not throw or re-cancel`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+
+        // Submit a quick job that completes immediately
+        executor.invoke {
+            // no-op
+        }
+        // Now the job is already completed, `_job` is null again
+        assertNull(executor.getJob(), "Job should already be null after completion.")
+
+        // Attempt to cancel again
+        executor.cancelCurrent()
+        // Should still be null, no exception
+        assertNull(executor.getJob(), "Calling cancel on a completed (null) job does nothing.")
+    }
+
+    @Test
+    fun `cancelCurrent - multiple calls in a row - no issues`() = runTest {
+        val executor = AtomicSingleTaskExecutor(this)
+
+        // Start a job
+        val longJob = async(start = CoroutineStart.UNDISPATCHED) {
+            executor.invoke {
+                awaitCancellation()
+            }
+        }
+        // Cancel the executor multiple times
+        executor.cancelCurrent()
+        executor.cancelCurrent()
+        executor.cancelCurrent()
+
+        longJob.join()
+        // Confirm the job was canceled
+        assertTrue(longJob.isCancelled, "Job should be canceled after repeated executor.cancel() calls.")
+        assertNull(executor.getJob(), "Job reference should be cleared.")
+
+        // Now try to invoke a new job to ensure the executor is still usable
+        var ranNewJob = false
+        executor.invoke {
+            ranNewJob = true
+        }
+        assertTrue(ranNewJob, "Executor should still function for future calls after repeated cancels.")
+        assertNull(executor.getJob(), "New job should be cleared after completion.")
+    }
+
+    @Test
+    fun `cancelCurrent - does not affect scope cancellation`() = runTest {
+        val externalExecutor = AtomicSingleTaskExecutor(this)
+
+        // If the parent scope is canceled, the executor is effectively canceled. 
+        // But calling executor.cancel() first should not affect the scope itself.
+        externalExecutor.cancelCurrent()
+        // Still, the parent scope is active in this test environment 
+        // => we can schedule tasks if the SingleTaskExecutor code doesn't check scope cancellation.
+        var sideEffect = false
+        externalExecutor.invoke {
+            sideEffect = true
+        }
+        assertTrue(sideEffect, "Executor can still run if the underlying scope isn't canceled.")
+    }
+
+    @Test
+    fun `cancelCurrent - concurrent call overshadow check`() = runTest {
+        // This test ensures that if we call cancel right before a new invoke, 
+        // the new job isn't erroneously canceled after it starts.
+        val executor = AtomicSingleTaskExecutor(this)
+        var blockRan = false
+
+        // Immediately call cancel
+        executor.cancelCurrent()
+
+        // Then invoke a new task
+        executor.invoke {
+            blockRan = true
+        }
+
+        assertTrue(blockRan, "The new block should run even if we called cancel just before.")
+        assertNull(executor.getJob(), "Job reference should be cleared after completion.")
+    }
+}


### PR DESCRIPTION
main 全部是我写的, test 全部是 o1pro 写的. 代码看起来新增 1000 行实际上是 200 行实现, 150 行注释, 650 行 test. 实现比较简单.

tester 只写了测试全部, UI 可以只允许重试全部测试 (也是通常的需求). UI state 里可以直接用 tester.results 这个来组合 presentationFlow. 所有方法线程安全, 支持在任意 thread (包括主线程) 调用.

approve 后我手动 cherry pick 合并.

