### PR TITLE
fix(ui): 条目详情页的Tab栏在平板上显示不全问题

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -354,7 +354,10 @@ private fun SubjectDetailsPage(
                         relatedSubjects = state.relatedSubjectsPager.collectAsLazyPagingItemsWithLifecycle(),
                         Modifier
                             .nestedScrollWorkaround(state.detailsTabLazyListState, connectedScrollState)
-                            .nestedScroll(connectedScrollState.nestedScrollConnection),
+                            .nestedScroll(connectedScrollState.nestedScrollConnection)
+                            .fillMaxWidth()
+                            .wrapContentWidth(align = Alignment.CenterHorizontally)
+                            .widthIn(max = MaximumContentWidth),
                         state.detailsTabLazyListState,
                         contentPadding = contentPadding,
                     )
@@ -387,7 +390,6 @@ private fun SubjectDetailsPage(
                 },
                 Modifier
                     .fillMaxWidth()
-                    .wrapContentWidth(align = Alignment.CenterHorizontally)
                     .widthIn(max = MaximumContentWidth),
             )
         }


### PR DESCRIPTION
pager宽度没有铺满，导致左右划动时也有留白.
before:
<img width="1670" height="935" alt="before" src="https://github.com/user-attachments/assets/500bc37a-383a-438e-93a6-6522959da3b8" />

after:
<img width="1674" height="910" alt="after" src="https://github.com/user-attachments/assets/bceee4b3-6ef8-44b1-ad1f-b03c63c0ec21" />

