### PR TITLE
Feature: Allow users to ignore done and dropped subjects when searching

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/UISettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/UISettings.kt
@@ -109,6 +109,7 @@ enum class NsfwMode {
 @Immutable
 data class SearchSettings(
     val enableNewSearchSubjectApi: Boolean = false,
+    val ignoreDoneAndDroppedSubjects: Boolean = false,
     val nsfwMode: NsfwMode = NsfwMode.BLUR,
 ) {
     companion object {

--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
@@ -225,6 +225,24 @@ interface SubjectCollectionDao {
 
     @Query("""UPDATE subject_collection SET cachedStaffUpdated = :time, cachedCharactersUpdated = :time WHERE subjectId = :subjectId""")
     suspend fun updateCachedRelationsUpdated(subjectId: Int, time: Long = currentTimeMillis())
+
+    @Query(
+        """
+        SELECT sc.subjectId FROM subject_collection sc
+        WHERE collectionType IS NOT NULL
+        AND (collectionType = :collectionType)
+        """,
+    )
+    fun subjectIdsByCollectionType(collectionType: UnifiedCollectionType): Flow<List<Int>>
+
+    @Query(
+        """
+        SELECT sc.nameCn FROM subject_collection sc
+        WHERE collectionType IS NOT NULL
+        AND (collectionType = :collectionType)
+        """,
+    )
+    fun subjectNamesCnByCollectionType(collectionType: UnifiedCollectionType): Flow<List<String>>
 }
 
 suspend inline fun SubjectCollectionDao.deleteAll(type: UnifiedCollectionType?) {

--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
@@ -230,19 +230,19 @@ interface SubjectCollectionDao {
         """
         SELECT sc.subjectId FROM subject_collection sc
         WHERE collectionType IS NOT NULL
-        AND (collectionType = :collectionType)
+        AND (collectionType IN (:collectionTypes))
         """,
     )
-    fun subjectIdsByCollectionType(collectionType: UnifiedCollectionType): Flow<List<Int>>
+    fun subjectIdsByCollectionType(collectionTypes: List<UnifiedCollectionType>): Flow<List<Int>>
 
     @Query(
         """
         SELECT sc.nameCn FROM subject_collection sc
         WHERE collectionType IS NOT NULL
-        AND (collectionType = :collectionType)
+        AND (collectionType IN (:collectionTypes))
         """,
     )
-    fun subjectNamesCnByCollectionType(collectionType: UnifiedCollectionType): Flow<List<String>>
+    fun subjectNamesCnByCollectionType(collectionTypes: List<UnifiedCollectionType>): Flow<List<String>>
 }
 
 suspend inline fun SubjectCollectionDao.deleteAll(type: UnifiedCollectionType?) {

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/BangumiSubjectSearchCompletionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/BangumiSubjectSearchCompletionRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2025 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -14,7 +14,6 @@ import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -56,16 +55,9 @@ class BangumiSubjectSearchCompletionRepository(
                     )
 
                     val filteredCompletions = if (ignoreDoneAndDroppedFlow.first()) {
-                        val excludedNames = combine(
-                            subjectCollectionRepository.getSubjectNamesCnByCollectionType(
-                                type = UnifiedCollectionType.DONE,
-                            ),
-                            subjectCollectionRepository.getSubjectNamesCnByCollectionType(
-                                type = UnifiedCollectionType.DROPPED,
-                            ),
-                        ) { doneNames, droppedNames ->
-                            (doneNames + droppedNames).map { it }
-                        }.first()
+                        val excludedNames = subjectCollectionRepository.getSubjectNamesCnByCollectionType(
+                            types = listOf(UnifiedCollectionType.DONE, UnifiedCollectionType.DROPPED),
+                        ).first()
 
                         completions.filter { it !in excludedNames }
                     } else {

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -170,6 +170,10 @@ sealed class SubjectCollectionRepository(
         subjectId: Int,
         type: UnifiedCollectionType?,
     )
+
+    abstract suspend fun getSubjectIdsByCollectionType(type: UnifiedCollectionType): Flow<List<Int>>
+
+    abstract suspend fun getSubjectNamesCnByCollectionType(type: UnifiedCollectionType): Flow<List<String>>
 }
 
 class SubjectCollectionRepositoryImpl(
@@ -545,6 +549,14 @@ class SubjectCollectionRepositoryImpl(
                 )
             }
         }
+    }
+
+    override suspend fun getSubjectIdsByCollectionType(type: UnifiedCollectionType): Flow<List<Int>> {
+        return subjectCollectionDao.subjectIdsByCollectionType(type).flowOn(defaultDispatcher)
+    }
+
+    override suspend fun getSubjectNamesCnByCollectionType(type: UnifiedCollectionType): Flow<List<String>> {
+        return subjectCollectionDao.subjectNamesCnByCollectionType(type).flowOn(defaultDispatcher)
     }
 
     private suspend fun patchSubjectCollection(

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -171,9 +171,9 @@ sealed class SubjectCollectionRepository(
         type: UnifiedCollectionType?,
     )
 
-    abstract suspend fun getSubjectIdsByCollectionType(type: UnifiedCollectionType): Flow<List<Int>>
+    abstract suspend fun getSubjectIdsByCollectionType(types: List<UnifiedCollectionType>): Flow<List<Int>>
 
-    abstract suspend fun getSubjectNamesCnByCollectionType(type: UnifiedCollectionType): Flow<List<String>>
+    abstract suspend fun getSubjectNamesCnByCollectionType(types: List<UnifiedCollectionType>): Flow<List<String>>
 }
 
 class SubjectCollectionRepositoryImpl(
@@ -551,12 +551,12 @@ class SubjectCollectionRepositoryImpl(
         }
     }
 
-    override suspend fun getSubjectIdsByCollectionType(type: UnifiedCollectionType): Flow<List<Int>> {
-        return subjectCollectionDao.subjectIdsByCollectionType(type).flowOn(defaultDispatcher)
+    override suspend fun getSubjectIdsByCollectionType(types: List<UnifiedCollectionType>): Flow<List<Int>> {
+        return subjectCollectionDao.subjectIdsByCollectionType(types).flowOn(defaultDispatcher)
     }
 
-    override suspend fun getSubjectNamesCnByCollectionType(type: UnifiedCollectionType): Flow<List<String>> {
-        return subjectCollectionDao.subjectNamesCnByCollectionType(type).flowOn(defaultDispatcher)
+    override suspend fun getSubjectNamesCnByCollectionType(types: List<UnifiedCollectionType>): Flow<List<String>> {
+        return subjectCollectionDao.subjectNamesCnByCollectionType(types).flowOn(defaultDispatcher)
     }
 
     private suspend fun patchSubjectCollection(

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.data.repository.subject
 
+import androidx.collection.MutableIntList
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -16,6 +17,8 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.data.models.schedule.AnimeSeasonId
@@ -30,6 +33,7 @@ import me.him188.ani.app.domain.search.RatingRange
 import me.him188.ani.app.domain.search.SearchSort
 import me.him188.ani.app.domain.search.SubjectSearchQuery
 import me.him188.ani.app.domain.search.SubjectType
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 import me.him188.ani.datasources.bangumi.models.BangumiSubjectType
 import me.him188.ani.datasources.bangumi.models.search.BangumiSort
 import me.him188.ani.utils.logging.logger
@@ -38,6 +42,7 @@ import kotlin.coroutines.cancellation.CancellationException
 
 class SubjectSearchRepository(
     private val bangumiSubjectSearchService: BangumiSubjectSearchService,
+    private val subjectCollectionRepository: SubjectCollectionRepository,
     private val subjectService: BangumiSubjectService,
     defaultDispatcher: CoroutineContext = Dispatchers.Default,
 ) : Repository(defaultDispatcher) {
@@ -50,18 +55,20 @@ class SubjectSearchRepository(
     fun searchSubjects(
         searchQuery: SubjectSearchQuery,
         useNewApi: suspend () -> Boolean = { false },
+        ignoreDoneAndDropped: suspend () -> Boolean = { false },
         pagingConfig: PagingConfig = Repository.defaultPagingConfig
     ): Flow<PagingData<BatchSubjectDetails>> = Pager(
         config = pagingConfig,
         initialKey = 0,
 //        remoteMediator = SubjectSearchRemoteMediator(useNewApi, searchQuery, pagingConfig),
         pagingSourceFactory = {
-            SubjectSearchPagingSource(useNewApi, searchQuery)
+            SubjectSearchPagingSource(useNewApi, ignoreDoneAndDropped, searchQuery)
         },
     ).flow.flowOn(defaultDispatcher)
 
     private inner class SubjectSearchPagingSource(
         private val useNewApi: suspend () -> Boolean,
+        private val ignoreDoneAndDropped: suspend () -> Boolean,
         private val searchQuery: SubjectSearchQuery
     ) : PagingSource<Int, BatchSubjectDetails>() {
         private val filters = searchQuery.toBangumiSearchFilters()
@@ -81,7 +88,26 @@ class SubjectSearchRepository(
                     sort = searchQuery.sort.toBangumiSort(),
                 )
 
-                val subjectInfos = subjectService.batchGetSubjectDetails(res)
+                val filteredIds = if (ignoreDoneAndDropped()) {
+                    val excludedIds = combine(
+                        subjectCollectionRepository.getSubjectIdsByCollectionType(
+                            type = UnifiedCollectionType.DONE,
+                        ),
+                        subjectCollectionRepository.getSubjectIdsByCollectionType(
+                            type = UnifiedCollectionType.DROPPED,
+                        ),
+                    ) { doneIds, droppedIds ->
+                        (doneIds + droppedIds).map { it }
+                    }.first()
+
+                    MutableIntList().apply {
+                        res.forEach { if (it !in excludedIds) add(it) }
+                    }
+                } else {
+                    res
+                }
+
+                val subjectInfos = subjectService.batchGetSubjectDetails(filteredIds)
 
                 return@withContext LoadResult.Page(
                     subjectInfos,

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -17,7 +17,6 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
@@ -89,16 +88,9 @@ class SubjectSearchRepository(
                 )
 
                 val filteredIds = if (ignoreDoneAndDropped()) {
-                    val excludedIds = combine(
-                        subjectCollectionRepository.getSubjectIdsByCollectionType(
-                            type = UnifiedCollectionType.DONE,
-                        ),
-                        subjectCollectionRepository.getSubjectIdsByCollectionType(
-                            type = UnifiedCollectionType.DROPPED,
-                        ),
-                    ) { doneIds, droppedIds ->
-                        (doneIds + droppedIds).map { it }
-                    }.first()
+                    val excludedIds = subjectCollectionRepository.getSubjectIdsByCollectionType(
+                        types = listOf(UnifiedCollectionType.DONE, UnifiedCollectionType.DROPPED),
+                    ).first()
 
                     MutableIntList().apply {
                         res.forEach { if (it !in excludedIds) add(it) }

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -136,6 +136,7 @@
     <string name="settings_app_search">搜索</string>
     <string name="settings_app_use_new_search_api">使用新版条目查询接口</string>
     <string name="settings_app_use_new_search_api_description">实验性接口，可能会缺失部分条目，谨慎启用</string>
+    <string name="settings_app_not_show_done_and_dropped_subjects">不显示看过和抛弃的条目</string>
     <string name="settings_app_nsfw_hide">隐藏</string>
     <string name="settings_app_nsfw_blur">模糊</string>
     <string name="settings_app_nsfw_display">显示</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -136,6 +136,7 @@
     <string name="settings_app_search">搜索</string>
     <string name="settings_app_use_new_search_api">使用新版條目查詢接口</string>
     <string name="settings_app_use_new_search_api_description">實驗性接口，可能會缺失部分條目，謹慎啟用</string>
+    <string name="settings_app_not_show_done_and_dropped_subjects">不顯示看過和抛棄的條目</string>
     <string name="settings_app_nsfw_hide">隱藏</string>
     <string name="settings_app_nsfw_blur">模糊</string>
     <string name="settings_app_nsfw_display">顯示</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -136,6 +136,7 @@
     <string name="settings_app_search">搜尋</string>
     <string name="settings_app_use_new_search_api">使用新版條目查詢介面</string>
     <string name="settings_app_use_new_search_api_description">實驗性介面，可能會缺失部分條目，請謹慎啟用</string>
+    <string name="settings_app_not_show_done_and_dropped_subjects">不顯示看過和抛棄的條目</string>
     <string name="settings_app_nsfw_hide">隱藏</string>
     <string name="settings_app_nsfw_blur">模糊</string>
     <string name="settings_app_nsfw_display">顯示</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="settings_app_search">Search</string>
     <string name="settings_app_use_new_search_api">Use the new entry search API</string>
     <string name="settings_app_use_new_search_api_description">Experimental API. May miss some entries. Use with caution</string>
+    <string name="settings_app_not_show_done_and_dropped_subjects">Do not show done and dropped subjects</string>
     <string name="settings_app_nsfw_hide">Hide</string>
     <string name="settings_app_nsfw_blur">Blur</string>
     <string name="settings_app_nsfw_display">Show</string>

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -285,12 +285,14 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
     single<SubjectSearchRepository> {
         SubjectSearchRepository(
             bangumiSubjectSearchService = get(),
+            subjectCollectionRepository = get(),
             subjectService = get(),
         )
     }
     single<BangumiSubjectSearchCompletionRepository> {
         BangumiSubjectSearchCompletionRepository(
             bangumiSubjectSearchService = get(),
+            subjectCollectionRepository = get(),
             settingsRepository = get(),
         )
     }

--- a/app/shared/src/commonMain/kotlin/ui/main/SearchViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/SearchViewModel.kt
@@ -101,6 +101,10 @@ class SearchViewModel(
                                 settingsRepository.uiSettings.flow.map { it.searchSettings.enableNewSearchSubjectApi }
                                     .first()
                     },
+                    ignoreDoneAndDropped = {
+                        settingsRepository.uiSettings.flow.map { it.searchSettings.ignoreDoneAndDroppedSubjects }
+                            .first()
+                    },
                 ).combine(nsfwSettingFlow) { data, nsfwMode ->
                     // 当 settings 变更时, 会重新计算所有的 SubjectPreviewItemInfo 以更新其显示状态, 但不会重新搜索.
                     data.map { subject ->

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
@@ -53,6 +53,7 @@ import me.him188.ani.app.ui.lang.settings_app_light_up_mode_description
 import me.him188.ani.app.ui.lang.settings_app_list_animation
 import me.him188.ani.app.ui.lang.settings_app_list_animation_description
 import me.him188.ani.app.ui.lang.settings_app_my_collections
+import me.him188.ani.app.ui.lang.settings_app_not_show_done_and_dropped_subjects
 import me.him188.ani.app.ui.lang.settings_app_nsfw_blur
 import me.him188.ani.app.ui.lang.settings_app_nsfw_content
 import me.him188.ani.app.ui.lang.settings_app_nsfw_display
@@ -208,6 +209,19 @@ fun SettingsScope.AppearanceGroup(
             },
             title = { Text(stringResource(Lang.settings_app_use_new_search_api)) },
             description = { Text(stringResource(Lang.settings_app_use_new_search_api_description)) },
+        )
+        SwitchItem(
+            checked = uiSettings.searchSettings.ignoreDoneAndDroppedSubjects,
+            onCheckedChange = {
+                state.update(
+                    uiSettings.copy(
+                        searchSettings = uiSettings.searchSettings.copy(
+                            ignoreDoneAndDroppedSubjects = !uiSettings.searchSettings.ignoreDoneAndDroppedSubjects,
+                        ),
+                    ),
+                )
+            },
+            title = { Text(stringResource(Lang.settings_app_not_show_done_and_dropped_subjects)) },
         )
         DropdownItem(
             selected = { uiSettings.searchSettings.nsfwMode },


### PR DESCRIPTION
考虑到目前的搜索功能中，关键词筛选后显示的番剧基本不会变动，这会导致用户很难翻阅自己没有看过的番剧（例如需要下滑搜索页面很久）。

因此在设置页面中新增了一个开关，来允许用户选择在搜索时是否不显示被自己标记为“看过”和“抛弃”的番剧，这样用户能直观地浏览自己哪些番剧还没有看过。