### PR TITLE
[codex] fix JCEF browser lifecycle cleanup

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -443,6 +443,7 @@ object AniDesktop {
             val exitApplicationSavingWindowState = remember(saveCurrentWindowState) {
                 {
                     saveCurrentWindowState()
+                    AniCefApp.disposeBlocking()
                     exitApplication()
                 }
             }
@@ -454,7 +455,7 @@ object AniDesktop {
             }
             MacOSQuitHandler(
                 saveCurrentWindowState = saveCurrentWindowState,
-                exitApplication = ::exitApplication,
+                exitApplication = exitApplicationSavingWindowState,
             )
 
             val uiSettings by settingsRepository.uiSettings.flow.collectAsState(UISettings.Default)

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -20,6 +20,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.preference.ProxyConfig
 import me.him188.ani.app.data.models.preference.VideoResolverSettings
@@ -109,19 +110,19 @@ class DesktopWebMediaResolver(
             }
 
             val webVideo = (
-                webCaptchaCoordinator.extractVideoResourceInSolvedSession(
-                    mediaSourceId = media.mediaSourceId,
-                    pageUrl = media.download.uri,
-                    timeoutMillis = resolverSettings.effectiveResourceExtractionTimeoutMillis,
-                    resourceMatcher = resourceMatcher,
-                ) ?: CefVideoExtractor(proxyProvider.proxy.first(), resolverSettings)
-                    .getVideoResourceUrl(
-                        this@DesktopWebMediaResolver.context,
-                        media.download.uri,
-                        webViewConfig,
+                    webCaptchaCoordinator.extractVideoResourceInSolvedSession(
+                        mediaSourceId = media.mediaSourceId,
+                        pageUrl = media.download.uri,
+                        timeoutMillis = resolverSettings.effectiveResourceExtractionTimeoutMillis,
                         resourceMatcher = resourceMatcher,
-                    )
-                )?.let {
+                    ) ?: CefVideoExtractor(proxyProvider.proxy.first(), resolverSettings)
+                        .getVideoResourceUrl(
+                            this@DesktopWebMediaResolver.context,
+                            media.download.uri,
+                            webViewConfig,
+                            resourceMatcher = resourceMatcher,
+                        )
+                    )?.let {
                     (match(it.url) as? WebVideoMatcher.MatchResult.Matched)?.video
                 } ?: throw MediaResolutionException(ResolutionFailures.NO_MATCHING_RESOURCE)
             return@withContext HttpStreamingMediaDataProvider(
@@ -208,7 +209,7 @@ class CefVideoExtractor(
                                             if (browser.url == url || lastUrl.value == url) return false // don't recurse
                                             logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
                                             lastUrl.value = url
-                                            val escapedUrl = json.encodeToString(kotlinx.serialization.builtins.serializer<String>(), url)
+                                            val escapedUrl = json.encodeToString(String.serializer(), url)
                                             AniCefApp.runOnCefContext {
                                                 browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
                                             }

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
@@ -208,8 +208,9 @@ class CefVideoExtractor(
                                             if (browser.url == url || lastUrl.value == url) return false // don't recurse
                                             logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
                                             lastUrl.value = url
+                                            val escapedUrl = json.encodeToString(kotlinx.serialization.builtins.serializer<String>(), url)
                                             AniCefApp.runOnCefContext {
-                                                browser.executeJavaScript("window.location.href='$url';", "", 1)
+                                                browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
                                             }
                                             return true
                                         }

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
@@ -16,6 +16,7 @@ import io.ktor.util.date.toJvmDate
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -148,121 +149,125 @@ class CefVideoExtractor(
         config: WebViewConfig,
         resourceMatcher: (String) -> Instruction
     ): WebResource? = withContext(Dispatchers.IO) {
-        val client = AniCefApp.suspendCoroutineOnCefContext {
-            AniCefApp.createClient()
-        } ?: kotlin.run {
-            logger.warn { "AniCefApp isn't initialized yet." }
-            return@withContext null
-        }
+        AniCefApp.withBrowserCreationPermit {
+            var client: org.cef.CefClient? = null
+            var browser: CefBrowser? = null
+            val deferred = CompletableDeferred<WebResource>()
 
-        val deferred = CompletableDeferred<WebResource>()
+            try {
+                val createdClient = AniCefApp.suspendCoroutineOnCefContext {
+                    AniCefApp.createClient()
+                } ?: kotlin.run {
+                    logger.warn { "AniCefApp isn't initialized yet." }
+                    return@withBrowserCreationPermit null
+                }
+                client = createdClient
 
-        val browser = AniCefApp.suspendCoroutineOnCefContext {
-            val lastUrl = object {
-                // broswer.url is not updated immediately, so we need to keep track of the current url.
-                var value: String? by atomic(null)
-            }
-            client.createBrowser(
-                pageUrl,
-                CefRendering.DEFAULT,
-                true,
-                CefRequestContext.createContext { _, _, _, _, _, _, _ ->
-                    object : CefResourceRequestHandlerAdapter() {
-                        override fun onBeforeResourceLoad(
-                            browser: CefBrowser?,
-                            frame: CefFrame?,
-                            request: CefRequest?
-                        ): Boolean {
-                            if (request != null && browser != null) {
-                                if (handleUrl(request, browser)) {
-                                    return true
-                                }
-                            }
-                            return super.onBeforeResourceLoad(browser, frame, request)
-                        }
-
-                        /**
-                         * @return `true` to intercept
-                         */
-                        private fun handleUrl(
-                            request: CefRequest,
-                            browser: CefBrowser
-                        ): Boolean = synchronized(this) {
-                            val url = request.url
-                            val matched = resourceMatcher(url)
-                            when (matched) {
-                                Instruction.Continue -> return false
-                                Instruction.FoundResource -> {
-                                    deferred.complete(WebResource(url))
-                                    logger.info { "Found video stream resource: $url" }
-                                    return true
-                                }
-
-                                Instruction.LoadPage -> {
-                                    if (browser.url == url || lastUrl.value == url) return false // don't recurse
-                                    logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
-                                    lastUrl.value = url
-                                    AniCefApp.runOnCefContext {
-                                        browser.executeJavaScript("window.location.href='$url';", "", 1)
-                                    }
-                                    return true
-                                }
-                            }
-                        }
+                val createdBrowser = AniCefApp.suspendCoroutineOnCefContext {
+                    val lastUrl = object {
+                        // browser.url is not updated immediately, so we need to keep track of the current url.
+                        var value: String? by atomic(null)
                     }
-                },
-            )
-        }
-        browser.setCloseAllowed() // browser should be allowed to close.
+                    createdClient.createBrowser(
+                        pageUrl,
+                        CefRendering.DEFAULT,
+                        true,
+                        CefRequestContext.createContext { _, _, _, _, _, _, _ ->
+                            object : CefResourceRequestHandlerAdapter() {
+                                override fun onBeforeResourceLoad(
+                                    browser: CefBrowser?,
+                                    frame: CefFrame?,
+                                    request: CefRequest?
+                                ): Boolean {
+                                    if (request != null && browser != null) {
+                                        if (handleUrl(request, browser)) {
+                                            return true
+                                        }
+                                    }
+                                    return super.onBeforeResourceLoad(browser, frame, request)
+                                }
 
-        try {
-            AniCefApp.runOnCefContext {
-                client.addDisplayHandler(
-                    object : CefDisplayHandlerAdapter() {
-                        override fun onConsoleMessage(
-                            browser: CefBrowser?,
-                            level: CefSettings.LogSeverity?,
-                            message: String?,
-                            source: String?,
-                            line: Int
-                        ): Boolean {
-                            logger.info { "CEF client console: ${message?.replace("\n", "\\n")} ($source:$line)" }
-                            return super.onConsoleMessage(browser, level, message, source, line)
-                        }
-                    },
-                )
+                                /**
+                                 * @return `true` to intercept
+                                 */
+                                private fun handleUrl(
+                                    request: CefRequest,
+                                    browser: CefBrowser
+                                ): Boolean = synchronized(this) {
+                                    val url = request.url
+                                    val matched = resourceMatcher(url)
+                                    when (matched) {
+                                        Instruction.Continue -> return false
+                                        Instruction.FoundResource -> {
+                                            deferred.complete(WebResource(url))
+                                            logger.info { "Found video stream resource: $url" }
+                                            return true
+                                        }
 
-                // set cookie
-                val cookieManager = CefCookieManager.getGlobalManager()
-                val url = Url(pageUrl)
-                for (cookie in config.cookies) {
-                    val ktorCookie = parseServerSetCookieHeader(cookie)
-                    cookieManager.setCookie(url.host, ktorCookie.toCefCookie())
+                                        Instruction.LoadPage -> {
+                                            if (browser.url == url || lastUrl.value == url) return false // don't recurse
+                                            logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
+                                            lastUrl.value = url
+                                            AniCefApp.runOnCefContext {
+                                                browser.executeJavaScript("window.location.href='$url';", "", 1)
+                                            }
+                                            return true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    )
+                }
+                browser = createdBrowser
+
+                AniCefApp.suspendCoroutineOnCefContext {
+                    createdBrowser.setCloseAllowed()
+                    createdClient.addDisplayHandler(
+                        object : CefDisplayHandlerAdapter() {
+                            override fun onConsoleMessage(
+                                browser: CefBrowser?,
+                                level: CefSettings.LogSeverity?,
+                                message: String?,
+                                source: String?,
+                                line: Int
+                            ): Boolean {
+                                logger.info { "CEF client console: ${message?.replace("\n", "\\n")} ($source:$line)" }
+                                return super.onConsoleMessage(browser, level, message, source, line)
+                            }
+                        },
+                    )
+
+                    // set cookie
+                    val cookieManager = CefCookieManager.getGlobalManager()
+                    val url = Url(pageUrl)
+                    for (cookie in config.cookies) {
+                        val ktorCookie = parseServerSetCookieHeader(cookie)
+                        cookieManager.setCookie(url.host, ktorCookie.toCefCookie())
+                    }
+
+                    logger.info { "Fetching $pageUrl" }
+                    // start browser immediately
+                    createdBrowser.createImmediately()
                 }
 
-                logger.info { "Fetching $pageUrl" }
-                // start browser immediately
-                browser.createImmediately()
+                withTimeoutOrNull(videoResolverSettings.effectiveResourceExtractionTimeoutMillis) {
+                    deferred.await()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.error(e) { "Failed to get video url." }
+                if (deferred.isActive) {
+                    deferred.cancel()
+                }
+                null
+            } finally {
+                withContext(NonCancellable) {
+                    AniCefApp.closeBrowserAndDisposeClient(browser, client)
+                }
+                logger.info { "CEF client is disposed." }
             }
-
-            withTimeoutOrNull(videoResolverSettings.effectiveResourceExtractionTimeoutMillis) {
-                deferred.await()
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            logger.error(e) { "Failed to get video url." }
-            if (deferred.isActive) {
-                deferred.cancel()
-            }
-            null
-        } finally {
-            // close browser and client asynchronously.
-            AniCefApp.runOnCefContext {
-                browser.close(true)
-                client.dispose()
-            }
-            logger.info { "CEF client is disposed." }
         }
     }
 }

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/mediasource/web/DesktopWebCaptchaCoordinator.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/mediasource/web/DesktopWebCaptchaCoordinator.kt
@@ -91,6 +91,7 @@ class DesktopWebCaptchaCoordinator(
     private val solvedResults = linkedMapOf<String, WebCaptchaSolveResult.Solved>()
     private val sessions = linkedMapOf<String, DesktopCaptchaSession>()
     private val solvedByMediaSource = linkedMapOf<String, SolvedSessionEntry>()
+    private val sessionLock = Any()
 
     override fun getSolvedCookies(
         mediaSourceId: String,
@@ -105,11 +106,14 @@ class DesktopWebCaptchaCoordinator(
         timeoutMillis: Long,
         resourceMatcher: (String) -> WebViewVideoExtractor.Instruction,
     ): WebResource? {
-        val selectedKey = findSolvedSessionKey(mediaSourceId, pageUrl) ?: return null
-        sessions[selectedKey]?.let { session ->
+        val selected = synchronized(sessionLock) {
+            val selectedKey = findSolvedSessionKeyLocked(mediaSourceId, pageUrl) ?: return null
+            sessions[selectedKey] to solvedResults.containsKey(selectedKey)
+        }
+        selected.first?.let { session ->
             return session.extractVideoResource(pageUrl, timeoutMillis, resourceMatcher)
         }
-        solvedResults[selectedKey] ?: return null
+        if (!selected.second) return null
         return withTemporarySession { session ->
             session.extractVideoResource(pageUrl, timeoutMillis, resourceMatcher)
         }
@@ -119,18 +123,21 @@ class DesktopWebCaptchaCoordinator(
         mediaSourceId: String,
         pageUrl: String,
     ): WebCaptchaLoadedPage? {
-        val selectedKey = findSolvedSessionKey(mediaSourceId, pageUrl) ?: return null
-        sessions[selectedKey]?.let { session ->
+        val selected = synchronized(sessionLock) {
+            val selectedKey = findSolvedSessionKeyLocked(mediaSourceId, pageUrl) ?: return null
+            sessions[selectedKey] to solvedResults.containsKey(selectedKey)
+        }
+        selected.first?.let { session ->
             return session.loadPage(pageUrl)
         }
-        solvedResults[selectedKey] ?: return null
+        if (!selected.second) return null
         return withTemporarySession { session ->
             session.loadPage(pageUrl)
         }
     }
 
     override suspend fun tryAutoSolve(request: WebCaptchaRequest): WebCaptchaSolveResult {
-        solvedResults[request.storageKey()]?.let {
+        synchronized(sessionLock) { solvedResults[request.storageKey()] }?.let {
             return it
         }
 
@@ -146,7 +153,7 @@ class DesktopWebCaptchaCoordinator(
     }
 
     override suspend fun solveInteractively(request: WebCaptchaRequest): WebCaptchaSolveResult {
-        solvedResults[request.storageKey()]?.let {
+        synchronized(sessionLock) { solvedResults[request.storageKey()] }?.let {
             return it
         }
 
@@ -201,29 +208,36 @@ class DesktopWebCaptchaCoordinator(
 
     override fun resetSolvedSession(mediaSourceId: String) {
         interactiveSolveState = interactiveSolveState?.takeUnless { it.request.mediaSourceId == mediaSourceId }
-        solvedByMediaSource.remove(mediaSourceId)
-        solvedResults.keys
-            .filter { it.startsWith("$mediaSourceId@") }
-            .toList()
-            .forEach { key ->
-                solvedResults.remove(key)
-                sessions.remove(key)?.cancel()
-            }
+        val sessionsToCancel = synchronized(sessionLock) {
+            solvedByMediaSource.remove(mediaSourceId)
+            solvedResults.keys
+                .filter { it.startsWith("$mediaSourceId@") }
+                .toList()
+                .mapNotNull { key ->
+                    solvedResults.remove(key)
+                    sessions.remove(key)
+                }
+        }
+        sessionsToCancel.forEach { it.cancel() }
     }
 
     override fun cancelAutoResolutionRequests() {
         val interactiveSession = interactiveSolveState?.session
-        val autoSessionKeys = sessions
-            .filterValues { it !== interactiveSession }
-            .keys
-            .toList()
-        autoSessionKeys.forEach { key ->
-            sessions.remove(key)?.cancel()
-            solvedResults.remove(key)
+        val sessionsToCancel = synchronized(sessionLock) {
+            val autoSessionKeys = sessions
+                .filterValues { it !== interactiveSession }
+                .keys
+                .toList()
+            val removedSessions = autoSessionKeys.mapNotNull { key ->
+                solvedResults.remove(key)
+                sessions.remove(key)
+            }
+            solvedByMediaSource.entries.removeAll { (_, entry) ->
+                entry.key in autoSessionKeys
+            }
+            removedSessions
         }
-        solvedByMediaSource.entries.removeAll { (_, entry) ->
-            entry.key in autoSessionKeys
-        }
+        sessionsToCancel.forEach { it.cancel() }
     }
 
     @Composable
@@ -312,9 +326,26 @@ class DesktopWebCaptchaCoordinator(
         return WebCaptchaSolveResult.StillBlocked(lastKind ?: request.kind)
     }
 
-    private fun getOrCreateSession(request: WebCaptchaRequest): DesktopCaptchaSession {
+    private suspend fun getOrCreateSession(request: WebCaptchaRequest): DesktopCaptchaSession {
         val key = request.storageKey()
-        return sessions.getOrPut(key) { createSession() }
+        synchronized(sessionLock) {
+            sessions[key]?.let { return it }
+        }
+
+        val newSession = createSession()
+        var duplicateSession: DesktopCaptchaSession? = null
+        val result = synchronized(sessionLock) {
+            val existing = sessions[key]
+            if (existing != null) {
+                duplicateSession = newSession
+                existing
+            } else {
+                sessions[key] = newSession
+                newSession
+            }
+        }
+        duplicateSession?.cancel()
+        return result
     }
 
     private fun rememberSolved(
@@ -324,9 +355,11 @@ class DesktopWebCaptchaCoordinator(
     ) {
         if (result is WebCaptchaSolveResult.Solved) {
             val key = request.storageKey()
-            sessions[key] = session
-            solvedResults[key] = result
-            solvedByMediaSource[request.mediaSourceId] = SolvedSessionEntry(key)
+            synchronized(sessionLock) {
+                sessions[key] = session
+                solvedResults[key] = result
+                solvedByMediaSource[request.mediaSourceId] = SolvedSessionEntry(key)
+            }
         }
     }
 
@@ -334,13 +367,16 @@ class DesktopWebCaptchaCoordinator(
         key: String,
         session: DesktopCaptchaSession,
     ) {
-        if (interactiveSolveState?.session === session) {
-            return
+        val shouldCancel = synchronized(sessionLock) {
+            if (interactiveSolveState?.session === session) {
+                return
+            }
+            if (sessions[key] === session) {
+                sessions.remove(key)
+            }
+            sessions.none { it.value === session }
         }
-        if (sessions[key] === session) {
-            sessions.remove(key)
-        }
-        if (sessions.none { it.value === session }) {
+        if (shouldCancel) {
             session.cancel()
         }
     }
@@ -360,11 +396,13 @@ class DesktopWebCaptchaCoordinator(
         mediaSourceId: String,
         pageUrl: String,
     ): WebCaptchaSolveResult.Solved? {
-        val selectedKey = findSolvedSessionKey(mediaSourceId, pageUrl) ?: return null
-        return solvedResults[selectedKey]
+        return synchronized(sessionLock) {
+            val selectedKey = findSolvedSessionKeyLocked(mediaSourceId, pageUrl) ?: return@synchronized null
+            solvedResults[selectedKey]
+        }
     }
 
-    private fun findSolvedSessionKey(
+    private fun findSolvedSessionKeyLocked(
         mediaSourceId: String,
         pageUrl: String,
     ): String? {
@@ -418,14 +456,27 @@ class DesktopWebCaptchaCoordinator(
         ).storageKey()
     }
 
-    private fun createSession(): DesktopCaptchaSession {
-        return runBlocking {
-            AniCefApp.suspendCoroutineOnCefContext {
-                val client = AniCefApp.createClient()
-                    ?: return@suspendCoroutineOnCefContext DesktopCaptchaSession(EmptyComponent)
+    private suspend fun createSession(): DesktopCaptchaSession {
+        var permit: AniCefApp.BrowserLifecyclePermit? = AniCefApp.acquireBrowserLifecyclePermit()
+        var client: CefClient? = null
+        var browser: CefBrowser? = null
+        var session: DesktopCaptchaSession? = null
+        try {
+            return AniCefApp.suspendCoroutineOnCefContext {
+                val createdClient = AniCefApp.createClient()
+                    ?: return@suspendCoroutineOnCefContext DesktopCaptchaSession(EmptyComponent).also {
+                        permit?.release()
+                        permit = null
+                    }
+                client = createdClient
 
-                val session = DesktopCaptchaSession(EmptyComponent)
-                client.addLoadHandler(
+                val createdSession = DesktopCaptchaSession(
+                    component = EmptyComponent,
+                    browserPermit = permit,
+                )
+                session = createdSession
+                permit = null
+                createdClient.addLoadHandler(
                     object : CefLoadHandlerAdapter() {
                         override fun onLoadingStateChange(
                             browser: CefBrowser?,
@@ -434,7 +485,7 @@ class DesktopWebCaptchaCoordinator(
                             canGoForward: Boolean,
                         ) {
                             if (browser == null) return
-                            session.updateLoadingState(isLoading)
+                            createdSession.updateLoadingState(isLoading)
                         }
 
                         override fun onLoadEnd(
@@ -443,11 +494,11 @@ class DesktopWebCaptchaCoordinator(
                             httpStatusCode: Int,
                         ) {
                             if (browser == null || frame?.isMain != true) return
-                            session.dispatchLoadedPage(browser)
+                            createdSession.dispatchLoadedPage(browser)
                         }
                     },
                 )
-                client.addRequestHandler(
+                createdClient.addRequestHandler(
                     object : CefRequestHandlerAdapter() {
                         override fun getResourceRequestHandler(
                             browser: CefBrowser?,
@@ -464,7 +515,7 @@ class DesktopWebCaptchaCoordinator(
                                     frame: CefFrame?,
                                     request: CefRequest?,
                                 ): Boolean {
-                                    if (browser != null && request != null && session.handleVideoRequest(
+                                    if (browser != null && request != null && createdSession.handleVideoRequest(
                                             browser,
                                             request,
                                         )
@@ -478,22 +529,28 @@ class DesktopWebCaptchaCoordinator(
                     },
                 )
 
-                val browser = client.createBrowser(
+                val createdBrowser = createdClient.createBrowser(
                     "about:blank",
                     CefRendering.DEFAULT,
                     true,
                     CefRequestContext.getGlobalContext(),
                 )
-                browser.setCloseAllowed()
-                browser.createImmediately()
-                session.attach(client, browser)
-                session
+                browser = createdBrowser
+                createdBrowser.setCloseAllowed()
+                createdBrowser.createImmediately()
+                createdSession.attach(createdClient, createdBrowser)
+                createdSession
             }
+        } catch (e: Throwable) {
+            AniCefApp.closeBrowserAndDisposeClientBlocking(browser, client)
+            session?.dispose() ?: permit?.release()
+            throw e
         }
     }
 
     private class DesktopCaptchaSession(
         var component: Component,
+        private var browserPermit: AniCefApp.BrowserLifecyclePermit? = null,
     ) {
         private data class VideoExtractionState(
             val deferred: CompletableDeferred<WebResource>,
@@ -772,9 +829,17 @@ class DesktopWebCaptchaCoordinator(
         }
 
         fun dispose() {
-            AniCefApp.runOnCefContext {
-                browser?.close(true)
-                client?.dispose()
+            val currentBrowser = browser
+            val currentClient = client
+            val currentBrowserPermit = browserPermit
+            browser = null
+            client = null
+            browserPermit = null
+            component = EmptyComponent
+            try {
+                AniCefApp.closeBrowserAndDisposeClientBlocking(currentBrowser, currentClient)
+            } finally {
+                currentBrowserPermit?.release()
             }
         }
 

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -13,7 +13,9 @@ import com.jetbrains.cef.JCefAppConfig
 import io.ktor.http.Url
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
 import me.him188.ani.utils.io.readLastNLines
 import me.him188.ani.utils.logging.error
@@ -37,7 +39,10 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.text.SimpleDateFormat
+import java.util.Collections
 import java.util.Date
+import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
 import kotlin.concurrent.thread
 import kotlin.coroutines.resume
@@ -55,6 +60,8 @@ object AniCefApp {
         private set
 
     private val lock = Mutex()
+    private val browserLifecycleSemaphore = Semaphore(2)
+    private val disposedApps = Collections.newSetFromMap(IdentityHashMap<CefApp, Boolean>())
 
     private var proxyServer: Url? = null
     private var proxyAuthUsername: String? = null
@@ -208,7 +215,7 @@ object AniCefApp {
 
             Runtime.getRuntime().addShutdownHook(
                 thread(start = false) {
-                    runOnCefContext { newApp.dispose() }
+                    disposeAppBlocking(newApp)
                 },
             )
 
@@ -220,7 +227,7 @@ object AniCefApp {
             logger.info { "Awaiting JCEF initialization." }
             suspendCancellableCoroutine<Unit> { cont ->
                 cefApp.onInitialization { state ->
-                    if (state == CefApp.CefAppState.INITIALIZED) {
+                    if (state == CefApp.CefAppState.INITIALIZED && cont.isActive) {
                         logger.info { "JCEF is initialized." }
                         cont.resume(Unit)
                     }
@@ -229,6 +236,8 @@ object AniCefApp {
         }.also { result ->
             if (result == null) {
                 // 长时间没加载好 JCEF, 可能是 CEF 内部出错了, 直接抛出异常并附带最新的 CEF 日志.
+                app = null
+                disposeAppBlocking(cefApp)
                 throw JCEFInitializationException(
                     "Failed to initialize JCEF, state: ${CefApp.getState()}, " +
                             "last cef logs: \n${getLatestCefLog().joinToString("\n")}",
@@ -280,6 +289,84 @@ object AniCefApp {
     fun createClient(): CefClient? {
         return app?.createClient()
             ?.apply { addRequestHandler(proxiedRequestHandler) }
+    }
+
+    suspend fun <T> withBrowserCreationPermit(block: suspend () -> T): T {
+        return browserLifecycleSemaphore.withPermit {
+            block()
+        }
+    }
+
+    suspend fun acquireBrowserLifecyclePermit(): BrowserLifecyclePermit {
+        browserLifecycleSemaphore.acquire()
+        return BrowserLifecyclePermit(browserLifecycleSemaphore)
+    }
+
+    class BrowserLifecyclePermit internal constructor(
+        private val semaphore: Semaphore,
+    ) {
+        private val released = AtomicBoolean(false)
+
+        fun release() {
+            if (released.compareAndSet(false, true)) {
+                semaphore.release()
+            }
+        }
+    }
+
+    suspend fun closeBrowserAndDisposeClient(
+        browser: CefBrowser?,
+        client: CefClient?,
+    ) {
+        suspendCoroutineOnCefContext {
+            closeBrowserAndDisposeClientNow(browser, client)
+        }
+    }
+
+    fun closeBrowserAndDisposeClientBlocking(
+        browser: CefBrowser?,
+        client: CefClient?,
+    ) {
+        blockOnCefContext {
+            closeBrowserAndDisposeClientNow(browser, client)
+        }
+    }
+
+    fun disposeBlocking() {
+        val currentApp = app ?: return
+        app = null
+        disposeAppBlocking(currentApp)
+    }
+
+    private fun disposeAppBlocking(target: CefApp) {
+        val shouldDispose = synchronized(disposedApps) {
+            disposedApps.add(target)
+        }
+        if (!shouldDispose) return
+
+        runCatching {
+            blockOnCefContext {
+                target.dispose()
+            }
+        }.onFailure {
+            logger.warn(it) { "Failed to dispose JCEF." }
+        }
+    }
+
+    private fun closeBrowserAndDisposeClientNow(
+        browser: CefBrowser?,
+        client: CefClient?,
+    ) {
+        runCatching {
+            browser?.close(true)
+        }.onFailure {
+            logger.warn(it) { "Failed to close CEF browser." }
+        }
+        runCatching {
+            client?.dispose()
+        }.onFailure {
+            logger.warn(it) { "Failed to dispose CEF client." }
+        }
     }
 
     /**

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -480,7 +480,7 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
     single<MeteredNetworkDetector> { createMeteredNetworkDetector(getContext()) }
     single<SubjectDetailsStateFactory> { DefaultSubjectDetailsStateFactory() }
 
-    single<TurnstileState> {
+    factory<TurnstileState> {
         CreateTurnstileState(
             buildString {
                 append(get<BangumiClient>().turnstileBaseUrl)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -1007,6 +1007,7 @@ class EpisodeViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        turnstileState.cancel()
         webCaptchaCoordinator.cancelAutoResolutionRequests()
         backgroundScope.launch(NonCancellable + CoroutineName("EpisodeViewModel#onCleared")) {
             fetchPlayState.onClose()

--- a/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
+++ b/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
@@ -38,6 +39,7 @@ class DesktopTurnstileState(
 ) : TurnstileState {
     private var client: CefClient? = null
     private var browser: CefBrowser? = null
+    private var browserPermit: AniCefApp.BrowserLifecyclePermit? = null
 
     var isDarkTheme: Boolean = false
 
@@ -49,12 +51,24 @@ class DesktopTurnstileState(
     }
 
     fun initializeBrowser(): Component = runBlocking {
-        AniCefApp.suspendCoroutineOnCefContext {
-            val newClient = AniCefApp.createClient()
-                ?: throw IllegalStateException("AniCefApp should be initialized.")
+        browser?.uiComponent?.let { return@runBlocking it }
 
-            client = newClient.apply { 
-                addLoadHandler(object : CefLoadHandlerAdapter() {
+        var createdPermit: AniCefApp.BrowserLifecyclePermit? = AniCefApp.acquireBrowserLifecyclePermit()
+        var createdClient: CefClient? = null
+        var createdBrowser: CefBrowser? = null
+        try {
+            AniCefApp.suspendCoroutineOnCefContext {
+                browser?.uiComponent?.let {
+                    createdPermit?.release()
+                    createdPermit = null
+                    return@suspendCoroutineOnCefContext it
+                }
+
+                val newClient = AniCefApp.createClient()
+                    ?: throw IllegalStateException("AniCefApp should be initialized.")
+                createdClient = newClient
+
+                newClient.addLoadHandler(object : CefLoadHandlerAdapter() {
                     override fun onLoadError(
                         browser: CefBrowser?,
                         frame: CefFrame?,
@@ -65,7 +79,7 @@ class DesktopTurnstileState(
                         if (frame?.isMain != true || errorCode == null) {
                             return super.onLoadError(browser, frame, errorCode, errorText, failedUrl)
                         }
-                        
+
                         if (errorCode in networkErrors) {
                             webErrorFlow.tryEmit(TurnstileState.Error.Network(errorCode.code))
                         } else {
@@ -74,43 +88,53 @@ class DesktopTurnstileState(
                         return super.onLoadError(browser, frame, errorCode, errorText, failedUrl)
                     }
                 })
-            }
 
-            val newBrowser = newClient.createBrowser(
-                concatUrl(),
-                CefRendering.DEFAULT,
-                true,
-                CefRequestContext.createContext { _, _, _, _, _, _, _ ->
-                    object : CefResourceRequestHandlerAdapter() {
-                        override fun onBeforeResourceLoad(
-                            browser: CefBrowser?,
-                            frame: CefFrame?,
-                            request: CefRequest?,
-                        ): Boolean {
-                            val requestUrl = request?.url
-                            if (requestUrl != null &&
-                                requestUrl.startsWith(TurnstileState.CALLBACK_INTERCEPTION_PREFIX)
-                            ) {
-                                val responseToken = TurnstileState.CALLBACK_REGEX
-                                    .matchEntire(requestUrl)?.groupValues?.getOrNull(1)
-                                if (responseToken != null) {
-                                    tokenFlow.tryEmit(
-                                        requestUrl.substringAfter(
-                                            TurnstileState.CALLBACK_INTERCEPTION_PREFIX,
-                                        ),
-                                    )
-                                    return true
+                val newBrowser = newClient.createBrowser(
+                    concatUrl(),
+                    CefRendering.DEFAULT,
+                    true,
+                    CefRequestContext.createContext { _, _, _, _, _, _, _ ->
+                        object : CefResourceRequestHandlerAdapter() {
+                            override fun onBeforeResourceLoad(
+                                browser: CefBrowser?,
+                                frame: CefFrame?,
+                                request: CefRequest?,
+                            ): Boolean {
+                                val requestUrl = request?.url
+                                if (requestUrl != null &&
+                                    requestUrl.startsWith(TurnstileState.CALLBACK_INTERCEPTION_PREFIX)
+                                ) {
+                                    val responseToken = TurnstileState.CALLBACK_REGEX
+                                        .matchEntire(requestUrl)?.groupValues?.getOrNull(1)
+                                    if (responseToken != null) {
+                                        tokenFlow.tryEmit(
+                                            requestUrl.substringAfter(
+                                                TurnstileState.CALLBACK_INTERCEPTION_PREFIX,
+                                            ),
+                                        )
+                                        return true
+                                    }
                                 }
+                                return super.onBeforeResourceLoad(browser, frame, request)
                             }
-                            return super.onBeforeResourceLoad(browser, frame, request)
                         }
-                    }
-                },
-            )
+                    },
+                )
 
-            browser = newBrowser
-            newBrowser.setCloseAllowed()
-            newBrowser.uiComponent.apply { }
+                createdBrowser = newBrowser
+                newBrowser.setCloseAllowed()
+                val component = newBrowser.uiComponent
+                client = newClient
+                browser = newBrowser
+                browserPermit = createdPermit
+                createdPermit = null
+                component
+            }
+        } catch (e: Throwable) {
+            AniCefApp.closeBrowserAndDisposeClientBlocking(createdBrowser, createdClient)
+            throw e
+        } finally {
+            createdPermit?.release()
         }
     }
 
@@ -121,11 +145,16 @@ class DesktopTurnstileState(
     }
 
     override fun cancel() {
-        AniCefApp.blockOnCefContext {
-            browser?.close(true)
-            client?.dispose()
-            client = null
-            browser = null
+        val currentBrowser = browser
+        val currentClient = client
+        val currentBrowserPermit = browserPermit
+        browser = null
+        client = null
+        browserPermit = null
+        try {
+            AniCefApp.closeBrowserAndDisposeClientBlocking(currentBrowser, currentClient)
+        } finally {
+            currentBrowserPermit?.release()
         }
     }
     
@@ -154,6 +183,12 @@ actual fun ActualTurnstile(
 ) {
     check(state is DesktopTurnstileState)
     val isDark = isSystemInDarkTheme()
+
+    DisposableEffect(state) {
+        onDispose {
+            state.cancel()
+        }
+    }
 
     SwingPanel(
         background = Color.Transparent,

--- a/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
+++ b/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
@@ -107,11 +107,7 @@ class DesktopTurnstileState(
                                     val responseToken = TurnstileState.CALLBACK_REGEX
                                         .matchEntire(requestUrl)?.groupValues?.getOrNull(1)
                                     if (responseToken != null) {
-                                        tokenFlow.tryEmit(
-                                            requestUrl.substringAfter(
-                                                TurnstileState.CALLBACK_INTERCEPTION_PREFIX,
-                                            ),
-                                        )
+                                        tokenFlow.tryEmit(responseToken)
                                         return true
                                     }
                                 }


### PR DESCRIPTION
## Summary
- centralize JCEF browser/client cleanup and add a lifecycle permit for active browsers
- close video-extraction, captcha-session, and Turnstile browsers on timeout, cancellation, failure, UI disposal, and app exit
- make desktop Turnstile state per-consumer instead of a singleton to avoid retaining shared JCEF state

## Why
Windows desktop users can hit freezes when automatic datasource captcha handling creates too many JCEF browser/helper processes or leaves them alive after cancellation. The fix limits active browser lifetimes and makes every JCEF creation path release its browser/client deterministically.

## Validation
- `./gradlew.bat :app:desktop:compileKotlin --console=plain --no-daemon`
- `./gradlew.bat :app:shared:app-data:desktopTest --console=plain --no-daemon`
- launched `:app:desktop:run`, confirmed the Ani window starts with JCEF helper processes, then closed the app and confirmed no `java`/`jcef_helper` processes remained
- `git diff --check` passed with only Windows LF/CRLF warnings