### PR TITLE
Media Selector simple mode

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/GetPreferredMediaSourceSortingUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/GetPreferredMediaSourceSortingUseCase.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.selector
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import me.him188.ani.app.domain.media.fetch.MediaSourceFetchResult
+import me.him188.ani.app.domain.media.fetch.MediaSourceManager
+import me.him188.ani.app.domain.usecase.UseCase
+import kotlin.coroutines.CoroutineContext
+
+fun interface GetPreferredMediaSourceSortingUseCase : UseCase {
+    /**
+     * @return [MediaSourceFetchResult.instanceId]
+     */
+    operator fun invoke(): Flow<List<String>>
+}
+
+class GetPreferredMediaSourceSortingUseCaseImpl(
+    private val mediaSourceManager: MediaSourceManager,
+    private val context: CoroutineContext = Dispatchers.Default,
+) : GetPreferredMediaSourceSortingUseCase {
+    override fun invoke(): Flow<List<String>> {
+        return mediaSourceManager.allInstances.map { list ->
+            list.map {
+                it.instanceId
+            }
+        }.flowOn(context)
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MaybeExcludedMedia.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MaybeExcludedMedia.kt
@@ -9,7 +9,9 @@
 
 package me.him188.ani.app.domain.media.selector
 
+import me.him188.ani.app.data.models.episode.EpisodeInfo
 import me.him188.ani.app.data.models.subject.SubjectInfo
+import me.him188.ani.app.domain.mediasource.MediaListFilters
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.EpisodeRange
 import me.him188.ani.utils.platform.annotations.Range
@@ -46,11 +48,13 @@ sealed class MaybeExcludedMedia {
      */
     data class Included(
         override val result: Media,
-        val similarity: @Range(from = 0L, to = 100L) Int,
+        val metadata: MatchMetadata,
     ) : MaybeExcludedMedia() {
         @UnsafeOriginalMediaAccess
         override val original: Media get() = result
         override val exclusionReason: Nothing? get() = null
+
+        val similarity: @Range(from = 0L, to = 100L) Int get() = metadata.similarity
     }
 
     /**
@@ -107,4 +111,43 @@ sealed class MediaExclusionReason {
      * 资源标题不匹配 (不包含 [SubjectInfo.allNames])
      */
     data object SubjectNameMismatch : MediaExclusionReason()
+}
+
+data class MatchMetadata(
+    val subjectMatchKind: SubjectMatchKind,
+    /**
+     * media 识别到了精准的 sort, 并且完全匹配正在观看的 [sort][EpisodeInfo.sort].
+     * 注意, 这不包含匹配 [EpisodeInfo.ep], 因为我们无法在第二季时根据 ep 区分是否正确.
+     */
+    val episodeMatchKind: EpisodeMatchKind,
+    val similarity: @Range(from = 0L, to = 100L) Int,
+) {
+    enum class SubjectMatchKind {
+        /**
+         * 没有精确匹配.
+         */
+        FUZZY,
+
+        /**
+         * media 识别到了精准的条目名称, 并且完全匹配正在观看的条目名称.
+         * @see MediaListFilters.specialEquals
+         */
+        EXACT,
+    }
+
+    enum class EpisodeMatchKind { // Element order has semantics. Check usage before changing.
+        NONE,
+
+        /**
+         * media 识别到了精准的 sort 或 ep, 并且完全匹配正在观看的 [ep][EpisodeInfo.ep].
+         * 注意, 如果能匹配正在观看的 [sort][EpisodeInfo.sort], 则会是 [SORT].
+         */
+        EP,
+
+        /**
+         * media 识别到了精准的 sort 或 ep, 并且完全匹配正在观看的 [sort][EpisodeInfo.sort].
+         * 注意, 这不包含匹配 [EpisodeInfo.ep], 因为我们无法在第二季时根据 ep 区分是否正确.
+         */
+        SORT,
+    }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MaybeExcludedMedia.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MaybeExcludedMedia.kt
@@ -15,6 +15,7 @@ import me.him188.ani.app.domain.mediasource.MediaListFilters
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.EpisodeRange
 import me.him188.ani.utils.platform.annotations.Range
+import me.him188.ani.utils.platform.annotations.TestOnly
 
 /**
  * 表示一个可能被排除的资源, 包含其被排除的原因.
@@ -151,3 +152,12 @@ data class MatchMetadata(
         SORT,
     }
 }
+
+@TestOnly
+val TestMatchMetadata
+    get() = MatchMetadata(
+        MatchMetadata.SubjectMatchKind.EXACT,
+        MatchMetadata.EpisodeMatchKind.EP,
+        90,
+    )
+

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -393,7 +393,7 @@ class DefaultMediaSelector(
                         }
                     },
             )
-    }.flowOn(flowCoroutineContext)
+    }.cached()
 
     override val filteredCandidatesMedia: Flow<List<Media>> = filteredCandidates.map { list ->
         list.mapNotNull { it.result }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -430,7 +430,7 @@ class DefaultMediaSelector(
             fun include(): MaybeExcludedMedia {
                 return MaybeExcludedMedia.Included(
                     media,
-                    metadata = computeMatchMetadata(
+                    metadata = calculateMatchMetadata(
                         contextSubjectNames,
                         mediaSubjectName,
                         media.episodeRange,
@@ -517,7 +517,7 @@ class DefaultMediaSelector(
 
     }
 
-    private fun computeMatchMetadata(
+    private fun calculateMatchMetadata(
         contextSubjectNames: Sequence<String>,
         mediaSubjectName: String,
         mediaEpisodeRange: EpisodeRange?,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -32,6 +32,7 @@ import me.him188.ani.app.domain.mediasource.MediaListFilter
 import me.him188.ani.app.domain.mediasource.MediaListFilterContext
 import me.him188.ani.app.domain.mediasource.MediaListFilters
 import me.him188.ani.app.domain.mediasource.StringMatcher
+import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.source.MediaSourceLocation
@@ -421,48 +422,20 @@ class DefaultMediaSelector(
             )
         } else null
 
-
         return list.fastMap filter@{ media ->
             val mediaSubjectName = media.properties.subjectName ?: media.originalTitle
-            val contextSubjectNames = context.subjectInfo?.allNames.orEmpty().asSequence() + sequenceOfEmptyString
-            val contextEpisodeSort = context.episodeInfo?.sort
-            val contextEpisodeEp = context.episodeInfo?.ep
-            val mediaEpisodeRange = media.episodeRange
+            val contextSubjectNames = context.subjectInfo?.allNames.orEmpty().asSequence()
 
             // 由下面实现调用, 方便创建 MaybeExcludedMedia
             fun include(): MaybeExcludedMedia {
                 return MaybeExcludedMedia.Included(
                     media,
-                    metadata = MatchMetadata(
-                        subjectMatchKind = if (
-                            contextSubjectNames.any {
-                                MediaListFilters.specialEquals(mediaSubjectName, it)
-                            }
-                        ) {
-                            MatchMetadata.SubjectMatchKind.EXACT
-                        } else {
-                            MatchMetadata.SubjectMatchKind.FUZZY
-                        },
-                        episodeMatchKind = if (mediaEpisodeRange != null) {
-                            when {
-                                contextEpisodeSort != null && contextEpisodeSort in mediaEpisodeRange -> {
-                                    MatchMetadata.EpisodeMatchKind.SORT
-                                }
-
-                                contextEpisodeEp != null && contextEpisodeEp in mediaEpisodeRange -> {
-                                    MatchMetadata.EpisodeMatchKind.EP
-                                }
-
-                                else -> {
-                                    MatchMetadata.EpisodeMatchKind.NONE
-                                }
-                            }
-                        } else {
-                            MatchMetadata.EpisodeMatchKind.NONE
-                        },
-                        similarity = contextSubjectNames
-                            .map { StringMatcher.calculateMatchRate(it, mediaSubjectName) }
-                            .max(),
+                    metadata = computeMatchMetadata(
+                        contextSubjectNames,
+                        mediaSubjectName,
+                        media.episodeRange,
+                        context.episodeInfo?.sort,
+                        context.episodeInfo?.ep,
                     ),
                 )
             }
@@ -543,6 +516,44 @@ class DefaultMediaSelector(
         }
 
     }
+
+    private fun computeMatchMetadata(
+        contextSubjectNames: Sequence<String>,
+        mediaSubjectName: String,
+        mediaEpisodeRange: EpisodeRange?,
+        contextEpisodeSort: EpisodeSort?,
+        contextEpisodeEp: EpisodeSort?
+    ) = MatchMetadata(
+        subjectMatchKind = if (
+            contextSubjectNames.any {
+                MediaListFilters.specialEquals(mediaSubjectName, it)
+            }
+        ) {
+            MatchMetadata.SubjectMatchKind.EXACT
+        } else {
+            MatchMetadata.SubjectMatchKind.FUZZY
+        },
+        episodeMatchKind = if (mediaEpisodeRange != null) {
+            when {
+                contextEpisodeSort != null && contextEpisodeSort in mediaEpisodeRange -> {
+                    MatchMetadata.EpisodeMatchKind.SORT
+                }
+
+                contextEpisodeEp != null && contextEpisodeEp in mediaEpisodeRange -> {
+                    MatchMetadata.EpisodeMatchKind.EP
+                }
+
+                else -> {
+                    MatchMetadata.EpisodeMatchKind.NONE
+                }
+            }
+        } else {
+            MatchMetadata.EpisodeMatchKind.NONE
+        },
+        similarity = (contextSubjectNames + sequenceOfEmptyString)
+            .map { StringMatcher.calculateMatchRate(it, mediaSubjectName) }
+            .max(),
+    )
 
     private val savedUserPreferenceNotCached = savedUserPreference
     private val savedUserPreference: Flow<MediaPreference> = savedUserPreference.cached()

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
@@ -245,7 +245,7 @@ abstract class SelectorMediaSourceEngine {
                     episodeName = info.name,
                     subtitleLanguageIds = subtitleLanguages,
                     resolution = config.defaultResolution.id,
-                    alliance = info.channel ?: mediaSourceId,
+                    alliance = info.channel ?: "",
                     size = FileSize.Unspecified,
                     subtitleKind = SubtitleKind.EMBEDDED,
                 ),

--- a/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/usecase/UseCaseModules.kt
@@ -27,6 +27,8 @@ import me.him188.ani.app.domain.episode.GetSubjectEpisodeInfoBundleFlowUseCase
 import me.him188.ani.app.domain.episode.GetSubjectEpisodeInfoBundleFlowUseCaseImpl
 import me.him188.ani.app.domain.episode.SetEpisodeCollectionTypeUseCase
 import me.him188.ani.app.domain.episode.SetEpisodeCollectionTypeUseCaseImpl
+import me.him188.ani.app.domain.media.selector.GetPreferredMediaSourceSortingUseCase
+import me.him188.ani.app.domain.media.selector.GetPreferredMediaSourceSortingUseCaseImpl
 import me.him188.ani.app.domain.media.selector.MediaSelectorAutoSelectUseCase
 import me.him188.ani.app.domain.media.selector.MediaSelectorAutoSelectUseCaseImpl
 import me.him188.ani.app.domain.media.selector.MediaSelectorEventSavePreferenceUseCase
@@ -59,6 +61,7 @@ fun KoinApplication.useCaseModules() = module {
     single<GetEpisodeCollectionTypeUseCase> { GetEpisodeCollectionTypeUseCaseImpl(koin) }
     single<GetAnimeScheduleFlowUseCase> { GetAnimeScheduleFlowUseCaseImpl(get(), get()) }
     single<PostCommentUseCase> { PostCommentUseCaseImpl(get(), get()) }
+    single<GetPreferredMediaSourceSortingUseCase> { GetPreferredMediaSourceSortingUseCaseImpl(get()) }
 }
 
 val GlobalKoin get() = KoinPlatform.getKoin()

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
@@ -103,7 +103,7 @@ class DefaultMediaSelectorMatchMetadataTest {
     }
 
     @TestFactory
-    fun `subject + episode combined test`() = runDynamicTests {
+    fun `subject and episode combined test`() = runDynamicTests {
         addMediaSelectorTest(
             "subject + episode combined test",
             {

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.selector
+
+import me.him188.ani.app.domain.media.selector.MatchMetadata.EpisodeMatchKind
+import me.him188.ani.app.domain.media.selector.MatchMetadata.SubjectMatchKind
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.topic.EpisodeRange
+import me.him188.ani.test.TestContainer
+import me.him188.ani.test.TestFactory
+import me.him188.ani.test.runDynamicTests
+
+@TestContainer
+class DefaultMediaSelectorMatchMetadataTest {
+    @TestFactory
+    fun `subjectMatchKind EXACT vs FUZZY`() = runDynamicTests {
+        addMediaSelectorTest(
+            "subject match kind tests",
+            {
+                initSubject("Bocchi The Rock") {}
+            },
+        ) {
+            checkMatchMetadata {
+                expect(
+                    mediaSubjectName = "Bocchi The Rock",
+                    episodeRange = EpisodeRange.single(EpisodeSort(1)),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.SORT,
+                )
+                expect(
+                    mediaSubjectName = "Bocchi The Rock 2",
+                    episodeRange = EpisodeRange.single(EpisodeSort(2)),
+                    subjectMatchKind = SubjectMatchKind.FUZZY,
+                    episodeMatchKind = EpisodeMatchKind.NONE,
+                )
+            }
+        }
+    }
+
+    @TestFactory
+    fun `episodeMatchKind for sorts`() = runDynamicTests {
+        addMediaSelectorTest(
+            "episode match kind - sorts",
+            {
+                initSubject(
+                    subjectName = "Test Anime",
+                ) {
+                    this.episodeSort = EpisodeSort(10)
+                }
+            },
+        ) {
+            checkMatchMetadata {
+                expect(
+                    mediaSubjectName = "Test Anime",
+                    episodeRange = EpisodeRange.single(EpisodeSort(10)),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.SORT,
+                )
+
+                expect(
+                    mediaSubjectName = "Test Anime",
+                    episodeRange = EpisodeRange.single(EpisodeSort(11)),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.NONE,
+                )
+            }
+        }
+    }
+
+    @TestFactory
+    fun `episodeMatchKind for ep`() = runDynamicTests {
+        addMediaSelectorTest(
+            "episode match kind - ep",
+            {
+                initSubject("My OVA") {
+                    episodeEp = EpisodeSort("7")
+                }
+            },
+        ) {
+            checkMatchMetadata {
+                expect(
+                    mediaSubjectName = "My OVA",
+                    episodeRange = EpisodeRange.single(EpisodeSort("7")),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.EP,
+                )
+
+                expect(
+                    mediaSubjectName = "My OVA",
+                    episodeRange = EpisodeRange.single(EpisodeSort("8")),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.NONE,
+                )
+            }
+        }
+    }
+
+    @TestFactory
+    fun `subject + episode combined test`() = runDynamicTests {
+        addMediaSelectorTest(
+            "subject + episode combined test",
+            {
+                initSubject("进击的巨人") {
+                    episodeSort = EpisodeSort(2)
+                }
+            },
+        ) {
+            checkMatchMetadata {
+                expect(
+                    mediaSubjectName = "进击的巨人",
+                    episodeRange = EpisodeRange.single(EpisodeSort(2)),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.SORT,
+                )
+                expect(
+                    mediaSubjectName = "进击的巨人 第二季",
+                    episodeRange = EpisodeRange.single(EpisodeSort(2)),
+                    subjectMatchKind = SubjectMatchKind.FUZZY,
+                    episodeMatchKind = EpisodeMatchKind.SORT,
+                )
+                expect(
+                    mediaSubjectName = "进击的巨人",
+                    episodeRange = EpisodeRange.single(EpisodeSort(3)),
+                    subjectMatchKind = SubjectMatchKind.EXACT,
+                    episodeMatchKind = EpisodeMatchKind.NONE,
+                )
+            }
+        }
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/DefaultMediaSelectorMatchMetadataTest.kt
@@ -105,7 +105,7 @@ class DefaultMediaSelectorMatchMetadataTest {
     @TestFactory
     fun `subject and episode combined test`() = runDynamicTests {
         addMediaSelectorTest(
-            "subject + episode combined test",
+            "subject and episode combined test",
             {
                 initSubject("进击的巨人") {
                     episodeSort = EpisodeSort(2)

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
@@ -26,6 +26,7 @@ import me.him188.ani.app.domain.media.selector.DefaultMediaSelector
 import me.him188.ani.app.domain.media.selector.MaybeExcludedMedia
 import me.him188.ani.app.domain.media.selector.MediaExclusionReason
 import me.him188.ani.app.domain.media.selector.MediaSelectorContext
+import me.him188.ani.app.domain.media.selector.TestMatchMetadata
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.datasources.api.CachedMedia
 import me.him188.ani.datasources.api.Media
@@ -100,7 +101,7 @@ private fun PreviewMediaItemIncluded(modifier: Modifier = Modifier) = ProvideCom
     MediaSelectorItem(
         remember {
             MediaGroupBuilder("Test").apply {
-                add(previewMediaList[0].let { MaybeExcludedMedia.Included(it, similarity = 90) })
+                add(previewMediaList[0].let { MaybeExcludedMedia.Included(it, TestMatchMetadata) })
             }.build()
         },
         remember { MediaGroupState("test") },

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
@@ -12,8 +12,10 @@ package me.him188.ani.app.ui.subject.episode.mediaFetch
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.data.models.preference.MediaPreference
@@ -45,7 +47,8 @@ internal val previewMediaList = TestMediaList.run {
 @PreviewLightDark
 @Composable
 private fun PreviewMediaSelector() {
-    val mediaSelector = rememberTestMediaSelectorPresentation(previewMediaList)
+    val scope = rememberCoroutineScope()
+    val mediaSelector = rememberTestMediaSelectorPresentation(previewMediaList, scope)
     ProvideCompositionLocalsForPreview {
         Surface {
             MediaSelectorView(
@@ -58,6 +61,8 @@ private fun PreviewMediaSelector() {
                         onRestartSource = {},
                     )
                 },
+                onRestartSource = {
+                }
             )
         }
     }
@@ -65,8 +70,8 @@ private fun PreviewMediaSelector() {
 
 @Composable
 @OptIn(TestOnly::class)
-private fun rememberTestMediaSelectorPresentation(previewMediaList: List<Media>) =
-    rememberMediaSelectorState(rememberTestMediaSourceInfoProvider()) {
+private fun rememberTestMediaSelectorPresentation(previewMediaList: List<Media>, scope: CoroutineScope) =
+    rememberMediaSelectorState(rememberTestMediaSourceInfoProvider(), createTestMediaSourceResultsFilterer(scope).filteredSourceResults) {
         DefaultMediaSelector(
             mediaSelectorContextNotCached = flowOf(MediaSelectorContext.EmptyForPreview),
             mediaListNotCached = MutableStateFlow(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -418,7 +418,7 @@ private fun EpisodeScreenTabletVeryWide(
                                         }
                                     },
                                     onRefreshMediaSources = { vm.refreshFetch() },
-                                    onRestartSource = { vm.restartSource(it.instanceId) },
+                                    onRestartSource = { vm.restartSource(it) },
                                     onSetDanmakuSourceEnabled = { providerId, enabled ->
                                         vm.setDanmakuSourceEnabled(providerId, enabled)
                                     },
@@ -536,7 +536,7 @@ private fun EpisodeScreenContentPhone(
                         }
                     },
                     onRefreshMediaSources = { vm.refreshFetch() },
-                    onRestartSource = { vm.restartSource(it.instanceId) },
+                    onRestartSource = { vm.restartSource(it) },
                     onSetDanmakuSourceEnabled = { providerId, enabled ->
                         vm.setDanmakuSourceEnabled(providerId, enabled)
                     },
@@ -857,7 +857,7 @@ private fun EpisodeVideo(
                             page.mediaSourceResultListPresentation,
                             onDismissRequest = { goBack() },
                             onRefresh = { vm.refreshFetch() },
-                            onRestartSource = { vm.restartSource(it.instanceId) },
+                            onRestartSource = { vm.restartSource(it) },
                         )
                     }
                 },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -540,7 +540,7 @@ class EpisodeViewModel(
         val mediaSourceResultsFlow = MediaSourceResultListPresenter(
             filteredSourceResults,
             flowScope = this,
-        ).presentationFlow.sample(200.milliseconds)
+        ).presentationFlow.sampleWithInitial(200.milliseconds)
         return me.him188.ani.utils.coroutines.flows.combine(
             authStateProvider.state,
             episodeSession.infoBundleFlow.distinctUntilChanged().onStart { emit(null) },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -530,14 +530,15 @@ class EpisodeViewModel(
     }.stateIn(backgroundScope, started = SharingStarted.WhileSubscribed(5_000), null)
 
     private fun CoroutineScope.createPageStateFlow(episodeSession: EpisodeSession): Flow<EpisodePageState> {
+        val filteredSourceResults = MediaSourceResultsFilterer(
+            results = episodeSession.fetchSelectFlow.map {
+                it?.mediaFetchSession?.mediaSourceResults ?: emptyList()
+            },
+            settings = settingsRepository.mediaSelectorSettings.flow,
+            flowScope = this,
+        ).filteredSourceResults
         val mediaSourceResultsFlow = MediaSourceResultListPresenter(
-            MediaSourceResultsFilterer(
-                results = episodeSession.fetchSelectFlow.map {
-                    it?.mediaFetchSession?.mediaSourceResults ?: emptyList()
-                },
-                settings = settingsRepository.mediaSelectorSettings.flow,
-                flowScope = this,
-            ).filteredSourceResults,
+            filteredSourceResults,
             flowScope = this,
         ).presentationFlow.sample(200.milliseconds)
         return me.him188.ani.utils.coroutines.flows.combine(
@@ -554,11 +555,15 @@ class EpisodeViewModel(
             settingsRepository.danmakuEnabled.flow,
             settingsRepository.danmakuConfig.flow,
             episodeSession.fetchSelectFlow.map { fetchSelect ->
-                if (fetchSelect != null) MediaSelectorState(
-                    fetchSelect.mediaSelector,
-                    mediaSourceInfoProvider,
-                    backgroundScope,
-                ) else {
+                if (fetchSelect != null) {
+                    MediaSelectorState(
+                        fetchSelect.mediaSelector,
+                        filteredSourceResults,
+                        mediaSourceInfoProvider,
+                        backgroundScope,
+                        koin.get(),
+                    )
+                } else {
                     // TODO: 2025/1/22 We should not use createTestMediaSelectorState
                     @OptIn(TestOnly::class)
                     createTestMediaSelectorState(backgroundScope)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -540,7 +540,7 @@ class EpisodeViewModel(
         val mediaSourceResultsFlow = MediaSourceResultListPresenter(
             filteredSourceResults,
             flowScope = this,
-        ).presentationFlow.sampleWithInitial(200.milliseconds)
+        ).presentationFlow
         return me.him188.ani.utils.coroutines.flows.combine(
             authStateProvider.state,
             episodeSession.infoBundleFlow.distinctUntilChanged().onStart { emit(null) },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -39,6 +39,8 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -234,9 +236,11 @@ fun EpisodeDetails(
         exposedEpisodeItem = { innerPadding ->
             var showMediaSelector by rememberSaveable { mutableStateOf(false) }
             if (showMediaSelector) {
+                val sheetState =
+                    rememberModalBottomSheetState(skipPartiallyExpanded = LocalPlatform.current.isDesktop())
                 ModalBottomSheet(
                     { showMediaSelector = false },
-                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = LocalPlatform.current.isDesktop()),
+                    sheetState = sheetState,
                     modifier = Modifier.desktopTitleBarPadding().statusBarsPadding(),
                     contentWindowInsets = { BottomSheetDefaults.windowInsets.add(WindowInsets.desktopTitleBar()) },
                 ) {
@@ -248,6 +252,7 @@ fun EpisodeDetails(
                         onRestartSource = onRestartSource,
                         onSelected = { showMediaSelector = false },
                         stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
+                        scrollable = sheetState.targetValue == SheetValue.Expanded,
                     )
                 }
             }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -126,7 +126,7 @@ fun EpisodeDetails(
     authState: AuthState,
     onSwitchEpisode: (episodeId: Int) -> Unit,
     onRefreshMediaSources: () -> Unit,
-    onRestartSource: (MediaSourceResultPresentation) -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     onSetDanmakuSourceEnabled: (providerId: String, enabled: Boolean) -> Unit,
     onClickLogin: () -> Unit,
     modifier: Modifier = Modifier,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
@@ -34,7 +34,7 @@ fun EpisodePlayMediaSelector(
     sourceResults: () -> MediaSourceResultListPresentation,
     onDismissRequest: () -> Unit,
     onRefresh: () -> Unit,
-    onRestartSource: (MediaSourceResultPresentation) -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
     stickyHeaderBackgroundColor: Color = Color.Unspecified,
     onSelected: (Media) -> Unit = {},
@@ -48,6 +48,7 @@ fun EpisodePlayMediaSelector(
                 onRestartSource = onRestartSource,
             )
         },
+        onRestartSource,
         modifier.padding(vertical = 12.dp, horizontal = 16.dp)
             .fillMaxWidth()
             .navigationBarsPadding(),

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
@@ -38,6 +38,7 @@ fun EpisodePlayMediaSelector(
     modifier: Modifier = Modifier,
     stickyHeaderBackgroundColor: Color = Color.Unspecified,
     onSelected: (Media) -> Unit = {},
+    scrollable: Boolean = true,
 ) {
     MediaSelectorView(
         mediaSelector,
@@ -63,5 +64,6 @@ fun EpisodePlayMediaSelector(
                 Text("取消")
             }
         },
+        scrollable = scrollable,
     )
 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
@@ -55,6 +55,7 @@ import me.him188.ani.app.ui.mediaselect.selector.WebSource
 import me.him188.ani.app.ui.mediaselect.selector.WebSourceChannel
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.utils.coroutines.sampleWithInitial
 import me.him188.ani.utils.platform.annotations.TestOnly
 import me.him188.ani.utils.platform.collections.tupleOf
 import kotlin.time.Duration.Companion.milliseconds
@@ -289,7 +290,7 @@ class MediaSelectorState(
                     it.filterNotNull()
                 }
             }
-        }.debounce(200.milliseconds)
+        }.sampleWithInitial(200.milliseconds)
             .catch {
                 it.printStackTrace()
                 ErrorReport.captureException(it) {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
@@ -21,13 +21,13 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -49,17 +49,14 @@ import me.him188.ani.app.domain.media.selector.MediaSelector
 import me.him188.ani.app.domain.media.selector.MediaSelectorContext
 import me.him188.ani.app.domain.usecase.GlobalKoin
 import me.him188.ani.app.tools.MonoTasker
-import me.him188.ani.app.trace.ErrorReport
 import me.him188.ani.app.ui.foundation.rememberBackgroundScope
 import me.him188.ani.app.ui.mediaselect.selector.WebSource
 import me.him188.ani.app.ui.mediaselect.selector.WebSourceChannel
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
-import me.him188.ani.utils.coroutines.sampleWithInitial
 import me.him188.ani.utils.platform.annotations.TestOnly
 import me.him188.ani.utils.platform.collections.tupleOf
-import kotlin.time.Duration.Companion.milliseconds
 
 // todo: shit
 @Composable
@@ -246,6 +243,8 @@ class MediaSelectorState(
             tupleOf(sources, mediaList)
         }.flatMapLatest { (sources, allMediaList) ->
             val showWebSources = sources.map { source ->
+
+                // 属于这个数据源的 medias
                 val myMediaList = allMediaList
                     .asSequence()
                     .filter {
@@ -270,7 +269,10 @@ class MediaSelectorState(
                             WebSourceChannel(media.properties.alliance, original = media)
                         }.toList()
 
-                        if (channels.isEmpty() && state is MediaSourceFetchState.Succeed) {
+                        if (channels.isEmpty()
+                            && state is MediaSourceFetchState.Succeed
+                        ) {
+                            delay(1000)
                             null // 查询成功, 0 条, 隐藏
                         } else {
                             WebSource(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
@@ -55,6 +55,7 @@ import me.him188.ani.app.ui.mediaselect.selector.WebSource
 import me.him188.ani.app.ui.mediaselect.selector.WebSourceChannel
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
 import me.him188.ani.utils.coroutines.sampleWithInitial
 import me.him188.ani.utils.platform.annotations.TestOnly
 import me.him188.ani.utils.platform.collections.tupleOf
@@ -248,9 +249,11 @@ class MediaSelectorState(
                 val myMediaList = allMediaList
                     .asSequence()
                     .filter {
+                        // Filter medias that are from this source
                         it.result?.mediaSourceId == source.mediaSourceId // null result gives `false` and is hence excluded
                     }
                     .filter {
+                        // Take only exact matches
                         when (it) {
                             is MaybeExcludedMedia.Excluded -> false
                             is MaybeExcludedMedia.Included -> {
@@ -271,9 +274,10 @@ class MediaSelectorState(
                             null // 查询成功, 0 条, 隐藏
                         } else {
                             WebSource(
-                                source.instanceId,
-                                source.mediaSourceId,
-                                source.sourceInfo.iconUrl ?: "", source.sourceInfo.displayName,
+                                instanceId = source.instanceId,
+                                mediaSourceId = source.mediaSourceId,
+                                iconUrl = source.sourceInfo.iconUrl ?: "",
+                                name = source.sourceInfo.displayName,
                                 channels = channels,
                                 isLoading = state.isWorking,
                                 isError = state.isFailedOrAbandoned,
@@ -282,7 +286,7 @@ class MediaSelectorState(
                     }
             }
             if (showWebSources.isEmpty()) {
-                flowOf(emptyList())
+                flowOfEmptyList()
             } else {
                 combine(
                     showWebSources,
@@ -290,13 +294,7 @@ class MediaSelectorState(
                     it.filterNotNull()
                 }
             }
-        }.sampleWithInitial(200.milliseconds)
-            .catch {
-                it.printStackTrace()
-                ErrorReport.captureException(it) {
-                    this.setTag("module", "media selector")
-                }
-            }
+        }
     }
 
     /**

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorState.kt
@@ -224,18 +224,6 @@ class MediaSelectorState(
         ),
     )
 
-    suspend fun selectWebSource(webSource: WebSource, channel: WebSourceChannel) {
-//        val mediaList = mediaSelector.preferredCandidates.first()
-//        mediaSelector.select(
-//            mediaList.asSequence().mapNotNull { it.result }.find {
-//                it.mediaSourceId == webSource.mediaSourceId && it.properties.
-//            },
-//        )
-        channel.original?.let {
-            mediaSelector.select(it)
-        }
-    }
-
     private fun createWebSourcesFlow(
         getPreferredMediaSourceSortingUseCase: GetPreferredMediaSourceSortingUseCase,
     ): Flow<List<WebSource>> {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -154,18 +154,18 @@ fun MediaSelectorView(
                     onShowExcludedChange = { showExcluded = !showExcluded },
                     Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
                 )
-            }
-        }
 
-        if (bottomActions != null) {
-            HorizontalDivider(Modifier.padding(bottom = 8.dp))
+                if (bottomActions != null) {
+                    HorizontalDivider(Modifier.padding(bottom = 8.dp))
 
-            Row(
-                Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                ProvideTextStyle(MaterialTheme.typography.labelLarge) {
-                    bottomActions()
+                    Row(
+                        Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ProvideTextStyle(MaterialTheme.typography.labelLarge) {
+                            bottomActions()
+                        }
+                    }
                 }
             }
         }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.ui.subject.episode.mediaFetch
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -58,6 +59,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import me.him188.ani.app.domain.media.selector.UnsafeOriginalMediaAccess
 import me.him188.ani.app.platform.currentAniBuildConfig
+import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.widgets.FastLinearProgressIndicator
 import me.him188.ani.app.ui.mediaselect.selector.MediaSelectorWebSourcesColumn
@@ -128,46 +130,56 @@ fun MediaSelectorView(
             }
         }
 
-        when (selectedViewKind) {
-            ViewKind.WEB -> {
-                MediaSelectorWebSourcesColumn(
-                    presentation.webSources,
-                    selectedSource = { presentation.selectedWebSource },
-                    selectedChannel = { presentation.selectedWebSourceChannel },
-                    onSelect = { _, channel ->
-                        channel.original?.let { onClickItem(it) }
-                    },
-                    onRefresh = { onRestartSource(it.instanceId) },
-                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false)
-                        .ifThen(scrollable) { verticalScroll(rememberScrollState()) },
-                )
-            }
+        AnimatedContent(
+            selectedViewKind,
+            transitionSpec = LocalAniMotionScheme.current.animatedContent.topLevel,
+            contentAlignment = Alignment.TopCenter,
+        ) { target ->
+            when (target) {
+                ViewKind.WEB -> {
+                    MediaSelectorWebSourcesColumn(
+                        presentation.webSources,
+                        selectedSource = { presentation.selectedWebSource },
+                        selectedChannel = { presentation.selectedWebSourceChannel },
+                        onSelect = { _, channel ->
+                            channel.original?.let { onClickItem(it) }
+                        },
+                        onRefresh = { onRestartSource(it.instanceId) },
+                        Modifier.padding(bottom = WINDOW_VERTICAL_PADDING)
+                            .weight(1f, fill = false)
+                            .fillMaxWidth()
+                            .ifThen(scrollable) { verticalScroll(rememberScrollState()) },
+                    )
+                }
 
-            ViewKind.BT -> {
-                LegacyBTSourceColumn(
-                    lazyListState,
-                    presentation,
-                    sourceResults,
-                    stickyHeaderBackgroundColor,
-                    state,
-                    singleLineFilter,
-                    bringIntoViewRequesters,
-                    onClickItem,
-                    itemProgressBar,
-                    showExcluded,
-                    onShowExcludedChange = { showExcluded = !showExcluded },
-                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
-                )
+                ViewKind.BT -> {
+                    LegacyBTSourceColumn(
+                        lazyListState,
+                        presentation,
+                        sourceResults,
+                        stickyHeaderBackgroundColor,
+                        state,
+                        singleLineFilter,
+                        bringIntoViewRequesters,
+                        onClickItem,
+                        itemProgressBar,
+                        showExcluded,
+                        onShowExcludedChange = { showExcluded = !showExcluded },
+                        Modifier.padding(bottom = WINDOW_VERTICAL_PADDING)
+                            .fillMaxWidth()
+                            .weight(1f, fill = false),
+                    )
 
-                if (bottomActions != null) {
-                    HorizontalDivider(Modifier.padding(bottom = 8.dp))
+                    if (bottomActions != null) {
+                        HorizontalDivider(Modifier.padding(bottom = 8.dp))
 
-                    Row(
-                        Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        ProvideTextStyle(MaterialTheme.typography.labelLarge) {
-                            bottomActions()
+                        Row(
+                            Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            ProvideTextStyle(MaterialTheme.typography.labelLarge) {
+                                bottomActions()
+                            }
                         }
                     }
                 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -153,32 +153,34 @@ fun MediaSelectorView(
                 }
 
                 ViewKind.BT -> {
-                    LegacyBTSourceColumn(
-                        lazyListState,
-                        presentation,
-                        sourceResults,
-                        stickyHeaderBackgroundColor,
-                        state,
-                        singleLineFilter,
-                        bringIntoViewRequesters,
-                        onClickItem,
-                        itemProgressBar,
-                        showExcluded,
-                        onShowExcludedChange = { showExcluded = !showExcluded },
-                        Modifier.padding(bottom = WINDOW_VERTICAL_PADDING)
-                            .fillMaxWidth()
-                            .weight(1f, fill = false),
-                    )
+                    Column {
+                        LegacyBTSourceColumn(
+                            lazyListState,
+                            presentation,
+                            sourceResults,
+                            stickyHeaderBackgroundColor,
+                            state,
+                            singleLineFilter,
+                            bringIntoViewRequesters,
+                            onClickItem,
+                            itemProgressBar,
+                            showExcluded,
+                            onShowExcludedChange = { showExcluded = !showExcluded },
+                            Modifier.padding(bottom = WINDOW_VERTICAL_PADDING)
+                                .fillMaxWidth()
+                                .weight(1f, fill = false),
+                        )
 
-                    if (bottomActions != null) {
-                        HorizontalDivider(Modifier.padding(bottom = 8.dp))
+                        if (bottomActions != null) {
+                            HorizontalDivider(Modifier.padding(bottom = 8.dp))
 
-                        Row(
-                            Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            ProvideTextStyle(MaterialTheme.typography.labelLarge) {
-                                bottomActions()
+                            Row(
+                                Modifier.align(Alignment.End).padding(bottom = 8.dp).padding(horizontal = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                ProvideTextStyle(MaterialTheme.typography.labelLarge) {
+                                    bottomActions()
+                                }
                             }
                         }
                     }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -131,10 +131,8 @@ fun MediaSelectorView(
                     presentation.webSources,
                     selectedSource = { presentation.selectedWebSource },
                     selectedChannel = { presentation.selectedWebSourceChannel },
-                    onSelect = { webSource, channel ->
-                        uiScope.launch {
-                            state.selectWebSource(webSource, channel)
-                        }
+                    onSelect = { _, channel ->
+                        channel.original?.let { onClickItem(it) }
                     },
                     onRefresh = { onRestartSource(it.instanceId) },
                     Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.relocation.BringIntoViewRequester
@@ -27,6 +28,9 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -38,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -49,9 +54,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 import me.him188.ani.app.domain.media.selector.UnsafeOriginalMediaAccess
 import me.him188.ani.app.platform.currentAniBuildConfig
 import me.him188.ani.app.ui.foundation.widgets.FastLinearProgressIndicator
+import me.him188.ani.app.ui.mediaselect.selector.MediaSelectorWebSourcesColumn
 import me.him188.ani.datasources.api.Media
 
 
@@ -68,6 +75,7 @@ private inline val WINDOW_VERTICAL_PADDING get() = 8.dp
 fun MediaSelectorView(
     state: MediaSelectorState,
     sourceResults: @Composable LazyItemScope.() -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
     stickyHeaderBackgroundColor: Color = Color.Unspecified,
     itemProgressBar: @Composable RowScope.(MediaGroup) -> Unit = { group ->
@@ -89,88 +97,66 @@ fun MediaSelectorView(
 ) {
     val bringIntoViewRequesters = remember { mutableStateMapOf<Media, BringIntoViewRequester>() }
     val presentation by state.presentationFlow.collectAsStateWithLifecycle()
+    val uiScope = rememberCoroutineScope()
+
     Column(modifier) {
         val lazyListState = rememberLazyListState()
         var showExcluded by rememberSaveable { mutableStateOf(false) }
-        LazyColumn(
-            Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
-            lazyListState,
+
+        // 切换数据源类型的按钮
+        var selectedViewKind by rememberSaveable { mutableStateOf(ViewKind.WEB) }
+        SingleChoiceSegmentedButtonRow(
+            Modifier.fillMaxWidth().padding(bottom = 16.dp),
         ) {
-            if (currentAniBuildConfig.isDebug) {
-                item {
-                    Surface {
-                        Row {
-                            Text("Debug tools: ")
-                            FilledTonalButton(onClick = { MediaSelectorDebugTools.dumpSubjectNames(presentation.filteredCandidates) }) {
-                                Text("Dump unique media lists")
-                            }
+            // TODO: 2025/3/7 如果用户设置是优先选择 BT, 则默认选择 BT
+            SegmentedButton(
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                onClick = { selectedViewKind = ViewKind.WEB },
+                selected = selectedViewKind == ViewKind.WEB,
+            ) {
+                Text("简单模式", softWrap = false)
+            }
+            SegmentedButton(
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                onClick = { selectedViewKind = ViewKind.BT },
+                selected = selectedViewKind == ViewKind.BT,
+            ) {
+                Text("详细模式", softWrap = false)
+            }
+        }
+
+        when (selectedViewKind) {
+            ViewKind.WEB -> {
+                MediaSelectorWebSourcesColumn(
+                    presentation.webSources,
+                    selectedSource = { presentation.selectedWebSource },
+                    selectedChannel = { presentation.selectedWebSourceChannel },
+                    onSelect = { webSource, channel ->
+                        uiScope.launch {
+                            state.selectWebSource(webSource, channel)
                         }
-                    }
-                }
-            }
-            item {
-                Row(Modifier.padding(bottom = 12.dp)) {
-                    sourceResults()
-                }
+                    },
+                    onRefresh = { onRestartSource(it.instanceId) },
+                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
+                )
             }
 
-            stickyHeader {
-                val isStuck by remember(lazyListState) {
-                    derivedStateOf {
-                        lazyListState.firstVisibleItemIndex == 1
-                    }
-                }
-                Column(
-                    Modifier.background(stickyHeaderBackgroundColor).padding(bottom = 12.dp)
-                        .fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        remember(presentation.preferredCandidates.size, presentation.filteredCandidates.size) {
-                            "筛选到 ${presentation.preferredCandidates.size}/${presentation.filteredCandidates.size} 条资源"
-                        },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-
-                    MediaSelectorFilters(
-                        resolution = state.resolution,
-                        subtitleLanguageId = state.subtitleLanguageId,
-                        alliance = state.alliance,
-                        singleLine = singleLineFilter,
-                    )
-                }
-                if (isStuck) {
-                    HorizontalDivider(Modifier.fillMaxWidth(), thickness = 2.dp)
-                }
+            ViewKind.BT -> {
+                LegacyBTSourceColumn(
+                    lazyListState,
+                    presentation,
+                    sourceResults,
+                    stickyHeaderBackgroundColor,
+                    state,
+                    singleLineFilter,
+                    bringIntoViewRequesters,
+                    onClickItem,
+                    itemProgressBar,
+                    showExcluded,
+                    onShowExcludedChange = { showExcluded = !showExcluded },
+                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
+                )
             }
-
-            items(presentation.groupedMediaListIncluded, key = { it.groupId }) { group ->
-                MediaItemGroup(group, bringIntoViewRequesters, state, presentation, onClickItem, itemProgressBar)
-            }
-
-            if (presentation.groupedMediaListExcluded.isNotEmpty()) {
-                item {
-                    Row(
-                        Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            "显示已被排除的资源 (${presentation.groupedMediaListExcluded.size})",
-                            Modifier.padding(end = 8.dp),
-                            style = MaterialTheme.typography.labelLarge,
-                        )
-                        Switch(showExcluded, { showExcluded = !showExcluded })
-                    }
-                }
-            }
-            if (showExcluded) {
-                items(presentation.groupedMediaListExcluded, key = { it.groupId }) { group ->
-                    MediaItemGroup(group, bringIntoViewRequesters, state, presentation, onClickItem, itemProgressBar)
-                }
-            }
-
-            item { } // dummy spacer
         }
 
         if (bottomActions != null) {
@@ -195,6 +181,108 @@ fun MediaSelectorView(
                 bringIntoViewRequesters[it]?.bringIntoView()
             }
     }
+}
+
+@Composable
+private fun LegacyBTSourceColumn(
+    lazyListState: LazyListState,
+    presentation: MediaSelectorState.Presentation,
+    sourceResults: @Composable() (LazyItemScope.() -> Unit),
+    stickyHeaderBackgroundColor: Color,
+    state: MediaSelectorState,
+    singleLineFilter: Boolean,
+    bringIntoViewRequesters: SnapshotStateMap<Media, BringIntoViewRequester>,
+    onClickItem: (Media) -> Unit,
+    itemProgressBar: @Composable() (RowScope.(MediaGroup) -> Unit),
+    showExcluded: Boolean,
+    onShowExcludedChange: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier,
+        lazyListState,
+    ) {
+        if (currentAniBuildConfig.isDebug) {
+            item {
+                Surface {
+                    Row {
+                        Text("Debug tools: ")
+                        FilledTonalButton(onClick = { MediaSelectorDebugTools.dumpSubjectNames(presentation.filteredCandidates) }) {
+                            Text("Dump unique media lists")
+                        }
+                    }
+                }
+            }
+        }
+        item {
+            Row(Modifier.padding(bottom = 12.dp)) {
+                sourceResults()
+            }
+        }
+
+        stickyHeader {
+            val isStuck by remember(lazyListState) {
+                derivedStateOf {
+                    lazyListState.firstVisibleItemIndex == 1
+                }
+            }
+            Column(
+                Modifier.background(stickyHeaderBackgroundColor).padding(bottom = 12.dp)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    remember(presentation.preferredCandidates.size, presentation.filteredCandidates.size) {
+                        "筛选到 ${presentation.preferredCandidates.size}/${presentation.filteredCandidates.size} 条资源"
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                )
+
+                MediaSelectorFilters(
+                    resolution = state.resolution,
+                    subtitleLanguageId = state.subtitleLanguageId,
+                    alliance = state.alliance,
+                    singleLine = singleLineFilter,
+                )
+            }
+            if (isStuck) {
+                HorizontalDivider(Modifier.fillMaxWidth(), thickness = 2.dp)
+            }
+        }
+
+        items(presentation.groupedMediaListIncluded, key = { it.groupId }) { group ->
+            MediaItemGroup(group, bringIntoViewRequesters, state, presentation, onClickItem, itemProgressBar)
+        }
+
+        if (presentation.groupedMediaListExcluded.isNotEmpty()) {
+            item {
+                Row(
+                    Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        "显示已被排除的资源 (${presentation.groupedMediaListExcluded.size})",
+                        Modifier.padding(end = 8.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                    Switch(showExcluded, { onShowExcludedChange() })
+                }
+            }
+        }
+        if (showExcluded) {
+            items(presentation.groupedMediaListExcluded, key = { it.groupId }) { group ->
+                MediaItemGroup(group, bringIntoViewRequesters, state, presentation, onClickItem, itemProgressBar)
+            }
+        }
+
+        item { } // dummy spacer
+    }
+}
+
+private enum class ViewKind {
+    WEB,
+    BT,
 }
 
 @OptIn(UnsafeOriginalMediaAccess::class)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -54,9 +56,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.launch
 import me.him188.ani.app.domain.media.selector.UnsafeOriginalMediaAccess
 import me.him188.ani.app.platform.currentAniBuildConfig
+import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.widgets.FastLinearProgressIndicator
 import me.him188.ani.app.ui.mediaselect.selector.MediaSelectorWebSourcesColumn
 import me.him188.ani.datasources.api.Media
@@ -94,6 +96,7 @@ fun MediaSelectorView(
     onClickItem: ((Media) -> Unit) = { state.select(it) },
     bottomActions: (@Composable RowScope.() -> Unit)? = null,
     singleLineFilter: Boolean = false,
+    scrollable: Boolean = true,
 ) {
     val bringIntoViewRequesters = remember { mutableStateMapOf<Media, BringIntoViewRequester>() }
     val presentation by state.presentationFlow.collectAsStateWithLifecycle()
@@ -135,7 +138,8 @@ fun MediaSelectorView(
                         channel.original?.let { onClickItem(it) }
                     },
                     onRefresh = { onRestartSource(it.instanceId) },
-                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false),
+                    Modifier.padding(bottom = WINDOW_VERTICAL_PADDING).weight(1f, fill = false)
+                        .ifThen(scrollable) { verticalScroll(rememberScrollState()) },
                 )
             }
 

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultPresentation.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultPresentation.kt
@@ -9,7 +9,6 @@
 
 package me.him188.ani.app.ui.subject.episode.mediaFetch
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import kotlinx.atomicfu.atomic
@@ -119,57 +118,61 @@ class MediaSourceResultListPresenter(
 ///////////////////////////////////////////////////////////////////////////
 
 @TestOnly
-@Composable
 fun createTestMediaSourceResultsPresenter(
     flowScope: CoroutineScope,
 ): MediaSourceResultListPresenter {
     return MediaSourceResultListPresenter(
-        MediaSourceResultsFilterer(
-            results = flowOf(
-                listOf(
-                    TestMediaSourceResult(
-                        MikanMediaSource.ID,
-                        MikanMediaSource.INFO,
-                        MediaSourceKind.BitTorrent,
-                        initialState = MediaSourceFetchState.Working,
-                        results = TestMediaList,
-                    ),
-                    TestMediaSourceResult(
-                        "dmhy",
-                        MediaSourceInfo("dmhy"),
-                        MediaSourceKind.BitTorrent,
-                        initialState = MediaSourceFetchState.Succeed(1),
-                        results = TestMediaList,
-                    ),
-                    TestMediaSourceResult(
-                        "acg.rip",
-                        MediaSourceInfo("acg.rip"),
-                        MediaSourceKind.BitTorrent,
-                        initialState = MediaSourceFetchState.Disabled,
-                        results = TestMediaList,
-                    ),
-                    TestMediaSourceResult(
-                        "nyafun",
-                        MediaSourceInfo("nyafun"),
-                        MediaSourceKind.WEB,
-                        initialState = MediaSourceFetchState.Succeed(1),
-                        results = TestMediaList,
-                    ),
-                    TestMediaSourceResult(
-                        MikanCNMediaSource.ID,
-                        MikanCNMediaSource.INFO,
-                        MediaSourceKind.BitTorrent,
-                        initialState = MediaSourceFetchState.Failed(IllegalStateException(), 1),
-                        results = emptyList(),
-                    ),
-                ),
-            ),
-            settings = flowOf(MediaSelectorSettings.Default),
-            flowScope = flowScope,
-        ).filteredSourceResults,
+        createTestMediaSourceResultsFilterer(flowScope).filteredSourceResults,
         flowScope = flowScope,
     )
 }
+
+@TestOnly
+fun createTestMediaSourceResultsFilterer(
+    flowScope: CoroutineScope
+) = MediaSourceResultsFilterer(
+    results = flowOf(
+        listOf(
+            TestMediaSourceResult(
+                MikanMediaSource.ID,
+                MikanMediaSource.INFO,
+                MediaSourceKind.BitTorrent,
+                initialState = MediaSourceFetchState.Working,
+                results = TestMediaList,
+            ),
+            TestMediaSourceResult(
+                "dmhy",
+                MediaSourceInfo("dmhy"),
+                MediaSourceKind.BitTorrent,
+                initialState = MediaSourceFetchState.Succeed(1),
+                results = TestMediaList,
+            ),
+            TestMediaSourceResult(
+                "acg.rip",
+                MediaSourceInfo("acg.rip"),
+                MediaSourceKind.BitTorrent,
+                initialState = MediaSourceFetchState.Disabled,
+                results = TestMediaList,
+            ),
+            TestMediaSourceResult(
+                "source1",
+                MediaSourceInfo("source1"),
+                MediaSourceKind.WEB,
+                initialState = MediaSourceFetchState.Succeed(1),
+                results = TestMediaList,
+            ),
+            TestMediaSourceResult(
+                MikanCNMediaSource.ID,
+                MikanCNMediaSource.INFO,
+                MediaSourceKind.BitTorrent,
+                initialState = MediaSourceFetchState.Failed(IllegalStateException(), 1),
+                results = emptyList(),
+            ),
+        ),
+    ),
+    settings = flowOf(MediaSelectorSettings.Default),
+    flowScope = flowScope,
+)
 
 @TestOnly
 val TestMediaSourceResultListPresentation

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultsView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceResultsView.kt
@@ -68,7 +68,7 @@ fun MediaSourceResultsView(
     sourceResults: MediaSourceResultListPresentation,
     mediaSelector: MediaSelectorState,
     onRefresh: () -> Unit,
-    onRestartSource: (MediaSourceResultPresentation) -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val presentation by mediaSelector.mediaSource.presentationFlow.collectAsStateWithLifecycle()
@@ -94,7 +94,7 @@ fun MediaSourceResultsView(
     sourceSelected: (String) -> Boolean,
     onClickEnabled: (mediaSourceId: String) -> Unit,
     onRefresh: () -> Unit,
-    onRestartSource: (MediaSourceResultPresentation) -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -153,7 +153,7 @@ fun MediaSourceResultsView(
             val onClick: (MediaSourceResultPresentation) -> Unit = remember(onClickEnabled) {
                 { item ->
                     if (item.isDisabled || item.isFailedOrAbandoned) {
-                        onRestartSource(item)
+                        onRestartSource(item.instanceId)
                     } else {
                         onClickEnabled(item.mediaSourceId)
                     }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
@@ -26,7 +26,6 @@ import me.him188.ani.app.ui.subject.episode.TAG_MEDIA_SELECTOR_SHEET
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorState
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorView
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultListPresentation
-import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultPresentation
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsView
 import me.him188.ani.app.ui.subject.episode.video.components.EpisodeVideoSideSheets
 import me.him188.ani.app.ui.subject.episode.video.settings.SideSheetLayout
@@ -38,7 +37,7 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
     mediaSourceResultListPresentation: MediaSourceResultListPresentation,
     onDismissRequest: () -> Unit,
     onRefresh: () -> Unit,
-    onRestartSource: (MediaSourceResultPresentation) -> Unit,
+    onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SideSheetLayout(
@@ -61,6 +60,7 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
                     onRestartSource,
                 )
             },
+            onRestartSource = onRestartSource,
             modifier.padding(horizontal = 16.dp)
                 .fillMaxWidth()
                 .navigationBarsPadding(),

--- a/app/shared/src/desktopTest/kotlin/ui/subject/cache/EpisodeCacheStateTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/cache/EpisodeCacheStateTest.kt
@@ -33,9 +33,11 @@ import me.him188.ani.app.domain.media.cache.storage.TestMediaCacheStorage
 import me.him188.ani.app.domain.media.fetch.MediaFetcherConfig
 import me.him188.ani.app.domain.media.fetch.MediaSourceMediaFetcher
 import me.him188.ani.app.domain.media.framework.TestMediaSelector
+import me.him188.ani.app.domain.media.selector.MatchMetadata
 import me.him188.ani.app.domain.media.selector.MaybeExcludedMedia
 import me.him188.ani.app.domain.media.selector.MediaSelector
 import me.him188.ani.app.domain.media.selector.MediaSelectorFactory
+import me.him188.ani.app.domain.media.selector.TestMatchMetadata
 import me.him188.ani.app.domain.mediasource.instance.createTestMediaSourceInstance
 import me.him188.ani.app.ui.foundation.produceState
 import me.him188.ani.app.ui.framework.runComposeStateTest
@@ -119,7 +121,7 @@ class EpisodeCacheStateTest {
                             list.map {
                                 MaybeExcludedMedia.Included(
                                     it,
-                                    similarity = 90,
+                                    metadata = TestMatchMetadata,
                                 )
                             }
                         },

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/common/SourceIcon.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/common/SourceIcon.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.mediaselect.common
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import me.him188.ani.app.ui.foundation.AsyncImage
+
+
+@Composable
+fun SourceIcon(
+    iconUrl: String,
+    sourceName: String,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        iconUrl,
+        contentDescription = sourceName,
+        Modifier.clip(CircleShape).then(modifier),
+        contentScale = ContentScale.Crop,
+    )
+}

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -110,7 +110,7 @@ private fun WebSourceCard(
             Modifier.heightIn(min = minHeight)
                 .widthIn(
                     min = 100.dp,
-                    max = 120.dp,
+                    max = 140.dp,
                 ),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.ui.mediaselect.selector
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -20,8 +21,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Refresh
@@ -76,19 +75,28 @@ fun MediaSelectorWebSourcesColumn(
     onRefresh: (WebSource) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    LazyColumn(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        items(list, key = { it.instanceId }) { source ->
-            WebSourceCard(
-                source,
-                selectedChannel = { if (selectedSource() == source) selectedChannel() else null },
-                onSelect = {
-                    onSelect(source, it)
-                },
-                onRefresh = {
-                    onRefresh(source)
-                },
-                Modifier.fillMaxWidth(),
-            )
+    val card = @Composable { source: WebSource ->
+        WebSourceCard(
+            source,
+            selectedChannel = { if (selectedSource() == source) selectedChannel() else null },
+            onSelect = {
+                onSelect(source, it)
+            },
+            onRefresh = {
+                onRefresh(source)
+            },
+            Modifier.fillMaxWidth(),
+        )
+    }
+//    LazyColumn(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+//        items(list, key = { it.instanceId }) { source ->
+//            card(source)
+//        }
+//    }
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // not scrollable. 否则会跟 bottom sheet 的 scroll 冲突. 
+        list.forEach { source ->
+            card(source)
         }
     }
 }

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -9,33 +9,16 @@
 
 package me.him188.ani.app.ui.mediaselect.selector
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.InputChip
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.domain.mediasource.instance.MediaSourceInstance
 import me.him188.ani.app.ui.foundation.IconButton
@@ -75,7 +58,7 @@ fun MediaSelectorWebSourcesColumn(
     selectedChannel: () -> WebSourceChannel?,
     onSelect: (WebSource, WebSourceChannel) -> Unit,
     onRefresh: (WebSource) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val card = @Composable { source: WebSource ->
         WebSourceCard(
@@ -117,23 +100,28 @@ private fun WebSourceCard(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Row(
-            Modifier.heightIn(min = minHeight)
-                .widthIn(
-                    min = 100.dp,
-                    max = 140.dp,
-                ),
+            Modifier.heightIn(min = minHeight),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SourceIcon(
                 source.iconUrl, source.name,
                 Modifier.size(24.dp),
             )
-            Text(
-                source.name,
-                Modifier.padding(start = 8.dp).width(IntrinsicSize.Max),
-                softWrap = true,
-                maxLines = 2,
-            )
+            Box(Modifier.padding(start = 8.dp)) {
+                Text(
+                    "五个字占位",
+                    Modifier.alpha(0f).width(IntrinsicSize.Max),
+                    softWrap = true,
+                    maxLines = 2,
+                )
+                Text(
+                    source.name,
+                    Modifier.matchParentSize(),
+                    softWrap = true,
+                    maxLines = 2,
+                    overflow = TextOverflow.Clip,
+                )
+            }
         }
 
         FlowRow(

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.mediaselect.selector
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.domain.mediasource.instance.MediaSourceInstance
+import me.him188.ani.app.ui.foundation.IconButton
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.mediaselect.common.SourceIcon
+import me.him188.ani.datasources.api.Media
+import me.him188.ani.utils.platform.annotations.TestOnly
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+
+data class WebSourceChannel(
+    val name: String,
+    val original: Media? = null,
+)
+
+data class WebSource(
+    /**
+     * @see MediaSourceInstance.instanceId
+     */
+    val instanceId: String,
+    val mediaSourceId: String,
+    val iconUrl: String,
+//    val iconResourceId: String?,
+    val name: String,
+    val channels: List<WebSourceChannel>,
+    val isLoading: Boolean,
+    val isError: Boolean,
+)
+
+/**
+ * https://www.figma.com/design/LET1n9mmDa6npDTIlUuJjU/Animeko?node-id=1054-13751&t=OSgRmNiOHpUGBYYu-0
+ */
+@Composable
+fun MediaSelectorWebSourcesColumn(
+    list: List<WebSource>,
+    selectedSource: () -> WebSource?,
+    selectedChannel: () -> WebSourceChannel?,
+    onSelect: (WebSource, WebSourceChannel) -> Unit,
+    onRefresh: (WebSource) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        items(list, key = { it.instanceId }) { source ->
+            WebSourceCard(
+                source,
+                selectedChannel = { if (selectedSource() == source) selectedChannel() else null },
+                onSelect = {
+                    onSelect(source, it)
+                },
+                onRefresh = {
+                    onRefresh(source)
+                },
+                Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun WebSourceCard(
+    source: WebSource,
+    selectedChannel: () -> WebSourceChannel?,
+    onSelect: (WebSourceChannel) -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val minHeight = 40.dp
+    Row(
+        modifier,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Row(
+            Modifier.heightIn(min = minHeight)
+                .widthIn(
+                    min = 100.dp,
+                    max = 120.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SourceIcon(
+                source.iconUrl, source.name,
+                Modifier.size(24.dp),
+            )
+            Text(
+                source.name,
+                Modifier.padding(start = 8.dp).width(IntrinsicSize.Max),
+                softWrap = true,
+                maxLines = 2,
+            )
+        }
+
+        FlowRow(
+            Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy((-8).dp),
+        ) {
+            for (channel in source.channels) {
+                InputChip(
+                    selected = channel == selectedChannel(),
+                    onClick = { onSelect(channel) },
+                    label = { Text(channel.name) },
+                )
+            }
+
+            if (source.isLoading) {
+                Box(
+                    Modifier.minimumInteractiveComponentSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+
+            if (source.isError) {
+                Box(
+                    Modifier.minimumInteractiveComponentSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Rounded.Close, null,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+
+        if (source.isError) {
+            IconButton(onRefresh) {
+                Icon(Icons.Rounded.Refresh, "刷新")
+            }
+        }
+    }
+}
+
+@OptIn(TestOnly::class)
+@Composable
+@Preview
+private fun PreviewMediaSelectorWebColumn() {
+    ProvideCompositionLocalsForPreview {
+        Surface {
+            MediaSelectorWebSourcesColumn(
+                TestWebSources,
+                selectedSource = { TestWebSources[0] },
+                selectedChannel = { TestWebSources[0].channels[1] },
+                onSelect = { _, _ -> },
+                onRefresh = {},
+            )
+        }
+    }
+}
+
+@OptIn(TestOnly::class)
+@Composable
+@Preview
+private fun PreviewWebSourceCard() {
+    ProvideCompositionLocalsForPreview {
+        Surface {
+            WebSourceCard(
+                TestWebSources[0],
+                selectedChannel = { TestWebSourceChannels2[0] },
+                onSelect = {},
+                onRefresh = {},
+            )
+        }
+    }
+}
+
+
+@TestOnly
+internal val TestWebSources
+    get() = (0..10).mapTo(mutableListOf()) {
+        WebSource(
+            instanceId = "source$it",
+            mediaSourceId = "source$it",
+            iconUrl = "https://example.com/example.png",
+            name = "数据源 $it",
+            channels = if (it % 2 == 0) {
+                TestWebSourceChannels1
+            } else {
+                TestWebSourceChannels2
+            },
+            isError = it % 4 == 0,
+            isLoading = it % 4 == 3,
+        )
+    }.apply {
+        add(
+            1,
+            WebSource(
+                instanceId = "source none",
+                mediaSourceId = "source none",
+                iconUrl = "https://example.com/example.png",
+                name = "初始",
+                channels = emptyList(),
+                isError = false,
+                isLoading = true,
+            ),
+        )
+        add(
+            1,
+            WebSource(
+                instanceId = "source error",
+                mediaSourceId = "source error",
+                iconUrl = "https://example.com/example.png",
+                name = "查询错误的数据源",
+                channels = emptyList(),
+                isError = true,
+                isLoading = false,
+            ),
+        )
+    }
+
+@TestOnly
+private val TestWebSourceChannels1
+    get() = listOf(
+        WebSourceChannel(name = "线路1"),
+        WebSourceChannel(name = "线路2"),
+        WebSourceChannel(name = "线路3"),
+        WebSourceChannel(name = "线路4"),
+        WebSourceChannel(name = "线路5"),
+    )
+
+@TestOnly
+private val TestWebSourceChannels2
+    get() = listOf(
+        WebSourceChannel(name = "主线"),
+        WebSourceChannel(name = "备线"),
+    )

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Refresh

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -94,7 +94,7 @@ private fun WebSourceCard(
     onRefresh: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val minHeight = 40.dp
+    val minHeight = 48.dp
     Row(
         modifier,
         horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/summary/MediaSelectorSummary.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/summary/MediaSelectorSummary.kt
@@ -14,8 +14,6 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +29,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.SyncAlt
 import androidx.compose.material3.ButtonDefaults
@@ -59,16 +56,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
-import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
 import me.him188.ani.utils.platform.annotations.TestOnly
@@ -128,7 +122,7 @@ fun MediaSelectorSummaryCard(
             ContentTransform(
                 EnterTransition.None,
                 ExitTransition.None,
-                sizeTransform = default.sizeTransform
+                sizeTransform = default.sizeTransform,
             )
         } else {
             default
@@ -280,6 +274,15 @@ fun MediaSelectorSummaryCard(
     )
 }
 
+@Composable
+private fun SourceIcon(source: QueriedSourcePresentation, modifier: Modifier) {
+    me.him188.ani.app.ui.mediaselect.common.SourceIcon(
+        iconUrl = source.sourceIconUrl,
+        sourceName = source.sourceName,
+        modifier,
+    )
+}
+
 @Stable
 private class MediaSelectorSummaryState(
     initialState: MediaSelectorSummary,
@@ -380,19 +383,6 @@ private fun QueriedSources(
 //        }
 
     }
-}
-
-@Composable
-private fun SourceIcon(
-    source: QueriedSourcePresentation,
-    modifier: Modifier = Modifier,
-) {
-    AsyncImage(
-        source.sourceIconUrl,
-        contentDescription = source.sourceName,
-        Modifier.clip(CircleShape).then(modifier),
-        contentScale = ContentScale.Crop,
-    )
 }
 
 /**

--- a/datasource/api/src/commonMain/kotlin/Media.kt
+++ b/datasource/api/src/commonMain/kotlin/Media.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -247,6 +247,8 @@ class MediaProperties private constructor(
     /**
      * 字幕组名称, 例如 "桜都字幕组", "北宇治字幕组".
      * 空字符串可能导致数据源选择器忽略掉这个资源.
+     * 
+     * 对于在线数据源, 这会是线路名称.
      *
      * 对于无法确定字幕组的数据源, 可以使用数据源的 [MediaSource.mediaSourceId] 代替.
      *


### PR DESCRIPTION
close #1508, close #1297.

此列表:
- 只会显示在线数据源
- 只会显示精确匹配标题名称的项目
- 只会显示 EP/sort 有任一匹配的项目
   - 大概率没问题, 但播第二季的第 13 集时可能会播第二季的第 1 集. 这个问题不在本 PR 考虑范围内.

BT 源仍然使用旧版 UI (切换到详细模式)

![image](https://github.com/user-attachments/assets/e5ff994d-a857-4fdd-b8a9-a9fc635d19a6)
