### PR TITLE
fix(ios): 修复ios声音无法在静音模式下正常播放与屏幕亮度无法正常设置问题

### DIFF
--- a/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import me.him188.ani.app.platform.Context
 import me.him188.ani.app.tools.MonoTasker
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.setActive
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSNotificationCenter
 import platform.MediaPlayer.MPVolumeView
@@ -46,12 +49,12 @@ private class IosBrightnessManager : BrightnessManager {
         NSNotificationCenter.defaultCenter.addObserverForName(
             name = UIScreenBrightnessDidChangeNotification,
             `object` = null,
-            queue = null
+            queue = null,
         ) { _ ->
             brightness = UIScreen.mainScreen.brightness.toFloat()
         }
     }
-    
+
     override fun getBrightness(): Float = brightness
 
     override fun setBrightness(level: Float) =
@@ -61,6 +64,7 @@ private class IosBrightnessManager : BrightnessManager {
         }
 }
 
+@OptIn(ExperimentalForeignApi::class)
 internal class IosAudioManager : AudioManager {
 
     @OptIn(ExperimentalForeignApi::class)
@@ -71,6 +75,13 @@ internal class IosAudioManager : AudioManager {
     val slider by lazy {
         // 在 MPVolumeView 中找到 UISlider 组件
         volumeView.subviews.first { it is UISlider } as UISlider
+    }
+
+    init {
+        AVAudioSession.sharedInstance().run {
+            setCategory(AVAudioSessionCategoryPlayback, null)
+            setActive(true, null)
+        }
     }
 
     override fun getVolume(streamType: StreamType): Float {

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
@@ -58,9 +58,9 @@ private class IosBrightnessManager : BrightnessManager {
     override fun getBrightness(): Float = brightness
 
     override fun setBrightness(level: Float) =
-        level.coerceIn(0f, 1f).let { salvedLevel ->
-            brightness = salvedLevel
-            UIScreen.mainScreen.brightness = salvedLevel.toDouble()
+        level.coerceIn(0f, 1f).let { savedLevel ->
+            brightness = savedLevel
+            UIScreen.mainScreen.brightness = savedLevel.toDouble()
         }
 }
 

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
@@ -9,14 +9,25 @@
 
 package me.him188.ani.app.platform.features
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import me.him188.ani.app.platform.Context
+import me.him188.ani.app.tools.MonoTasker
+import platform.CoreGraphics.CGRectMake
+import platform.MediaPlayer.MPVolumeView
+import platform.UIKit.UIApplication
 import platform.UIKit.UIScreen
+import platform.UIKit.UISlider
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 actual fun getComponentAccessorsImpl(context: Context): PlatformComponentAccessors =
     IosPlatformComponentAccessors
 
 private object IosPlatformComponentAccessors : PlatformComponentAccessors {
-    override val audioManager: AudioManager? get() = null // Ios does not allow adjusting system volume.
+    override val audioManager: AudioManager? by lazy { IosAudioManager() }
     override val brightnessManager: BrightnessManager? by lazy { IosBrightnessManager() }
 }
 
@@ -28,4 +39,39 @@ private class IosBrightnessManager : BrightnessManager {
     override fun setBrightness(level: Float) {
         UIScreen.mainScreen.brightness = level.coerceIn(0f, 1f).toDouble()
     }
+}
+
+internal class IosAudioManager : AudioManager {
+
+    @OptIn(ExperimentalForeignApi::class)
+    val volumeView = MPVolumeView(CGRectMake(-2000.0, -2000.0, 0.0, 0.0))
+
+    val tasker = MonoTasker(CoroutineScope(Dispatchers.Main))
+
+    val slider by lazy {
+        // 在 MPVolumeView 中找到 UISlider 组件
+        volumeView.subviews.first { it is UISlider } as UISlider
+    }
+
+    override fun getVolume(streamType: StreamType): Float {
+        return slider.value
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    override fun setVolume(streamType: StreamType, levelPercentage: Float) {
+        if (volumeView.superview == null) {
+            UIApplication.sharedApplication.keyWindow?.addSubview(volumeView)
+        }
+        dispatch_async(queue = dispatch_get_main_queue()) {
+            // 设置音量
+            slider.setValue(levelPercentage.coerceIn(0f, 1f), animated = false)
+        }
+        // 防抖移除 MPVolumeView
+        tasker.launch {
+            delay(3000)
+            // 移除 MPVolumeView
+            volumeView.removeFromSuperview()
+        }
+    }
+
 }

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
@@ -16,12 +16,15 @@ import kotlinx.coroutines.delay
 import me.him188.ani.app.platform.Context
 import me.him188.ani.app.tools.MonoTasker
 import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSNotificationCenter
 import platform.MediaPlayer.MPVolumeView
 import platform.UIKit.UIApplication
 import platform.UIKit.UIScreen
+import platform.UIKit.UIScreenBrightnessDidChangeNotification
 import platform.UIKit.UISlider
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
+
 
 actual fun getComponentAccessorsImpl(context: Context): PlatformComponentAccessors =
     IosPlatformComponentAccessors
@@ -38,6 +41,16 @@ private class IosBrightnessManager : BrightnessManager {
      *  UIScreen.mainScreen.brightness 设置后不能马上生效所以get的时候需要一个临时值
      */
     var brightness = UIScreen.mainScreen.brightness.toFloat()
+
+    init {
+        NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIScreenBrightnessDidChangeNotification,
+            `object` = null,
+            queue = null
+        ) { _ ->
+            brightness = UIScreen.mainScreen.brightness.toFloat()
+        }
+    }
     
     override fun getBrightness(): Float = brightness
 

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/features/PlatformComponentAccessors.ios.kt
@@ -32,13 +32,20 @@ private object IosPlatformComponentAccessors : PlatformComponentAccessors {
 }
 
 private class IosBrightnessManager : BrightnessManager {
-    override fun getBrightness(): Float {
-        return UIScreen.mainScreen.brightness.toFloat()
-    }
+    /**
+     * 屏幕亮度
+     *
+     *  UIScreen.mainScreen.brightness 设置后不能马上生效所以get的时候需要一个临时值
+     */
+    var brightness = UIScreen.mainScreen.brightness.toFloat()
+    
+    override fun getBrightness(): Float = brightness
 
-    override fun setBrightness(level: Float) {
-        UIScreen.mainScreen.brightness = level.coerceIn(0f, 1f).toDouble()
-    }
+    override fun setBrightness(level: Float) =
+        level.coerceIn(0f, 1f).let { salvedLevel ->
+            brightness = salvedLevel
+            UIScreen.mainScreen.brightness = salvedLevel.toDouble()
+        }
 }
 
 internal class IosAudioManager : AudioManager {

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -93,9 +92,6 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import org.openani.mediamp.MediampPlayerFactory
 import org.openani.mediamp.avkit.AVKitMediampPlayerFactory
-import platform.AVFAudio.AVAudioSession
-import platform.AVFAudio.AVAudioSessionCategoryPlayback
-import platform.AVFAudio.setActive
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIViewController
 import platform.UIKit.addChildViewController
@@ -275,11 +271,7 @@ fun getIosModules(
             mediaResolver = get<MediaResolver>(),
         )
     }
-    @OptIn(ExperimentalForeignApi::class)
     single<MediampPlayerFactory<*>> {
-        val audioSession = AVAudioSession.sharedInstance()
-        audioSession.setCategory(AVAudioSessionCategoryPlayback, null)
-        audioSession.setActive(true, null)
         AVKitMediampPlayerFactory()
     }
     single<MediaSaveDirProvider> {

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -92,6 +93,9 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import org.openani.mediamp.MediampPlayerFactory
 import org.openani.mediamp.avkit.AVKitMediampPlayerFactory
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.setActive
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIViewController
 import platform.UIKit.addChildViewController
@@ -271,7 +275,11 @@ fun getIosModules(
             mediaResolver = get<MediaResolver>(),
         )
     }
+    @OptIn(ExperimentalForeignApi::class)
     single<MediampPlayerFactory<*>> {
+        val audioSession = AVAudioSession.sharedInstance()
+        audioSession.setCategory(AVAudioSessionCategoryPlayback, null)
+        audioSession.setActive(true, null)
         AVKitMediampPlayerFactory()
     }
     single<MediaSaveDirProvider> {


### PR DESCRIPTION
原pr：https://github.com/open-ani/animeko/pull/2352 （同步太多次提交混乱导致重开pr）
实现 IosAudioManager，支持获取和设置系统音量
设置 `AVAudioSession` 的类别为 `Playback`，支持静音模式下正常播放 https://github.com/open-ani/animeko/issues/2351
添加临时变量存储屏幕亮度，解决 UIScreen.mainScreen.brightness 设置后无法立即生效导致亮度值在原地踏步踏无法正常设置问题 https://github.com/open-ani/animeko/issues/2005 https://github.com/open-ani/animeko/issues/2004