### PR TITLE
Fix search result column blank item (#2064)

### DIFF
--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.collectLatest
 import me.him188.ani.app.data.models.preference.NsfwMode
 import me.him188.ani.app.domain.search.SearchSort
@@ -113,7 +114,7 @@ internal fun SearchResultColumn(
 
     val visibleItems: List<Pair<Int, SubjectPreviewItemInfo>> =
         items.itemSnapshotList.items.mapIndexedNotNull { index, item ->
-            if (!item.hide) index to item else null
+            if (item != null && !item.hide) index to item else null
         }
     
     SearchResultLazyVerticalGrid(
@@ -180,7 +181,7 @@ internal fun SearchResultColumn(
                                     info?.title,
                                     info?.imageUrl,
                                     isPlaceholder = info == null,
-                                    onClick = { onSelect(index) },
+                                    onClick = { onSelect(originalIndex) },
                                     Modifier
                                         .ifNotNullThen(info) {
                                             sharedElement(


### PR DESCRIPTION
## What 

Fix filtered-out items leaving blank spaces in the search result grid.

## Why

Previously, hidden items were skipped at rendering time but still reserved layout slots in `LazyVerticalGrid`, causing visual gaps. This is because `LazyGridScope.items(count = N)` always allocates space for `N` items regardless of content visibility.

## Where

Refactored SearchResultColumn to pre-filter visible items (visibleItems: List<Pair<originalIndex, item>>) and use items(count = visibleItems.size) instead.

## Related
fix #2064 