### PR TITLE
修复番剧进度判定有误的问题

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/subject/SubjectProgressInfo.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/subject/SubjectProgressInfo.kt
@@ -87,7 +87,7 @@ data class SubjectProgressInfo(
             episodes: List<Episode>,
             subjectAirDate: PackedDate,
         ): SubjectProgressInfo {
-            // 过滤并排序普通剧集
+            // 进度应该仅考虑普通剧集，并且按 sort 排序
             val sortedNormalEpisodes = episodes
                 .filter { it.sort is EpisodeSort.Normal }
                 .sortedBy { it.sort }

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/subject/SubjectProgressInfo.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/subject/SubjectProgressInfo.kt
@@ -134,7 +134,6 @@ data class SubjectProgressInfo(
                         if (latestEpIndex != null && lastWatchedEpIndex < latestEpIndex && actualSubjectStarted) {
                             // 更新了 n+1 集
                             ContinueWatchingStatus.Continue(
-                                episodeIndex = lastWatchedEpIndex + 1,
                                 episodeEp = sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex + 1)?.ep,
                                 episodeSort = sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex + 1)?.sort,
                                 watchedEpisodeEp = sortedMainStoryEpisodes[lastWatchedEpIndex].ep,
@@ -143,7 +142,6 @@ data class SubjectProgressInfo(
                         } else {
                             // 还没更新
                             ContinueWatchingStatus.Watched(
-                                lastWatchedEpIndex,
                                 sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex)?.ep,
                                 sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex)?.sort,
                                 sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex + 1)?.airDate
@@ -160,7 +158,7 @@ data class SubjectProgressInfo(
 
             val episodeToPlay = kotlin.run {
                 if (continueWatchingStatus is ContinueWatchingStatus.Watched) {
-                    return@run sortedMainStoryEpisodes.getOrNull(continueWatchingStatus.episodeIndex)
+                    return@run sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex)
                 } else {
                     if (lastWatchedEpIndex != -1) {
                         sortedMainStoryEpisodes.getOrNull(lastWatchedEpIndex + 1)?.let { return@run it }
@@ -201,7 +199,6 @@ sealed class ContinueWatchingStatus {
      * 继续看
      */
     data class Continue(
-        val episodeIndex: Int,
         val episodeEp: EpisodeSort?,
         val episodeSort: EpisodeSort?, // "12.5"
         val watchedEpisodeEp: EpisodeSort?,
@@ -212,7 +209,6 @@ sealed class ContinueWatchingStatus {
      * 看到了, 但是下一集还没更新
      */
     data class Watched(
-        val episodeIndex: Int,
         val episodeEp: EpisodeSort?, // "12.5"
         val episodeSort: EpisodeSort?, // "24.5"
         /**
@@ -237,7 +233,6 @@ object TestSubjectProgressInfos {
     @Stable
     val ContinueWatching2 = SubjectProgressInfo(
         continueWatchingStatus = ContinueWatchingStatus.Continue(
-            episodeIndex = 1,
             episodeEp = EpisodeSort(2),
             episodeSort = EpisodeSort(2),
             watchedEpisodeEp = EpisodeSort(1),
@@ -248,7 +243,7 @@ object TestSubjectProgressInfos {
 
     @Stable
     val Watched2 = SubjectProgressInfo(
-        continueWatchingStatus = ContinueWatchingStatus.Watched(1, EpisodeSort(2), EpisodeSort(2), PackedDate.Invalid),
+        continueWatchingStatus = ContinueWatchingStatus.Watched(EpisodeSort(2), EpisodeSort(2), PackedDate.Invalid),
         nextEpisodeIdToPlay = null,
     )
 

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/subject/SubjectProgressInfoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/subject/SubjectProgressInfoTest.kt
@@ -33,7 +33,7 @@ class SubjectProgressInfoTest {
         id: Int = sort,
         episodeType: EpisodeType? = EpisodeType.MainStory, // 默认为主线剧集
     ): Episode = Episode(
-        id, type, episodeType, EpisodeSort(sort), EpisodeSort(sort),
+        id, type, EpisodeSort(sort, episodeType), EpisodeSort(sort, episodeType),
         airDate,
         isKnownCompleted,
     )
@@ -238,7 +238,7 @@ class SubjectProgressInfoTest {
                 ep(DONE, 0, isKnownCompleted = true), // 主线第0集
             ),
         ).run {
-            // 最后看的主线剧集应该是第1集（索引1），下一集应该是第2集（索引2）
+            // 最后看的主线剧集应该是第1集，下一集应该是第2集
             assertEquals(
                 ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
                 continueWatchingStatus,
@@ -247,20 +247,20 @@ class SubjectProgressInfoTest {
         }
     }
 
-    // 有 SP 且在最后
-    // https://bgm.tv/subject/43951
+    // 有 SP 且在最后并且已完成
+    // https://bgm.tv/subject/506677
     @Test
-    fun `episodes with sp`() {
+    fun `episodes with sp done`() {
         calculate(
             subjectStarted = true,
             episodes = listOf(
                 ep(DONE, 1, isKnownCompleted = true),  // 主线第1集
                 ep(WISH, 2, isKnownCompleted = true),  // 主线第2集，未看
                 ep(WISH, 3, isKnownCompleted = true),  // 主线第3集，未看
-                ep(WISH, 4, isKnownCompleted = true, episodeType = EpisodeType.SP),
+                ep(DONE, 4, isKnownCompleted = true, episodeType = EpisodeType.SP),
             ),
         ).run {
-            // 最后看的主线剧集应该是第1集（索引0），下一集应该是第2集（索引1）
+            // 最后看的主线剧集应该是第1集，下一集应该是第2集，应该排除掉 SP 干扰
             assertEquals(
                 ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
                 continueWatchingStatus,

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/subject/SubjectProgressInfoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/subject/SubjectProgressInfoTest.kt
@@ -110,7 +110,7 @@ class SubjectProgressInfoTest {
             ),
         ).run {
             assertEquals(
-                ContinueWatchingStatus.Watched(0, EpisodeSort(1), EpisodeSort(1), Invalid),
+                ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), Invalid),
                 continueWatchingStatus,
             )
             assertEquals(1, nextEpisodeIdToPlay)
@@ -127,7 +127,7 @@ class SubjectProgressInfoTest {
             ),
         ).run {
             assertEquals(
-                ContinueWatchingStatus.Watched(0, EpisodeSort(1), EpisodeSort(1), Invalid),
+                ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), Invalid),
                 continueWatchingStatus,
             )
             assertEquals(1, nextEpisodeIdToPlay)
@@ -172,7 +172,7 @@ class SubjectProgressInfoTest {
             ),
         ).run {
             assertEquals(
-                ContinueWatchingStatus.Watched(0, EpisodeSort(1), EpisodeSort(1), Invalid),
+                ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), Invalid),
                 continueWatchingStatus,
             )
             assertEquals(1, nextEpisodeIdToPlay)
@@ -208,7 +208,7 @@ class SubjectProgressInfoTest {
     }
 
     private fun continue2_1() =
-        ContinueWatchingStatus.Continue(1, EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1))
+        ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1))
 
     @Test
     fun `all ep done`() {
@@ -238,10 +238,9 @@ class SubjectProgressInfoTest {
                 ep(DONE, 0, isKnownCompleted = true), // 主线第0集
             ),
         ).run {
-            // 索引应该是排序后的列表的索引
             // 最后看的主线剧集应该是第1集（索引1），下一集应该是第2集（索引2）
             assertEquals(
-                ContinueWatchingStatus.Continue(2, EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
+                ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
                 continueWatchingStatus,
             )
             assertEquals(2, nextEpisodeIdToPlay)
@@ -263,7 +262,7 @@ class SubjectProgressInfoTest {
         ).run {
             // 最后看的主线剧集应该是第1集（索引0），下一集应该是第2集（索引1）
             assertEquals(
-                ContinueWatchingStatus.Continue(1, EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
+                ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
                 continueWatchingStatus,
             )
             assertEquals(2, nextEpisodeIdToPlay)

--- a/app/shared/src/commonTest/kotlin/ui/subject/collection/components/AiringProgressTests.kt
+++ b/app/shared/src/commonTest/kotlin/ui/subject/collection/components/AiringProgressTests.kt
@@ -93,9 +93,9 @@ class AiringProgressTests {
         val aug24 = PackedDate(2024, 8, 24)
         val sep30 = PackedDate(2024, 9, 30)
 
-        val watched2 = ContinueWatchingStatus.Watched(2 - 1, EpisodeSort(2), EpisodeSort(2), Invalid)
-        val watched22 = ContinueWatchingStatus.Watched(22 - 1, EpisodeSort(22 - 12), EpisodeSort(22), Invalid)
-        val watched1 = ContinueWatchingStatus.Watched(1 - 1, EpisodeSort(1), EpisodeSort(1), Invalid)
+        val watched2 = ContinueWatchingStatus.Watched(EpisodeSort(2), EpisodeSort(2), Invalid)
+        val watched22 = ContinueWatchingStatus.Watched(EpisodeSort(22 - 12), EpisodeSort(22), Invalid)
+        val watched1 = ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), Invalid)
         val done = Done
 
         add("未开播, 没有时间") {
@@ -180,7 +180,7 @@ class AiringProgressTests {
             }
         }
         add("连载到 1, 看过 2, 有 3 的开播时间") {
-            create(ON_AIR, 1, ep = ContinueWatchingStatus.Watched(2 - 1, EpisodeSort(2), EpisodeSort(2), aug24)).run {
+            create(ON_AIR, 1, ep = ContinueWatchingStatus.Watched(EpisodeSort(2), EpisodeSort(2), aug24)).run {
                 assertEquals("看过 02 · 预定全 12 话", airingLabel)
                 assertEquals(false, highlightProgress)
                 assertEquals("明天更新", buttonText)
@@ -190,7 +190,7 @@ class AiringProgressTests {
         add("连载到 2, 看过 1, 没有下集的开播时间") {
             create(
                 ON_AIR, 2,
-                ep = ContinueWatchingStatus.Watched(1 - 1, EpisodeSort(1), EpisodeSort(1), Invalid),
+                ep = ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), Invalid),
             ).run {
                 assertEquals("看过 01 · 预定全 12 话", airingLabel)
                 assertEquals(false, highlightProgress)
@@ -201,7 +201,7 @@ class AiringProgressTests {
         add("连载到 2, 看过 1, 有下集开播时间") {
             create(
                 ON_AIR, 2,
-                ep = ContinueWatchingStatus.Watched(1 - 1, EpisodeSort(1), EpisodeSort(1), aug24),
+                ep = ContinueWatchingStatus.Watched(EpisodeSort(1), EpisodeSort(1), aug24),
             ).run {
                 assertEquals("看过 01 · 预定全 12 话", airingLabel)
                 assertEquals(false, highlightProgress)
@@ -212,7 +212,7 @@ class AiringProgressTests {
         add("连载到 2, 看过 1, 可以看 2") {
             create(
                 ON_AIR, 2,
-                ep = ContinueWatchingStatus.Continue(2, EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
+                ep = ContinueWatchingStatus.Continue(EpisodeSort(2), EpisodeSort(2), EpisodeSort(1), EpisodeSort(1)),
             ).run {
                 assertEquals("连载至 02 · 预定全 12 话", airingLabel)
                 assertEquals(true, highlightProgress)
@@ -231,7 +231,7 @@ class AiringProgressTests {
         add("连载到 2, 看过 2, 有下集开播时间") {
             create(
                 ON_AIR, 2,
-                ep = ContinueWatchingStatus.Watched(2, EpisodeSort(2), EpisodeSort(2), aug24),
+                ep = ContinueWatchingStatus.Watched(EpisodeSort(2), EpisodeSort(2), aug24),
             ).run {
                 assertEquals("看过 02 · 预定全 12 话", airingLabel)
                 assertEquals(false, highlightProgress)
@@ -251,7 +251,6 @@ class AiringProgressTests {
             create(
                 COMPLETED, 12,
                 ep = ContinueWatchingStatus.Continue(
-                    2 - 1,
                     EpisodeSort(2),
                     EpisodeSort(2),
                     EpisodeSort(1),
@@ -306,7 +305,6 @@ class AiringProgressTests {
             create(
                 ON_AIR, 23,
                 ep = ContinueWatchingStatus.Continue(
-                    episodeIndex = 23 - 1,
                     episodeEp = EpisodeSort(23 - 12),
                     episodeSort = EpisodeSort(23),
                     watchedEpisodeEp = EpisodeSort(22 - 12),

--- a/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/details/components/SubjectDetailsHeader.android.kt
+++ b/app/shared/ui-subject/src/androidMain/kotlin/ui/subject/details/components/SubjectDetailsHeader.android.kt
@@ -76,7 +76,6 @@ fun PreviewSubjectDetailsHeaderOnAirWatched() {
         ),
         progressInfo = SubjectProgressInfo(
             continueWatchingStatus = ContinueWatchingStatus.Watched(
-                0,
                 episodeEp = EpisodeSort(20 - 12),
                 episodeSort = EpisodeSort(20),
                 PackedDate.Invalid,
@@ -98,7 +97,6 @@ fun PreviewSubjectDetailsHeaderOnAirContinue() {
         ),
         progressInfo = SubjectProgressInfo(
             continueWatchingStatus = ContinueWatchingStatus.Continue(
-                episodeIndex = 0,
                 episodeEp = EpisodeSort(20 - 12),
                 episodeSort = EpisodeSort(20),
                 watchedEpisodeEp = EpisodeSort(19 - 12),


### PR DESCRIPTION
进度应该仅考虑普通剧集，并且按 sort 排序。

fixed #1871 #2485