### PR TITLE
修复预计集数不正确的问题

### DIFF
--- a/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
@@ -24,7 +24,7 @@ class SubjectAiringInfoTest {
     private fun ep(
         sort: Int,
         airDate: PackedDate = PackedDate.Invalid,
-        type: EpisodeType = EpisodeType.MainStory, // Added type parameter
+        type: EpisodeType = EpisodeType.MainStory,
     ): EpisodeInfo = EpisodeInfo(
         episodeId = ++idCounter,
         type = type, // Use the new type parameter

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
@@ -24,9 +24,10 @@ class SubjectAiringInfoTest {
     private fun ep(
         sort: Int,
         airDate: PackedDate = PackedDate.Invalid,
+        type: EpisodeType = EpisodeType.MainStory, // Added type parameter
     ): EpisodeInfo = EpisodeInfo(
         episodeId = ++idCounter,
-        type = EpisodeType.MainStory,
+        type = type, // Use the new type parameter
         sort = EpisodeSort(sort),
         airDate = airDate,
     )
@@ -172,5 +173,22 @@ class SubjectAiringInfoTest {
         assertEquals(EpisodeSort(1), info.firstSort)
         assertEquals(EpisodeSort(1), info.latestSort)
         assertEquals(EpisodeSort(2), info.upcomingSort)
+    }
+
+    @Test
+    fun `on air with special episodes mixed in`() {
+        val eps = listOf(
+            ep(sort = 1, airDate = PackedDate(2023, 1, 8), type = EpisodeType.MainStory),     // Completed Main
+            ep(sort = 1, airDate = PackedDate(2023, 1, 10), type = EpisodeType.SP),    // Completed Special
+            ep(sort = 2, airDate = PackedDate(8888, 1, 15), type = EpisodeType.MainStory),  // Upcoming Main
+            ep(sort = 2, airDate = PackedDate(8888, 1, 20), type = EpisodeType.SP),    // Upcoming Special
+        )
+        val info = SubjectAiringInfo.computeFromEpisodeList(eps, PackedDate.Invalid, null)
+        assertEquals(SubjectAiringKind.ON_AIR, info.kind)
+        assertEquals(2, info.mainEpisodeCount) // Should only count main episodes
+        assertEquals(PackedDate(2023, 1, 8), info.airDate) // Air date of the first main episode
+        assertEquals(EpisodeSort(1), info.firstSort) // Sort of the first main episode
+        assertEquals(EpisodeSort(1), info.latestSort) // Sort of the last aired main episode
+        assertEquals(EpisodeSort(2), info.upcomingSort) // Sort of the first upcoming main episode
     }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/SubjectAiringInfoTest.kt
@@ -27,7 +27,7 @@ class SubjectAiringInfoTest {
         type: EpisodeType = EpisodeType.MainStory,
     ): EpisodeInfo = EpisodeInfo(
         episodeId = ++idCounter,
-        type = type, // Use the new type parameter
+        type = type,
         sort = EpisodeSort(sort),
         airDate = airDate,
     )


### PR DESCRIPTION
预计集数计算未过滤掉正片以外的剧集。

修复前：
<img width="808" height="366" alt="image" src="https://github.com/user-attachments/assets/70479e11-2609-4663-a160-3b4c72993d0d" />
修复后：
<img width="846" height="346" alt="image" src="https://github.com/user-attachments/assets/fba49928-4b1a-4299-9295-aa4c631d5f26" />
