### PR TITLE
Refactor window border handling for undecorated fullscreen

### DIFF
--- a/app/desktop/src/main/kotlin/window/WindowsWindowFrame.kt
+++ b/app/desktop/src/main/kotlin/window/WindowsWindowFrame.kt
@@ -277,7 +277,11 @@ private fun ExtendToTitleBar(frameState: WindowsWindowFrameState) {
     val platformWindow = LocalPlatformWindow.current
     LaunchedEffect(platformWindow, density, frameState) {
         WindowsWindowUtils.instance.collectWindowProcHitTestProvider(platformWindow) { x, y ->
-            frameState.hitTest(x, y, density)
+            if (!platformWindow.isUndecoratedFullscreen) {
+                frameState.hitTest(x, y, density)
+            } else {
+                WindowsWindowHitResult.CLIENT
+            }
         }
     }
 }

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
@@ -188,6 +188,11 @@ internal class ExtendedTitleBarWindowProc(
     private fun hitTestWindowResizerBorder(x: Int, y: Int): WindowsWindowHitResult {
         // Force update window info.
         updateWindowInfo()
+        // If window not contains the border, return NOWHERE.
+        val currentStyle = User32.INSTANCE.GetWindowLong(windowHandle, WinUser.GWL_STYLE)
+        if (currentStyle and WinUser.WS_CAPTION == 0) {
+            return WindowsWindowHitResult.NOWHERE
+        }
         val horizontalPadding = frameX
         val verticalPadding = frameY
         return when {


### PR DESCRIPTION
- Updated `WindowsWindowProc.kt` to avoid window resize when the window does not contain the border.
- Modified `WindowsWindowFrame.kt` to disable window resizing for undecorated fullscreen windows.