### PR TITLE
fix(player): Use only vertical window insets for danmaku padding.

### DIFF
--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -132,7 +132,7 @@ fun VideoScaffold(
                     .matchParentSize()
                     .fillMaxWidth()
                     .padding(vertical = 8.dp)
-                    .windowInsetsPadding(contentWindowInsets),
+                    .windowInsetsPadding(contentWindowInsets.only(WindowInsetsSides.Vertical)),
             ) {
                 CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
                     danmakuHost()


### PR DESCRIPTION
Closes #2497 .