### PR TITLE
Fix episode page layout when the system is in fullscreen on Android

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -280,7 +280,7 @@ private fun EpisodeScreenContent(
 
                 CompositionLocalProvider(LocalImageViewerHandler provides imageViewer) {
                     when {
-                        showExpandedUI || isSystemInFullscreen() ->
+                        showExpandedUI ->
                             EpisodeScreenTabletVeryWide(
                                 vm,
                                 page,


### PR DESCRIPTION
Tested on:
- Mi 15 (HyperOS 2)
- Flyme 10
- OnePlus 13 (ColorOS 15)
@Sanlorng  @WoLeo-Z  有空在自己手机上测测各种情况
