### PR TITLE
Fix incorrect handling of negative day differences in `TimeFormatter`…

### DIFF
--- a/app/shared/app-data/src/commonTest/kotlin/tools/TimeFormatterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/tools/TimeFormatterTest.kt
@@ -15,6 +15,7 @@ import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.char
+import me.him188.ani.utils.platform.currentTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -85,6 +86,11 @@ class TimeFormatterTest {
     fun testDaysAgo() {
         val timestamp = Instant.parse("2019-12-31T10:00:00Z")
         assertEquals("1 天前", timeFormatter.format(timestamp))
+    }
+    @Test
+    fun testDaysLater() {
+        val timestamp = Instant.parse("2020-01-02T11:00:00Z")
+        assertEquals("1 天后", timeFormatter.format(timestamp))
     }
 
     @Test

--- a/app/shared/app-platform/src/commonMain/kotlin/tools/TimeFormatter.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/tools/TimeFormatter.kt
@@ -46,7 +46,7 @@ class TimeFormatter(
             in 3600..<86400 -> "${differenceInSeconds / 3600} 小时前"
             in -86400..<-3600 -> "${-differenceInSeconds / 3600} 小时后"
             in 86400..<86400 * 2 -> "${differenceInSeconds / 86400} 天前"
-            in -86400 * 2..<-86400 -> "${differenceInSeconds / 86400} 天后"
+            in -86400 * 2..<-86400 -> "${-differenceInSeconds / 86400} 天后"
             else -> getFormatter(showTime).format(instant.toLocalDateTime(TimeZone.currentSystemDefault()))
         }
     }


### PR DESCRIPTION
少了个负号，导致会出现：“-1 天后” 的情况