### PR TITLE
remove linux theme detect

### DIFF
--- a/app/desktop/src/main/kotlin/SystemThemeDetector.kt
+++ b/app/desktop/src/main/kotlin/SystemThemeDetector.kt
@@ -16,22 +16,23 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class SystemThemeDetector {
+    private val isLinux = System.getProperty("os.name").lowercase().contains("linux")
     private val detector = OsThemeDetector.getDetector()
 
-    private val _current = MutableStateFlow(isDarkToTheme(detector.isDark))
+    private val _current = MutableStateFlow(
+        if (isLinux) SystemTheme.Light else isDarkToTheme(detector.isDark)
+    )
     val current: StateFlow<SystemTheme> = _current.asStateFlow()
 
     init {
-        detector.registerListener {
-            _current.value = isDarkToTheme(it)
+        if (!isLinux) {
+            detector.registerListener {
+                _current.value = isDarkToTheme(it)
+            }
         }
     }
 
     private fun isDarkToTheme(isDark: Boolean): SystemTheme {
-        return if (isDark) {
-            SystemTheme.Dark
-        } else {
-            SystemTheme.Light
-        }
+        return if (isDark) SystemTheme.Dark else SystemTheme.Light
     }
 }


### PR DESCRIPTION
由于上游问题，在linux上检测系统主题后关闭应用窗口会产生僵尸进程`gsettings monitor org.gnome.desktop.interface`，因此考虑暂时移除linux平台上的主题检测，直至出现解决方案。
参见：https://github.com/Dansoftowner/jSystemThemeDetector/issues/42