### PR TITLE
feat: Add Video Aspect Ratio Control Feature

### DIFF
--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
@@ -43,6 +43,7 @@ import me.him188.ani.app.ui.subject.episode.video.sidesheet.EpisodeSelectorSheet
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.MediaSelectorSheet
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.rememberTestEpisodeSelectorState
 import me.him188.ani.app.ui.subject.episode.video.topbar.EpisodePlayerTitle
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.NoOpPlaybackSpeedController
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
@@ -155,7 +156,7 @@ private fun PreviewVideoScaffoldImpl(
             PlaybackSpeedControllerState(NoOpPlaybackSpeedController, scope = scope)
         },
         aspectRatioControllerState = remember {
-            me.him188.ani.app.videoplayer.ui.AspectRatioControllerState()
+            AspectRatioControllerState()
         },
         leftBottomTips = {
             PlayerControllerDefaults.LeftBottomTips(onClick = {})

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/EpisodeVideo.android.kt
@@ -154,6 +154,9 @@ private fun PreviewVideoScaffoldImpl(
         playbackSpeedControllerState = remember {
             PlaybackSpeedControllerState(NoOpPlaybackSpeedController, scope = scope)
         },
+        aspectRatioControllerState = remember {
+            me.him188.ani.app.videoplayer.ui.AspectRatioControllerState()
+        },
         leftBottomTips = {
             PlayerControllerDefaults.LeftBottomTips(onClick = {})
         },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -76,7 +76,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -931,6 +930,7 @@ private fun EpisodeVideo(
         playbackSpeedControllerState = remember {
             vm.player.features[PlaybackSpeed]?.let { PlaybackSpeedControllerState(it, scope = scope) }
         },
+        aspectRatioControllerState = vm.aspectRatioControllerState,
         leftBottomTips = {
             AniAnimatedVisibility(
                 visible = vm.playerSkipOpEdState.showSkipTips,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -58,6 +58,7 @@ import me.him188.ani.app.ui.foundation.theme.AniTheme
 import me.him188.ani.app.ui.subject.episode.video.components.EpisodeVideoSideSheetPage
 import me.him188.ani.app.ui.subject.episode.video.components.rememberStatusBarHeightAsState
 import me.him188.ani.app.ui.subject.episode.video.loading.EpisodeVideoLoadingIndicator
+import me.him188.ani.app.videoplayer.ui.AspectRatioMode
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.VideoPlayer
@@ -127,6 +128,7 @@ internal fun EpisodeVideoImpl(
     audioController: LevelController,
     brightnessController: LevelController,
     playbackSpeedControllerState: PlaybackSpeedControllerState?,
+    aspectRatioControllerState: me.him188.ani.app.videoplayer.ui.AspectRatioControllerState?,
     leftBottomTips: @Composable () -> Unit,
     fullscreenSwitchButton: @Composable () -> Unit,
     sideSheets: @Composable (controller: VideoSideSheetsController<EpisodeVideoSideSheetPage>) -> Unit,
@@ -162,6 +164,7 @@ internal fun EpisodeVideoImpl(
             maintainAspectRatio = maintainAspectRatio,
             controllerState = playerControllerState,
             gestureLocked = isLocked,
+            aspectRatioControllerState = aspectRatioControllerState,
             topBar = {
                 WindowDragArea {
                     PlayerTopBar(
@@ -220,6 +223,7 @@ internal fun EpisodeVideoImpl(
                                 offset(x = -statusBarHeight / 2, y = 0.dp)
                             }
                             .matchParentSize(),
+                        aspectRatioMode = aspectRatioControllerState?.currentMode ?: AspectRatioMode.FIT,
                     )
                 }
             },
@@ -381,6 +385,17 @@ internal fun EpisodeVideoImpl(
 
                             playerState.subtitleTracks?.let {
                                 PlayerControllerDefaults.SubtitleSwitcher(it)
+                            }
+
+                            aspectRatioControllerState?.also { controller ->
+                                val aspectRatioAlwaysOnRequester = rememberAlwaysOnRequester(playerControllerState, "aspectRatioSwitcher")
+                                PlayerControllerDefaults.AspectRatioSwitcher(controller) {
+                                    if (it) {
+                                        aspectRatioAlwaysOnRequester.request()
+                                    } else {
+                                        aspectRatioAlwaysOnRequester.cancelRequest()
+                                    }
+                                }
                             }
 
                             val alwaysOnRequester = rememberAlwaysOnRequester(playerControllerState, "speedSwitcher")

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -58,6 +58,7 @@ import me.him188.ani.app.ui.foundation.theme.AniTheme
 import me.him188.ani.app.ui.subject.episode.video.components.EpisodeVideoSideSheetPage
 import me.him188.ani.app.ui.subject.episode.video.components.rememberStatusBarHeightAsState
 import me.him188.ani.app.ui.subject.episode.video.loading.EpisodeVideoLoadingIndicator
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.AspectRatioMode
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
@@ -128,7 +129,7 @@ internal fun EpisodeVideoImpl(
     audioController: LevelController,
     brightnessController: LevelController,
     playbackSpeedControllerState: PlaybackSpeedControllerState?,
-    aspectRatioControllerState: me.him188.ani.app.videoplayer.ui.AspectRatioControllerState?,
+    aspectRatioControllerState: AspectRatioControllerState?,
     leftBottomTips: @Composable () -> Unit,
     fullscreenSwitchButton: @Composable () -> Unit,
     sideSheets: @Composable (controller: VideoSideSheetsController<EpisodeVideoSideSheetPage>) -> Unit,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -131,6 +131,8 @@ import me.him188.ani.app.ui.subject.episode.video.PlayerSkipOpEdState
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.EpisodeSelectorState
 import me.him188.ani.app.ui.user.SelfInfoStateProducer
 import me.him188.ani.app.ui.user.SelfInfoUiState
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
+import me.him188.ani.app.videoplayer.ui.AspectRatioMode
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.danmaku.api.DanmakuContent
@@ -326,6 +328,7 @@ class EpisodeViewModel(
 
 
     val playerControllerState = PlayerControllerState(ControllerVisibility.Invisible)
+    val aspectRatioControllerState = AspectRatioControllerState(AspectRatioMode.FIT)
     private val mediaSourceInfoProvider: MediaSourceInfoProvider = MediaSourceInfoProvider(
         getSourceInfoFlow = { mediaSourceManager.infoFlowByMediaSourceId(it) },
     )

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -61,6 +61,7 @@ import me.him188.ani.app.ui.subject.episode.video.sidesheet.DanmakuRegexFilterSe
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.EpisodeSelectorSheet
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.MediaSelectorSheet
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.rememberTestEpisodeSelectorState
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.NoOpPlaybackSpeedController
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
@@ -213,6 +214,9 @@ class EpisodeVideoControllerTest {
                 brightnessController = NoOpLevelController,
                 playbackSpeedControllerState = remember {
                     PlaybackSpeedControllerState(NoOpPlaybackSpeedController, scope = scope)
+                },
+                aspectRatioControllerState = remember {
+                    AspectRatioControllerState()
                 },
                 leftBottomTips = {},
                 fullscreenSwitchButton = {

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
@@ -45,6 +45,7 @@ import me.him188.ani.app.ui.framework.doesNotExist
 import me.him188.ani.app.ui.framework.exists
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
 import me.him188.ani.app.ui.subject.episode.video.components.FloatingFullscreenSwitchButton
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.NoOpPlaybackSpeedController
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
@@ -125,6 +126,9 @@ class EpisodeVideoCursorTest {
                     brightnessController = NoOpLevelController,
                     playbackSpeedControllerState = remember {
                         PlaybackSpeedControllerState(NoOpPlaybackSpeedController, scope = scope)
+                    },
+                    aspectRatioControllerState = remember {
+                        AspectRatioControllerState()
                     },
                     leftBottomTips = {},
                     fullscreenSwitchButton = {

--- a/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
@@ -28,36 +28,50 @@ import org.openani.mediamp.exoplayer.compose.ExoPlayerMediampPlayerSurface
 @Composable
 actual fun VideoPlayer(
     player: MediampPlayer,
-    modifier: Modifier
+    modifier: Modifier,
+    aspectRatioMode: AspectRatioMode,
 ) {
     val isPreviewing by rememberUpdatedState(me.him188.ani.app.ui.foundation.LocalIsPreviewing.current)
 
     if (isPreviewing) {
         Box(modifier)
     } else {
-        ExoPlayerMediampPlayerSurface(player as ExoPlayerMediampPlayer, modifier) {
-            controllerAutoShow = false
-            useController = false
-            controllerHideOnTouch = false
-            subtitleView?.apply {
-                this.setStyle(
-                    CaptionStyleCompat(
-                        Color.WHITE,
-                        0x000000FF,
-                        0x00000000,
-                        CaptionStyleCompat.EDGE_TYPE_OUTLINE,
-                        Color.BLACK,
-                        Typeface.DEFAULT,
-                    ),
+        androidx.compose.runtime.key(aspectRatioMode) {
+            ExoPlayerMediampPlayerSurface(player as ExoPlayerMediampPlayer, modifier) {
+                controllerAutoShow = false
+                useController = false
+                controllerHideOnTouch = false
+
+                resizeMode = when (aspectRatioMode) {
+                    AspectRatioMode.FIT -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    AspectRatioMode.STRETCH -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FILL
+                    AspectRatioMode.FILL -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                    AspectRatioMode.RATIO_16_9 -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    AspectRatioMode.RATIO_4_3 -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
+                }
+                controllerAutoShow = false
+                useController = false
+                controllerHideOnTouch = false
+                subtitleView?.apply {
+                    this.setStyle(
+                        CaptionStyleCompat(
+                            Color.WHITE,
+                            0x000000FF,
+                            0x00000000,
+                            CaptionStyleCompat.EDGE_TYPE_OUTLINE,
+                            Color.BLACK,
+                            Typeface.DEFAULT,
+                        ),
+                    )
+                }
+                setControllerVisibilityListener(
+                    ControllerVisibilityListener { visibility ->
+                        if (visibility == View.VISIBLE) {
+                            hideController()
+                        }
+                    },
                 )
             }
-            setControllerVisibilityListener(
-                ControllerVisibilityListener { visibility ->
-                    if (visibility == View.VISIBLE) {
-                        hideController()
-                    }
-                },
-            )
         }
     }
 }

--- a/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
@@ -15,11 +15,14 @@ import android.view.View
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView.ControllerVisibilityListener
+import me.him188.ani.app.ui.foundation.LocalIsPreviewing
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
 import org.openani.mediamp.exoplayer.compose.ExoPlayerMediampPlayerSurface
@@ -31,23 +34,21 @@ actual fun VideoPlayer(
     modifier: Modifier,
     aspectRatioMode: AspectRatioMode,
 ) {
-    val isPreviewing by rememberUpdatedState(me.him188.ani.app.ui.foundation.LocalIsPreviewing.current)
+    val isPreviewing by rememberUpdatedState(LocalIsPreviewing.current)
 
     if (isPreviewing) {
         Box(modifier)
     } else {
-        androidx.compose.runtime.key(aspectRatioMode) {
+        key(aspectRatioMode) {
             ExoPlayerMediampPlayerSurface(player as ExoPlayerMediampPlayer, modifier) {
                 controllerAutoShow = false
                 useController = false
                 controllerHideOnTouch = false
 
                 resizeMode = when (aspectRatioMode) {
-                    AspectRatioMode.FIT -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
-                    AspectRatioMode.STRETCH -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FILL
-                    AspectRatioMode.FILL -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                    AspectRatioMode.RATIO_16_9 -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
-                    AspectRatioMode.RATIO_4_3 -> androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    AspectRatioMode.FIT -> AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    AspectRatioMode.STRETCH -> AspectRatioFrameLayout.RESIZE_MODE_FILL
+                    AspectRatioMode.FILL -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
                 }
                 controllerAutoShow = false
                 useController = false

--- a/app/shared/video-player/src/commonMain/kotlin/ui/AspectRatioControllerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/AspectRatioControllerState.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * 视频画面比例模式
+ */
+@Stable
+enum class AspectRatioMode(val displayName: String) {
+    FIT("适应"),
+    STRETCH("拉伸"),
+    FILL("填充")
+}
+
+/**
+ * 画面比例控制器状态
+ */
+@Stable
+class AspectRatioControllerState(
+    initialMode: AspectRatioMode = AspectRatioMode.FIT
+) {
+    var currentMode by mutableStateOf(initialMode)
+        private set
+
+    fun setMode(mode: AspectRatioMode) {
+        currentMode = mode
+    }
+}
+
+@Composable
+fun rememberAspectRatioControllerState(
+    initialMode: AspectRatioMode = AspectRatioMode.FIT
+): AspectRatioControllerState {
+    return remember { AspectRatioControllerState(initialMode) }
+}

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoPlayer.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoPlayer.kt
@@ -24,4 +24,5 @@ import org.openani.mediamp.MediampPlayer
 expect fun VideoPlayer(
     player: MediampPlayer,
     modifier: Modifier,
+    aspectRatioMode: AspectRatioMode = AspectRatioMode.FIT,
 )

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -119,8 +119,6 @@ fun VideoScaffold(
                             AspectRatioMode.FIT -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
                             AspectRatioMode.STRETCH -> Modifier.fillMaxSize()
                             AspectRatioMode.FILL -> Modifier.fillMaxSize()
-                            AspectRatioMode.RATIO_16_9 -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
-                            AspectRatioMode.RATIO_4_3 -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 3f / 4f)
                             null -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
                         }
                     },
@@ -137,8 +135,6 @@ fun VideoScaffold(
                             AspectRatioMode.FIT -> Modifier.matchParentSize()
                             AspectRatioMode.STRETCH -> Modifier.fillMaxSize()
                             AspectRatioMode.FILL -> Modifier.fillMaxSize()
-                            AspectRatioMode.RATIO_16_9 -> Modifier.matchParentSize()
-                            AspectRatioMode.RATIO_4_3 -> Modifier.matchParentSize()
                             null -> Modifier.matchParentSize()
                         }
                     )

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -81,6 +81,7 @@ fun VideoScaffold(
     maintainAspectRatio: Boolean = !expanded,
     controllerState: PlayerControllerState,
     gestureLocked: Boolean = false,
+    aspectRatioControllerState: AspectRatioControllerState? = null,
     topBar: @Composable RowScope.() -> Unit = {},
     /**
      * @see VideoPlayer
@@ -107,13 +108,21 @@ fun VideoScaffold(
         modifier.then(if (expanded) Modifier.fillMaxHeight() else Modifier.fillMaxWidth()),
         contentAlignment = Alignment.Center,
     ) { // 16:9 box
+        val currentMode = aspectRatioControllerState?.currentMode
         Box(
             Modifier
                 .then(
                     if (!maintainAspectRatio) {
                         Modifier.fillMaxSize()
                     } else {
-                        Modifier.fillMaxWidth().height(maxWidth * 9 / 16) // 16:9 box
+                        when (currentMode) {
+                            AspectRatioMode.FIT -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
+                            AspectRatioMode.STRETCH -> Modifier.fillMaxSize()
+                            AspectRatioMode.FILL -> Modifier.fillMaxSize()
+                            AspectRatioMode.RATIO_16_9 -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
+                            AspectRatioMode.RATIO_4_3 -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 3f / 4f)
+                            null -> Modifier.fillMaxWidth().height(this@BoxWithConstraints.maxWidth * 9f / 16f)
+                        }
                     },
                 ),
         ) {
@@ -122,7 +131,20 @@ fun VideoScaffold(
                     .background(Color.Transparent)
                     .matchParentSize(), // no window insets for video
             ) {
-                video()
+                Box(
+                    Modifier.then(
+                        when (currentMode) {
+                            AspectRatioMode.FIT -> Modifier.matchParentSize()
+                            AspectRatioMode.STRETCH -> Modifier.fillMaxSize()
+                            AspectRatioMode.FILL -> Modifier.fillMaxSize()
+                            AspectRatioMode.RATIO_16_9 -> Modifier.matchParentSize()
+                            AspectRatioMode.RATIO_4_3 -> Modifier.matchParentSize()
+                            null -> Modifier.matchParentSize()
+                        }
+                    )
+                ) {
+                    video()
+                }
                 Box(Modifier.matchParentSize()) // 防止点击事件传播到 video 里
             }
 
@@ -327,6 +349,7 @@ fun VideoScaffold(
                     }
                 }
             }
+
 
             // 右侧 sheet
             Box(Modifier.matchParentSize().windowInsetsPadding(contentWindowInsets)) {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -99,6 +99,7 @@ import me.him188.ani.app.ui.foundation.effects.onKey
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.theme.slightlyWeaken
 import me.him188.ani.app.ui.foundation.theme.stronglyWeaken
+import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.top.needWorkaroundForFocusManager
@@ -489,6 +490,26 @@ object PlayerControllerDefaults {
             ),
             textButtonTestTag = TAG_SPEED_SWITCHER_TEXT_BUTTON,
             dropdownMenuTestTag = TAG_SPEED_SWITCHER_DROPDOWN_MENU,
+            onExpandedChanged = onExpandedChanged,
+        )
+    }
+
+    @Composable
+    fun AspectRatioSwitcher(
+        aspectRatioControllerState: AspectRatioControllerState,
+        modifier: Modifier = Modifier,
+        onExpandedChanged: (expanded: Boolean) -> Unit = {},
+    ) {
+        return OptionsSwitcher(
+            value = aspectRatioControllerState.currentMode,
+            onValueChange = { aspectRatioControllerState.setMode(it) },
+            optionsProvider = { me.him188.ani.app.videoplayer.ui.AspectRatioMode.entries },
+            renderValue = { Text(it.displayName) },
+            renderValueExposed = { Text("画面") },
+            modifier,
+            properties = PlatformPopupProperties(
+                clippingEnabled = false,
+            ),
             onExpandedChanged = onExpandedChanged,
         )
     }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -100,6 +100,7 @@ import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.theme.slightlyWeaken
 import me.him188.ani.app.ui.foundation.theme.stronglyWeaken
 import me.him188.ani.app.videoplayer.ui.AspectRatioControllerState
+import me.him188.ani.app.videoplayer.ui.AspectRatioMode
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.top.needWorkaroundForFocusManager
@@ -503,7 +504,7 @@ object PlayerControllerDefaults {
         return OptionsSwitcher(
             value = aspectRatioControllerState.currentMode,
             onValueChange = { aspectRatioControllerState.setMode(it) },
-            optionsProvider = { me.him188.ani.app.videoplayer.ui.AspectRatioMode.entries },
+            optionsProvider = { AspectRatioMode.entries },
             renderValue = { Text(it.displayName) },
             renderValueExposed = { Text("画面") },
             modifier,

--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -9,11 +9,21 @@
 
 package me.him188.ani.app.videoplayer.ui
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.fastCoerceAtLeast
+import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.vlc.VlcMediampPlayer
-import org.openani.mediamp.vlc.compose.VlcMediampPlayerSurface
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 @Composable
 actual fun VideoPlayer(
@@ -23,5 +33,86 @@ actual fun VideoPlayer(
 ) {
     check(player is VlcMediampPlayer)
 
-    VlcMediampPlayerSurface(player, modifier = modifier)
+    val frameSizeCalculator = remember(aspectRatioMode) {
+        FrameSizeCalculator(aspectRatioMode)
+    }
+    
+    @OptIn(InternalMediampApi::class)
+    Canvas(modifier) {
+        val bitmap = player.surface.bitmap ?: return@Canvas
+        frameSizeCalculator.calculate(
+            IntSize(bitmap.width, bitmap.height),
+            Size(size.width, size.height),
+        )
+        drawImage(
+            bitmap,
+            dstSize = frameSizeCalculator.dstSize,
+            dstOffset = frameSizeCalculator.dstOffset,
+            filterQuality = FilterQuality.High,
+        )
+    }
+}
+
+private class FrameSizeCalculator(private val aspectRatioMode: AspectRatioMode) {
+    private var lastImageSize: IntSize = IntSize.Zero
+    private var lastFrameSize: IntSize = IntSize.Zero
+    private var lastAspectRatioMode: AspectRatioMode = aspectRatioMode
+
+    var dstSize: IntSize = IntSize.Zero
+        private set
+    var dstOffset: IntOffset = IntOffset.Zero
+        private set
+
+    fun calculate(imageSize: IntSize, frameSize: Size) {
+        val frameSizePx = IntSize(frameSize.width.roundToInt(), frameSize.height.roundToInt())
+
+        if (lastImageSize == imageSize && lastFrameSize == frameSizePx && lastAspectRatioMode == aspectRatioMode) return
+
+        when (aspectRatioMode) {
+            AspectRatioMode.FIT -> calculateFit(imageSize, frameSize)
+            AspectRatioMode.STRETCH -> calculateStretch(frameSize)
+            AspectRatioMode.FILL -> calculateFill(imageSize, frameSize)
+        }
+
+        lastImageSize = imageSize
+        lastFrameSize = frameSizePx
+        lastAspectRatioMode = aspectRatioMode
+    }
+
+    private fun calculateFit(imageSize: IntSize, frameSize: Size) {
+        val scale = min(
+            frameSize.width / imageSize.width,
+            frameSize.height / imageSize.height,
+        )
+
+        val scaledW = (imageSize.width * scale).roundToInt()
+        val scaledH = (imageSize.height * scale).roundToInt()
+
+        dstSize = IntSize(scaledW, scaledH)
+
+        val offsetX = ((frameSize.width - scaledW) / 2f).fastCoerceAtLeast(0f).roundToInt()
+        val offsetY = ((frameSize.height - scaledH) / 2f).fastCoerceAtLeast(0f).roundToInt()
+        dstOffset = IntOffset(offsetX, offsetY)
+    }
+
+    private fun calculateStretch(frameSize: Size) {
+        dstSize = IntSize(frameSize.width.roundToInt(), frameSize.height.roundToInt())
+        dstOffset = IntOffset.Zero
+    }
+
+    private fun calculateFill(imageSize: IntSize, frameSize: Size) {
+        val scale = max(
+            frameSize.width / imageSize.width,
+            frameSize.height / imageSize.height,
+        )
+
+        val scaledW = (imageSize.width * scale).roundToInt()
+        val scaledH = (imageSize.height * scale).roundToInt()
+
+        dstSize = IntSize(scaledW, scaledH)
+
+        val offsetX = ((frameSize.width - scaledW) / 2f).roundToInt()
+        val offsetY = ((frameSize.height - scaledH) / 2f).roundToInt()
+        dstOffset = IntOffset(offsetX, offsetY)
+    }
 }

--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -19,6 +19,7 @@ import org.openani.mediamp.vlc.compose.VlcMediampPlayerSurface
 actual fun VideoPlayer(
     player: MediampPlayer,
     modifier: Modifier,
+    aspectRatioMode: AspectRatioMode,
 ) {
     check(player is VlcMediampPlayer)
 

--- a/app/shared/video-player/src/iosMain/kotlin/ui/VideoPlayer.ios.kt
+++ b/app/shared/video-player/src/iosMain/kotlin/ui/VideoPlayer.ios.kt
@@ -23,7 +23,8 @@ import org.openani.mediamp.compose.MediampPlayerSurface
 @Composable
 actual fun VideoPlayer(
     player: MediampPlayer,
-    modifier: Modifier
+    modifier: Modifier,
+    aspectRatioMode: AspectRatioMode,
 ) {
     MediampPlayerSurface(player, modifier)
 }

--- a/app/shared/video-player/src/iosMain/kotlin/ui/VideoPlayer.ios.kt
+++ b/app/shared/video-player/src/iosMain/kotlin/ui/VideoPlayer.ios.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.videoplayer.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.compose.MediampPlayerSurface
@@ -26,5 +27,7 @@ actual fun VideoPlayer(
     modifier: Modifier,
     aspectRatioMode: AspectRatioMode,
 ) {
-    MediampPlayerSurface(player, modifier)
+    key(aspectRatioMode) {
+        MediampPlayerSurface(player, modifier)
+    }
 }


### PR DESCRIPTION
## What

Added aspect ratio switching functionality to the video player with three modes: Fit, Stretch, and Fill. Users can now adjust video display ratio via a dropdown button in the player control bar.

## Why

Users needed the ability to adjust video aspect ratios for different content types and viewing preferences. This improves the viewing experience by allowing optimal display for various video formats.

## Where

- UI : Added `AspectRatioSwitcher` component in `PlayerControllerDefaults`
- State : Created `AspectRatioControllerState` for managing aspect ratio modes
- Implementation:
  - Android: Uses ExoPlayer's `AspectRatioFrameLayout.resizeMode`
  - Desktop: Custom Canvas rendering with `FrameSizeCalculator`
- Integration : Connected to `VideoScaffold` and `EpisodeViewModel` for state persistence

## Related

Closes #1819 
