### PR TITLE
fix(search): resolve search page data refresh issue

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
@@ -41,6 +41,7 @@ abstract class Repository(
     companion object {
         val defaultPagingConfig = PagingConfig(
             pageSize = 30,
+            prefetchDistance = 20, // 增加预取距离
         )
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -99,7 +99,11 @@ class SubjectSearchRepository(
                     res
                 }
 
-                val subjectInfos = subjectService.batchGetSubjectDetails(filteredIds)
+                // 在分页源中直接过滤掉不符合条件的数据 #2380
+                val subjectInfos = filterSubjectsBySort(
+                    subjectService.batchGetSubjectDetails(filteredIds), 
+                    searchQuery.sort
+                )
 
                 return@withContext LoadResult.Page(
                     subjectInfos,
@@ -144,6 +148,20 @@ class SubjectSearchRepository(
                 range.min?.let { ">=${it}" },
                 range.max?.let { "<${it}" },
             )
+        }
+        
+        /**
+         * 将数据过滤从View提升到分页层，不然会导致 #2380
+         */
+        private fun filterSubjectsBySort(
+            subjects: List<BatchSubjectDetails>,
+            sort: SearchSort
+        ): List<BatchSubjectDetails> {
+            return when (sort) {
+                SearchSort.RANK -> subjects.filter { it.subjectInfo.ratingInfo.total >= 50 }
+                SearchSort.MATCH,
+                SearchSort.COLLECTION -> subjects
+            }
         }
     }
 

--- a/app/shared/src/commonMain/kotlin/ui/main/SearchViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/SearchViewModel.kt
@@ -23,14 +23,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import me.him188.ani.app.data.models.preference.NsfwMode
 import me.him188.ani.app.data.models.subject.SubjectInfo
-import me.him188.ani.app.data.network.BatchSubjectDetails
 import me.him188.ani.app.data.repository.episode.EpisodeCollectionRepository
 import me.him188.ani.app.data.repository.subject.BangumiSubjectSearchCompletionRepository
 import me.him188.ani.app.data.repository.subject.SubjectSearchHistoryRepository
 import me.him188.ani.app.data.repository.subject.SubjectSearchRepository
 import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.episode.SetEpisodeCollectionTypeUseCase
-import me.him188.ani.app.domain.search.SearchSort
 import me.him188.ani.app.domain.search.SubjectSearchQuery
 import me.him188.ani.app.ui.exploration.search.SearchPageState
 import me.him188.ani.app.ui.exploration.search.SubjectPreviewItemInfo
@@ -118,7 +116,6 @@ class SearchViewModel(
                             },
                             relatedPersonList = subject.lightSubjectRelations.lightRelatedPersonInfoList,
                             characters = subject.lightSubjectRelations.lightRelatedCharacterInfoList,
-                            hide = shouldHide(query, subject),
                         )
                     }
                     // 我们必须保证 data 的数量和 map 后的数量一致, 否则会导致 Pager 搜索下一页时使用的 offset 有误.
@@ -137,22 +134,6 @@ class SearchViewModel(
             }
         },
     )
-
-    private fun shouldHide(query: SubjectSearchQuery, subject: BatchSubjectDetails): Boolean {
-        when (query.sort) {
-            SearchSort.RANK -> {
-                if (subject.subjectInfo.ratingInfo.total < 50) {
-                    return true
-                }
-            }
-
-            SearchSort.MATCH,
-            SearchSort.COLLECTION -> {
-            }
-        }
-
-        return false
-    }
 
     val subjectDetailsStateLoader = SubjectDetailsStateLoader(subjectDetailsStateFactory, backgroundScope)
     private var currentPreviewingSubject: SubjectInfo? = null

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
@@ -45,7 +45,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -113,15 +112,6 @@ internal fun SearchResultColumn(
 
     val itemsState = rememberUpdatedState(items)
 
-    val visibleItems by remember(items.itemSnapshotList) {
-        derivedStateOf {
-            items.itemSnapshotList.items.mapIndexedNotNull { index, item ->
-                if (item != null && !item.hide) index to item else null
-            }
-        }
-    }
-
-    
     SearchResultLazyVerticalGrid(
         items,
         error = {
@@ -160,11 +150,11 @@ internal fun SearchResultColumn(
         }
 
         items(
-            count = visibleItems.size,
-            key = { visibleItems[it].second.subjectId },
+            count = items.itemCount,
+            key = items.itemKey { it.subjectId },
             contentType = items.itemContentType { 1 },
         ) { index ->
-            val (originalIndex, info) = visibleItems[index]
+            val info = items[index]
 
             SharedTransitionLayout {
                 AnimatedContent(
@@ -186,7 +176,7 @@ internal fun SearchResultColumn(
                                     info?.title,
                                     info?.imageUrl,
                                     isPlaceholder = info == null,
-                                    onClick = { onSelect(originalIndex) },
+                                    onClick = { onSelect(index) },
                                     Modifier
                                         .ifNotNullThen(info) {
                                             sharedElement(
@@ -221,9 +211,9 @@ internal fun SearchResultColumn(
 
                                     SearchResultItem(
                                         info = info,
-                                        selected = highlightSelected && originalIndex == selectedItemIndex(),
+                                        selected = highlightSelected && index == selectedItemIndex(),
                                         shape = layoutParams.previewItem.shape,
-                                        onClick = { onSelect(originalIndex) },
+                                        onClick = { onSelect(index) },
                                         onPlay = onPlay,
                                         Modifier
                                             .animateItem(

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/search/SearchResultLazyVerticalStaggeredGrid.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/search/SearchResultLazyVerticalStaggeredGrid.kt
@@ -105,6 +105,20 @@ fun <T : Any> SearchResultLazyVerticalGrid(
                         }
                     }
                 }
+                
+                // 显示下一页加载指示器，否则加载速度慢用户不知道是否在更新
+                if (items.loadState.append is LoadState.Loading) {
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        ListItem(
+                            headlineContent = {
+                                Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                    LoadingIndicator()
+                                }
+                            },
+                            colors = listItemColors,
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What
Fixed search results pagination stopping at ~20 items instead of loading more when scrolling to bottom.

## Why
Multiple issues caused pagination failure: incorrect pagination logic using filtered results count, and UI filtering creating gaps that prevented pagination triggers.

## Where
Moved filtering logic from UI layer (`SearchViewModel.shouldHide()`) to data layer (`SubjectSearchRepository.filterSubjectsBySort()`). Now filtered items are removed at the pagination source level before reaching the UI.

## Related
Closes #2380 