### PR TITLE
Adjust update notifier layout to respect navigation bar insets.

### DIFF
--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateNotifierHost.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateNotifierHost.kt
@@ -12,8 +12,11 @@ package me.him188.ani.app.ui.update
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -158,7 +161,9 @@ fun BoxScope.UpdateNotifier(
                             onDismiss = { dismissedManually = true },
                             onDetailsClick,
                             onAutoUpdateClick = onStartUpdateClick,
-                            modifier = Modifier.align(Alignment.BottomEnd).padding(24.dp)
+                            modifier = Modifier.align(Alignment.BottomEnd)
+                                .windowInsetsPadding(WindowInsets.navigationBars)
+                                .padding(24.dp)
                                 .shadow(4.dp, MaterialTheme.shapes.extraLarge),
                         )
                     }


### PR DESCRIPTION
<img width="1676" height="999" alt="ani" src="https://github.com/user-attachments/assets/e722c6c3-63ab-4bc0-bd91-20c0438b66ba" />
android平板上弹出更新提示时会被导航栏遮盖