### PR TITLE
关闭 VLC 快捷键

### DIFF
--- a/app/shared/video-player/src/desktopMain/kotlin/ui/ComposeMediaPlayerComponent.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/ComposeMediaPlayerComponent.kt
@@ -359,6 +359,7 @@ open class ComposeMediaPlayerComponent @JvmOverloads constructor(
             "--no-snapshot-preview",
             "--quiet",
             "--intf=dummy",
+            "--no-hotkeys",
         )
 
     }


### PR DESCRIPTION
close https://github.com/open-ani/animeko/issues/2128
对于快捷键方面我的意见是关闭目前vlc的快捷键，等待未来ani的自定义快捷键上线，而且目前vlc的自带快捷键对于ui并没有进行适配，对于小白来说不太友好