### PR TITLE
Fix #1661 : 代理设置 UI Bug

### DIFF
--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/network/GlobalProxyGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/network/GlobalProxyGroup.kt
@@ -19,12 +19,11 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.Flow
+import me.him188.ani.app.data.models.preference.ProxyAuthorization
 import me.him188.ani.app.data.models.preference.ProxyConfig
 import me.him188.ani.app.data.models.preference.ProxyMode
 import me.him188.ani.app.data.models.preference.ProxySettings
@@ -169,31 +168,19 @@ private fun SettingsScope.CustomProxyConfig(
 
     HorizontalDividerItem()
 
-    val username by remember {
-        derivedStateOf {
-            proxySettings.default.customConfig.authorization?.username ?: ""
-        }
-    }
-
-    val password by remember {
-        derivedStateOf {
-            proxySettings.default.customConfig.authorization?.password ?: ""
-        }
-    }
-
     TextFieldItem(
-        username,
+        proxySettings.default.customConfig.authorization?.username ?: "",
         title = { Text("用户名") },
         description = { Text("可选") },
         placeholder = { Text("无") },
         onValueChangeCompleted = {
+            val newAuth = proxySettings.default.customConfig.authorization?.copy(username = it)
+                ?: ProxyAuthorization(username = it, password = "")
             proxySettingsState.update(
                 proxySettings.copy(
                     default = proxySettings.default.copy(
                         customConfig = proxySettings.default.customConfig.copy(
-                            authorization = proxySettings.default.customConfig.authorization?.copy(
-                                username = it,
-                            ),
+                            authorization = newAuth,
                         ),
                     ),
                 ),
@@ -205,18 +192,18 @@ private fun SettingsScope.CustomProxyConfig(
     HorizontalDividerItem()
 
     TextFieldItem(
-        password,
+        proxySettings.default.customConfig.authorization?.password ?: "",
         title = { Text("密码") },
         description = { Text("可选") },
         placeholder = { Text("无") },
         onValueChangeCompleted = {
+            val newAuth = proxySettings.default.customConfig.authorization?.copy(password = it)
+                ?: ProxyAuthorization(username = "", password = it)
             proxySettingsState.update(
                 proxySettings.copy(
                     default = proxySettings.default.copy(
                         customConfig = proxySettings.default.customConfig.copy(
-                            authorization = proxySettings.default.customConfig.authorization?.copy(
-                                password = password,
-                            ),
+                            authorization = newAuth,
                         ),
                     ),
                 ),


### PR DESCRIPTION
这个 pr 只修复 ui bug 吧。代理的整个框架我不太熟悉（也不太会写）。详细内容可以转到 #1664 。

Fixes:
1. 在密码的 TextFieldItem 中，使用了外部变量 password 而非 it
2. 对于用户名和密码的更新，都采用了 ?.copy(...) 。这样在 proxySettings.default.customConfig.authorization 为 null 时，.copy 不会被执行。