### PR TITLE
Fix Bangumi API pagination by adjusting pageSize to match actual API limit

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
@@ -41,7 +41,6 @@ abstract class Repository(
     companion object {
         val defaultPagingConfig = PagingConfig(
             pageSize = 30,
-            prefetchDistance = 20,
         )
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
@@ -40,7 +40,8 @@ abstract class Repository(
 
     companion object {
         val defaultPagingConfig = PagingConfig(
-            pageSize = 30,
+            pageSize = 20, // Bangumi API 实际最多返回 20 个结果 #2417
+            initialLoadSize = 20, // 设置初始加载大小等于 pageSize
             prefetchDistance = 20, // 增加预取距离
         )
     }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/Repository.kt
@@ -40,9 +40,8 @@ abstract class Repository(
 
     companion object {
         val defaultPagingConfig = PagingConfig(
-            pageSize = 20, // Bangumi API 实际最多返回 20 个结果 #2417
-            initialLoadSize = 20, // 设置初始加载大小等于 pageSize
-            prefetchDistance = 20, // 增加预取距离
+            pageSize = 30,
+            prefetchDistance = 20,
         )
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -101,8 +101,8 @@ class SubjectSearchRepository(
 
                 // 在分页源中直接过滤掉不符合条件的数据 #2380
                 val subjectInfos = filterSubjectsBySort(
-                    subjectService.batchGetSubjectDetails(filteredIds), 
-                    searchQuery.sort
+                    subjectService.batchGetSubjectDetails(filteredIds),
+                    searchQuery.sort,
                 )
 
                 return@withContext LoadResult.Page(
@@ -149,7 +149,7 @@ class SubjectSearchRepository(
                 range.max?.let { "<${it}" },
             )
         }
-        
+
         /**
          * 将数据过滤从View提升到分页层，不然会导致 #2380
          */

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -228,7 +228,6 @@ class SubjectSearchRepository(
         private val bangumiSearchPagingConfig = PagingConfig(
             pageSize = 20, // Bangumi API 实际最多返回 20 个结果 #2417
             initialLoadSize = 20,
-            prefetchDistance = 20,
         )
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -55,7 +55,7 @@ class SubjectSearchRepository(
         searchQuery: SubjectSearchQuery,
         useNewApi: suspend () -> Boolean = { false },
         ignoreDoneAndDropped: suspend () -> Boolean = { false },
-        pagingConfig: PagingConfig = Repository.defaultPagingConfig
+        pagingConfig: PagingConfig = bangumiSearchPagingConfig
     ): Flow<PagingData<BatchSubjectDetails>> = Pager(
         config = pagingConfig,
         initialKey = 0,
@@ -225,6 +225,11 @@ class SubjectSearchRepository(
 
     private companion object {
         private val logger = logger<SubjectSearchRepository>()
+        private val bangumiSearchPagingConfig = PagingConfig(
+            pageSize = 20, // Bangumi API 实际最多返回 20 个结果 #2417
+            initialLoadSize = 20,
+            prefetchDistance = 20,
+        )
     }
 }
 

--- a/datasource/bangumi/src/commonMain/kotlin/client/BangumiSearchApi.kt
+++ b/datasource/bangumi/src/commonMain/kotlin/client/BangumiSearchApi.kt
@@ -25,7 +25,7 @@ interface BangumiSearchApi {
      * @param types 条目类型, 默认为 [BangumiSubjectType.ANIME]
      * @param responseGroup 返回数据大小, 默认为 [BangumiResponseGroup.SMALL]
      * @param offset 开始条数, 默认为 0
-     * @param limit 返回条数, 最大为 25
+     * @param limit 返回条数, 最大为 20
      * @return 搜索结果, null 表示已经到达最后一条
      */
     suspend fun searchSubjectByKeywords(


### PR DESCRIPTION
## What
Adjusted the default pageSize from 30 to 20 in Repository.defaultPagingConfig to match the actual Bangumi API response limit.

## Why
The Bangumi API documentation states a maximum limit of 25 results per request, but testing revealed the actual server-side limit is 20 results. This mismatch caused:

- Inefficient pagination (requesting 25/30 but only receiving 20)
- Index calculation error
- Discarded one-third of the search results, resulting in a basic fixed number of 630

Evidence from logs:
```bash
BangumiClient: API response total=1000, data.size=20, offset=25, limit=25
```

## Where
- Change: pageSize: `30` → `20` and initialLoadSize: 20

## Related
Closes #2417