### PR TITLE
Fix: blacklist previously auto-selected media when user manually switches source (#1763)

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -410,6 +410,16 @@ class DefaultMediaSelector(
     private suspend fun selectImpl(candidate: Media, updatePreference: Boolean, force: Boolean = false): Boolean {
         events.onBeforeSelect.emit(SelectEvent(candidate, null))
         if (selected.value == candidate && !force) return false
+        
+        // 如果是用户手动选择，将之前选中的媒体加入黑名单  
+        if (updatePreference) {
+            selected.value?.let { previousMedia ->
+                if (previousMedia.mediaId != candidate.mediaId) {
+                    events.onBlackListMedia.emit(previousMedia)
+                }
+            }
+        }
+        
         selected.value = candidate // MSF, will not trigger new emit
 
         if (updatePreference) {
@@ -422,7 +432,9 @@ class DefaultMediaSelector(
 
             broadcastChangePreference()
         }
-
+        
+        
+        
         // Publish events
         events.onSelect.emit(SelectEvent(candidate, null))
         return true

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorEvents.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorEvents.kt
@@ -35,6 +35,14 @@ interface MediaSelectorEvents {
      * flow 的值为新的用户设置
      */
     val onChangePreference: Flow<MediaPreference>
+    
+    /**
+     * 媒体被加入黑名单.
+     * 当用户选择某媒体后，应该将之前选择的媒体（即 fastSelect 的结果）加入黑名单.
+     * 
+     * flow 的值为加入黑名单的媒体.
+     */
+    val onBlackListMedia: Flow<Media>
 }
 
 data class SelectEvent(
@@ -52,5 +60,7 @@ class MutableMediaSelectorEvents(
     override val onBeforeSelect: MutableSharedFlow<SelectEvent> =
         MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)
     override val onChangePreference: MutableSharedFlow<MediaPreference> =
+        MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)
+    override val onBlackListMedia: MutableSharedFlow<Media> =
         MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)
 }


### PR DESCRIPTION
## What

Blacklist previously auto-selected media when the user manually switches to another source.

## Where

In `MediaSelector.selectImpl(...)`, emit a blacklist event (`onBlackListMedia`) when is user selected, targeting the previously auto-selected media.

## Why

Fixes issue where:

- Media A was auto-selected.
- User manually switched to media B.
- B failed to play.
- The system auto-switched back to A, which was not expected.

Now, media A will be blacklisted when user manually selects B, preventing fallback to A after B fails.

## Related

Close #1763 