### PR TITLE
Fix the big text size render problem

### DIFF
--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/richtext/RichText.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/richtext/RichText.kt
@@ -322,7 +322,7 @@ object RichTextDefaults {
             text = content,
             modifier = modifier,
             inlineContent = inlineStickerMap,
-            style = TextStyle.Default.copy(lineHeight = FontSize.sp * 1.5f),
+            style = TextStyle.Default,
             maxLines = maxLine ?: Int.MAX_VALUE,
             overflow = TextOverflow.Ellipsis,
             onClick = { textPos ->


### PR DESCRIPTION
修复评论中大字的行高渲染

- **before**: 
<img width="1280" height="2856" alt="Screenshot_20250807_164654" src="https://github.com/user-attachments/assets/0371283e-6b0e-4100-aa77-2138b52ff20c" />

- **now**: 
<img width="1280" height="2856" alt="Screenshot_20250807_165450" src="https://github.com/user-attachments/assets/2b1695e3-9420-4503-b498-beef0fb8a9a7" />
