### PR TITLE
Fix email input field visibility issue on iPad when keyboard appears

### DIFF
--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
@@ -10,10 +10,10 @@
 package me.him188.ani.app.ui.login
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -70,33 +70,38 @@ internal fun EmailLoginScreenLayout(
         },
         contentWindowInsets = AniWindowInsets.forPageContent(),
     ) { contentPadding ->
-        Column(
-            Modifier
-                .fillMaxWidth()
-                .wrapContentWidth(align = Alignment.CenterHorizontally)
-                .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium) {
-                    widthIn(max = 480.dp)
-                }
-                .padding(contentPadding)
-                .padding(horizontal = 24.dp)
-                .verticalScroll(rememberScrollState())
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
-        ) {
+        BoxWithConstraints {
+            val availableHeight = maxHeight - contentPadding.calculateTopPadding() - contentPadding.calculateBottomPadding() - 48.dp
+            val thirdPartyLoginHeight = if (showThirdPartyLogin) 180.dp else 0.dp
+            val contentAreaHeight = availableHeight - thirdPartyLoginHeight
+            
             Column(
                 Modifier
-                    .fillMaxHeight()
                     .fillMaxWidth()
-                    .heightIn(min = 230.dp),
-                verticalArrangement = Arrangement.Center,
+                    .wrapContentWidth(align = Alignment.CenterHorizontally)
+                    .ifThen(currentWindowAdaptiveInfo1().windowSizeClass.isWidthAtLeastMedium) {
+                        widthIn(max = 480.dp)
+                    }
+                    .padding(contentPadding)
+                    .padding(horizontal = 24.dp)
+                    .verticalScroll(rememberScrollState())
+                    .nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
-                content()
-            }
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = contentAreaHeight),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    content()
+                }
 
-            if (showThirdPartyLogin) {
-                ThirdPartyLoginMethods(
-                    onBangumiLoginClick,
-                    Modifier.heightIn(min = 180.dp).wrapContentHeight(align = Alignment.Top),
-                )
+                if (showThirdPartyLogin) {
+                    ThirdPartyLoginMethods(
+                        onBangumiLoginClick,
+                        Modifier.heightIn(min = 180.dp).wrapContentHeight(align = Alignment.Top),
+                    )
+                }
             }
         }
     }

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
@@ -13,12 +13,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -76,14 +79,15 @@ internal fun EmailLoginScreenLayout(
                 }
                 .padding(contentPadding)
                 .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState())
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
         ) {
             Column(
                 Modifier
-                    .weight(1f)
-                    .wrapContentHeight(align = Alignment.CenterVertically)
+                    .fillMaxHeight()
                     .fillMaxWidth()
                     .heightIn(min = 230.dp),
+                verticalArrangement = Arrangement.Center,
             ) {
                 content()
             }

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.ui.login
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -54,9 +55,9 @@ internal fun EmailLoginScreenLayout(
     modifier: Modifier = Modifier,
     title: @Composable () -> Unit = { Text("登录") },
     showThirdPartyLogin: Boolean = true,
-    content: @Composable ColumnScope.() -> Unit,
+    content: @Composable ColumnScope.(scrollState: ScrollState) -> Unit,
 ) {
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     Scaffold(
         modifier,
         topBar = {
@@ -74,6 +75,7 @@ internal fun EmailLoginScreenLayout(
             val availableHeight = maxHeight - contentPadding.calculateTopPadding() - contentPadding.calculateBottomPadding() - 48.dp
             val thirdPartyLoginHeight = if (showThirdPartyLogin) 180.dp else 0.dp
             val contentAreaHeight = availableHeight - thirdPartyLoginHeight
+            val scrollState = rememberScrollState()
             
             Column(
                 Modifier
@@ -84,7 +86,7 @@ internal fun EmailLoginScreenLayout(
                     }
                     .padding(contentPadding)
                     .padding(horizontal = 24.dp)
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(scrollState)
                     .nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
                 Column(
@@ -93,7 +95,7 @@ internal fun EmailLoginScreenLayout(
                         .heightIn(min = contentAreaHeight),
                     verticalArrangement = Arrangement.Center,
                 ) {
-                    content()
+                    content(scrollState)
                 }
 
                 if (showThirdPartyLogin) {

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginScreenLayout.kt
@@ -86,8 +86,8 @@ internal fun EmailLoginScreenLayout(
                     }
                     .padding(contentPadding)
                     .padding(horizontal = 24.dp)
-                    .verticalScroll(scrollState)
-                    .nestedScroll(scrollBehavior.nestedScrollConnection),
+                    .nestedScroll(scrollBehavior.nestedScrollConnection)
+                    .verticalScroll(scrollState),
             ) {
                 Column(
                     Modifier

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginStartScreen.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/login/EmailLoginStartScreen.kt
@@ -91,9 +91,9 @@ internal fun EmailLoginStartScreenImpl(
         onNavigateSettings,
         onNavigateBack,
         modifier,
-        showThirdPartyLogin = showThirdPartyLogin,
-        title = title,
-    ) {
+        title,
+        showThirdPartyLogin,
+    ) { scrollState ->
         CenteredSectionHeader(
             title = { Text("你的邮箱地址") },
             description = { Text("我们将发送一封验证码邮件") },

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeScreen.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeScreen.kt
@@ -75,12 +75,13 @@ internal fun BangumiAuthorizeScreen(
         onNavigateBack = onNavigateBack,
         title = { Text("授权 Bangumi 登录") },
         showThirdPartyLogin = false,
-    ) {
+    ) { scrollState ->
         BangumiAuthorizeLayout(
             authorizeState = state,
             contactActions = contactActions,
             onClickAuthorize = onClickAuthorize,
             onCancelAuthorize = onCancelAuthorize,
+            scrollState = scrollState,
         )
     }
 }


### PR DESCRIPTION
## What

Added vertical scroll capability to the email login screen layout to prevent input field from being hidden when the soft keyboard appears.

## Why
On iPad, the keyboard pushes content upward without providing scroll functionality, making the email input field invisible and unusable. The layout used `weight(1f)` which conflicted with scroll behavior.

## Where
- Modified `EmailLoginScreenLayout.kt` in the ui-onboarding module:
- Added `verticalScroll(rememberScrollState())` to the main Column
- Replaced `weight(1f)` with `fillMaxHeight()` and `verticalArrangement = Arrangement.Center` to resolve layout conflicts

Maintained content centering while enabling scrollability

## Related
Closes #2358 