### PR TITLE
Update desktop context menu to m3 style.

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.desktop
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.LocalContextMenuRepresentation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -471,6 +472,7 @@ private fun FrameWindowScope.MainWindowContent(
                             vm.show(text)
                         }
                     },
+                    LocalContextMenuRepresentation provides DesktopContextMenuRepresentation,
                 ) {
                     Box(Modifier.padding(all = paddingByWindowSize)) {
                         AniAppContent(aniNavigator)

--- a/app/desktop/src/main/kotlin/DesktopContextMenuRepresentation.kt
+++ b/app/desktop/src/main/kotlin/DesktopContextMenuRepresentation.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.desktop
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuRepresentation
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+
+object DesktopContextMenuRepresentation : ContextMenuRepresentation {
+
+    @Composable
+    override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
+        val status = state.status
+        if (status is ContextMenuState.Status.Open) {
+            DropdownMenu(
+                expanded = true,
+                onDismissRequest = {
+                    state.status = ContextMenuState.Status.Closed
+                },
+                offset = with(LocalDensity.current) {
+                    status.rect.center.let {
+                        DpOffset(
+                            it.x.toDp(),
+                            (-it.y).toDp()
+                        )
+                    }
+                },
+            ) {
+                items().forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            it.onClick()
+                            state.status = ContextMenuState.Status.Closed
+                        },
+                        text = {
+                            Text(it.label)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Old**
![image](https://github.com/user-attachments/assets/398b780b-2054-46b7-932f-4d1415059b72)
**New**
![image](https://github.com/user-attachments/assets/ca91f2dd-e818-4b67-915c-b0d856dc4f1d)

- Introduced `DesktopContextMenuRepresentation.kt` to implement a custom context menu for desktop.
- Updated `AniDesktop.kt` to utilize `DesktopContextMenuRepresentation` via `LocalContextMenuRepresentation`.