### PR TITLE
[codex] Respect preferred web source before fast select

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -210,7 +210,7 @@ interface MediaSelector {
      * 注意, 调用此方法时将从 [preferredCandidates] 和 [filteredCandidates] 当前的 snapshot 中选择,
      * 如果在选的过程中这些 flow 有更新, 则不会影响此次选择. 所以这个函数会很快返回结果.
      * 
-     * 如果希望始终从最新的数据中选择, 使用 [selectFromMediaSources].
+     * 如果希望始终从最新的数据中选择, 使用 [awaitSelectFromMediaSources].
      *
      * @param candidateSources 候选数据源, 只会从这些里选.
      * @param overrideUserSelection 是否覆盖用户选择.
@@ -234,7 +234,7 @@ interface MediaSelector {
      * 
      * @see trySelectFromMediaSources
      */
-    suspend fun selectFromMediaSources(
+    suspend fun awaitSelectFromMediaSources(
         candidateSources: List<String>,
         overrideUserSelection: Boolean = false,
         blacklistMediaIds: Set<String> = emptySet(),
@@ -489,8 +489,19 @@ class DefaultMediaSelector(
         selected.value = null
     }
 
-    private fun selectDefault(candidate: Media): Media? {
+    private suspend fun selectDefault(candidate: Media): Media? {
+        if (selected.value != null) return null
+
+        val event = SelectEvent(
+            media = candidate,
+            subtitleLanguageId = null,
+            previousMedia = null,
+        )
+        events.onBeforeSelect.emit(event)
+
         if (!selected.compareAndSet(null, candidate)) return null
+        events.onSelect.emit(event)
+
         // 自动选择时不更新 preference
         return candidate
     }
@@ -757,7 +768,7 @@ class DefaultMediaSelector(
         }
     }
 
-    override suspend fun selectFromMediaSources(
+    override suspend fun awaitSelectFromMediaSources(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelect.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelect.kt
@@ -137,7 +137,7 @@ class MediaSelectorAutoSelect(
                     // 例如: 第一个源查询好了, 但是两条结果都被排除了, 这里就会挂起.
                     // 第二个查询好了, 有满足条件的结果, 那第一次选择就被取消, 第二次就会成功.
                     // 成功后结果给 select builder, select 就会返回, 这个就是最终结果.
-                    mediaSelector.selectFromMediaSources(
+                    mediaSelector.awaitSelectFromMediaSources(
                         candidateResults.map { it.mediaSourceId },
                         overrideUserSelection = overrideUserSelection,
                         blacklistMediaIds = blacklistMediaIds,
@@ -171,9 +171,9 @@ class MediaSelectorAutoSelect(
     }
 
     /**
-     * 快速选择之前用户手选的源, 没选到就一直挂起
+     * 从用户偏好的 web 数据源快速选择媒体, 如果没有则返回 null
      */
-    suspend fun selectPreferredWebSource(
+    suspend fun trySelectPreferredWebSource(
         mediaFetchSession: MediaFetchSession,
         preferredWebMediaSourceId: String?,
     ): Media? {
@@ -184,12 +184,11 @@ class MediaSelectorAutoSelect(
             .firstOrNull { it.mediaSourceId == preferredWebMediaSourceId && it.kind == MediaSourceKind.WEB }
             ?.awaitCompletion()
 
-        // 尝试选择, 没有就一直挂起
-        return mediaSelector.selectFromMediaSources(
+        return mediaSelector.trySelectFromMediaSources(
             listOf(preferredWebMediaSourceId),
             overrideUserSelection = false,
             blacklistMediaIds = emptySet(),
-            allowNonPreferred = true,
+            allowNonPreferred = false, // 只从这一个源里选
         )
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCase.kt
@@ -72,7 +72,12 @@ class MediaSelectorAutoSelectUseCaseImpl(
                     // 快速选择不和这些竞争, 快速选择在这个 clause 完成之后再启动
                     resulting {
                         // subjectId 无效就等别的 clause.
-                        val subjectId = session.request.first().subjectId.toIntOrNull() ?: awaitCancellation()
+                        val subjectId = session.request.first().subjectId.toIntOrNull()
+                        if (subjectId == null) {
+                            selectPreferredFailed.complete(Unit)
+                            awaitCancellation()
+                        }
+
                         val result = autoSelector.trySelectPreferredWebSource(
                             session, getPreferredWebMediaSource(subjectId).first(),
                         )

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCase.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCase.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.domain.media.selector
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
@@ -59,33 +60,30 @@ class MediaSelectorAutoSelectUseCaseImpl(
                 }
             }
 
-            /**
-             * 为什么可以让 fast select 和 preferred select 一起跑?
-             * 
-             * 如果是热门资源, 通常不需要用户自己设置 web source preference, fast select 很快立刻就可以选好.
-             * 对于冷门资源, fast select 很大概率在 tolerance 时间内也选不到合适的, 但这时 preferred select 可能在这之内选好.
-             * 
-             * 所以一起跑, 不是 fast select 先选好, 就是 preferred 先选好, 总之能尽快选出一个合适的.
-             * 无论是 preferred select 或者 fast select 的结果, 对于用户来说都是比较优质的.
-             * 
-             * 如果 preferred 刚好也是 fast select 的一个结果也无所谓, 哪个 clause 快跑那个, 结果都是一样的.
-             */
             cancellableCoroutineScope {
                 fun <T> SelectBuilder<T>.resulting(block: suspend CoroutineScope.() -> T) {
                     this@cancellableCoroutineScope.async { block() }.onAwait { it }
                 }
 
                 select {
-                    // 选择用户偏好的源
+                    val selectPreferredFailed = CompletableDeferred<Unit>()
+
+                    // 这个 clause 和下面 选缓存 与 兜底 一起竞争
+                    // 快速选择不和这些竞争, 快速选择在这个 clause 完成之后再启动
                     resulting {
                         // subjectId 无效就等别的 clause.
                         val subjectId = session.request.first().subjectId.toIntOrNull() ?: awaitCancellation()
-                        val result = autoSelector.selectPreferredWebSource(
+                        val result = autoSelector.trySelectPreferredWebSource(
                             session, getPreferredWebMediaSource(subjectId).first(),
                         )
 
                         logger.info { "selectPreferredWebSource result: $result" }
-                        result ?: awaitCancellation()
+
+                        if (result == null) {
+                            selectPreferredFailed.complete(Unit)
+                            awaitCancellation()
+                        }
+                        result
                     }
 
                     // 快速自动选择数据源: 当按规则快速选择相应 Tier 的数据源. 仅在偏好 Web 时并且启用了快速选择时才执行.
@@ -95,6 +93,9 @@ class MediaSelectorAutoSelectUseCaseImpl(
                             // 没开启 fast select 就等别的 clause.
                             awaitCancellation()
                         }
+
+                        // 上面选完并且没结果再开始这个 clause
+                        selectPreferredFailed.await()
 
                         val result = autoSelector.fastSelectWebSources(
                             session,

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCaseTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorAutoSelectUseCaseTest.kt
@@ -1,0 +1,376 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.selector
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import me.him188.ani.app.data.models.preference.MediaPreference
+import me.him188.ani.app.data.models.preference.MediaSelectorSettings
+import me.him188.ani.app.domain.media.fetch.MediaFetchSession
+import me.him188.ani.app.domain.media.selector.testFramework.FetchMediaSelectorTestSuite
+import me.him188.ani.app.domain.media.selector.testFramework.Handle
+import me.him188.ani.app.domain.media.selector.testFramework.MediaSelectorTestSuite
+import me.him188.ani.app.domain.media.selector.testFramework.runFetchMediaSelectorTestSuite
+import me.him188.ani.app.domain.media.selector.testFramework.tier
+import me.him188.ani.app.domain.mediasource.GetMediaSelectorSourceTiersUseCase
+import me.him188.ani.app.domain.mediasource.GetPreferredWebMediaSourceUseCase
+import me.him188.ani.app.domain.settings.GetMediaSelectorSettingsFlowUseCase
+import me.him188.ani.datasources.api.Media
+import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.datasources.api.source.MediaSourceKind.BitTorrent
+import me.him188.ani.datasources.api.source.MediaSourceKind.LocalCache
+import me.him188.ani.datasources.api.source.MediaSourceKind.WEB
+import me.him188.ani.test.DisabledOnNative
+import org.koin.core.Koin
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@DisabledOnNative // TODO: ContextParameters crashes on Native
+class MediaSelectorAutoSelectUseCaseTest {
+    private val preferredWebMediaSource = MutableStateFlow<String?>(null)
+
+    @Test
+    fun `preferred web source blocks fast select until preferred source completes`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 0 }
+                val web2 by web { tier = 2 }
+            }
+        }
+        preferredWebMediaSource.value = "web2"
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.web2.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web2)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `fast select starts after preferred source completes with no media`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 0 }
+                val web2 by web { tier = 2 }
+            }
+        }
+        preferredWebMediaSource.value = "web2"
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.web2.complete(emptyList<Media>())
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `fast select starts immediately when preferred source is unset`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 0 }
+            }
+        }
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `fast select starts immediately when preferred source is not in session`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 0 }
+            }
+        }
+        preferredWebMediaSource.value = "missing"
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `preferred source obeys current source preference before fast select falls back to non preferred`() =
+        runFetchMediaSelectorTestSuite {
+            initSubject()
+            preferenceApi.savedUserPreference.value = MediaPreference.Any.copy(mediaSourceId = "web1")
+            preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+            val (_, session, sources) = configureFetchSession {
+                object {
+                    val web1 by web { tier = 0 }
+                    val web2 by web { tier = 2 }
+                }
+            }
+            preferredWebMediaSource.value = "web2"
+
+            val job = launchAutoSelect(session)
+            sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+            sources.web2.complete(media(kind = WEB, subjectName = initApi.subjectName))
+            testScope().runCurrent()
+
+            assertSelectedSource(sources.web1)
+            job.assertCompleted()
+        }
+
+    @Test
+    fun `fast select timeout starts only after preferred source fails`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings(lowTierToleranceDuration = 1.seconds)
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 2 }
+                val web2 by web { tier = 0 }
+                val web3 by web { tier = 2 }
+            }
+        }
+        preferredWebMediaSource.value = "web2"
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().advanceTimeBy(1.seconds)
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.web2.complete(emptyList<Media>())
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        testScope().advanceTimeBy(1.seconds)
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `local cache can win while preferred web source is still pending`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings()
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val cached by localCache()
+                val web1 by web { tier = 0 }
+            }
+        }
+        preferredWebMediaSource.value = "web1"
+
+        val job = launchAutoSelect(session)
+        sources.cached.complete(media(kind = LocalCache, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.cached)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `fallback default waits for preferred kind when fast select is disabled`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings(fastSelectWebKind = false)
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web { tier = 0 }
+                val web2 by web { tier = 2 }
+            }
+        }
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.web2.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `fast select is skipped when preferred kind is not web`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings(preferKind = BitTorrent)
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val bt1 by bt()
+                val web1 by web { tier = 0 }
+            }
+        }
+
+        val job = launchAutoSelect(session)
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.bt1.complete(media(kind = BitTorrent, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.bt1)
+        job.assertCompleted()
+    }
+
+    @Test
+    fun `auto enables last selected disabled source`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        preferenceApi.savedUserPreference.value = MediaPreference.Any.copy(mediaSourceId = "web1")
+        preferenceApi.mediaSelectorSettings.value = autoSelectSettings(
+            autoEnableLastSelected = true,
+            fastSelectWebKind = false,
+        )
+
+        val (_, session, sources) = configureFetchSession {
+            object {
+                val web1 by web(enabled = false)
+                val web2 by web()
+            }
+        }
+
+        val job = launchAutoSelect(session)
+        testScope().runCurrent()
+
+        sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertNull(selector.selected.value)
+        assertFalse(job.isCompleted)
+
+        sources.web2.complete(media(kind = WEB, subjectName = initApi.subjectName))
+        testScope().runCurrent()
+
+        assertSelectedSource(sources.web1)
+        job.assertCompleted()
+    }
+
+    context(scope: TestScope)
+    private fun FetchMediaSelectorTestSuite.launchAutoSelect(session: MediaFetchSession): Job {
+        val useCase = MediaSelectorAutoSelectUseCaseImpl(createKoin())
+        return scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            useCase(session, selector)
+        }
+    }
+
+    private fun FetchMediaSelectorTestSuite.createKoin(): Koin {
+        return Koin().apply {
+            loadModules(
+                listOf(
+                    module {
+                        single<GetMediaSelectorSettingsFlowUseCase> {
+                            GetMediaSelectorSettingsFlowUseCase { preferenceApi.mediaSelectorSettings }
+                        }
+                        single<GetMediaSelectorSourceTiersUseCase> {
+                            GetMediaSelectorSourceTiersUseCase {
+                                preferenceApi.mediaSelectorContext.map {
+                                    it.mediaSourceTiers ?: MediaSelectorSourceTiers.Empty
+                                }
+                            }
+                        }
+                        single<GetPreferredWebMediaSourceUseCase> {
+                            GetPreferredWebMediaSourceUseCase { preferredWebMediaSource }
+                        }
+                    },
+                ),
+            )
+        }
+    }
+
+    private fun FetchMediaSelectorTestSuite.assertSelectedSource(source: Handle) {
+        assertEquals(source.instance.mediaSourceId, selector.selected.value?.mediaSourceId)
+    }
+
+    private fun Job.assertCompleted() {
+        assertTrue(isCompleted, "Auto select job should have completed")
+    }
+
+    private fun autoSelectSettings(
+        preferKind: MediaSourceKind? = WEB,
+        fastSelectWebKind: Boolean = true,
+        autoEnableLastSelected: Boolean = false,
+        lowTierToleranceDuration: Duration = 5.seconds,
+    ): MediaSelectorSettings = MediaSelectorSettings.AllVisible.copy(
+        autoEnableLastSelected = autoEnableLastSelected,
+        fastSelectWebKind = fastSelectWebKind,
+        preferKind = preferKind,
+        fastSelectWebLowTierToleranceDuration = lowTierToleranceDuration,
+        hideSingleEpisodeForCompleted = false,
+        preferSeasons = false,
+    )
+
+    private fun MediaSelectorTestSuite.initSubject() {
+        initSubject("test")
+    }
+
+    context(scope: TestScope)
+    private fun testScope(): TestScope = implicit()
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/legacy/DefaultMediaSelectorTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/legacy/DefaultMediaSelectorTest.kt
@@ -1464,7 +1464,72 @@ class DefaultMediaSelectorTest : AbstractDefaultMediaSelectorTest() {
         }
     }
 
+    @Test
+    fun `event trySelectDefault`() = runTest {
+        savedUserPreference.value = MediaPreference.Companion.Empty
+        savedDefaultPreference.value = MediaPreference.Companion.Empty
+        val target = media(alliance = "字幕组", subtitleLanguages = listOf("CHS"))
+        addMedia(target)
+
+        runCollectEvents {
+            assertEquals(target, selector.trySelectDefault())
+        }.run {
+            val expectedEvent = SelectEvent(
+                media = target,
+                subtitleLanguageId = null,
+                previousMedia = null,
+            )
+
+            assertEquals(listOf(expectedEvent), onBeforeSelect)
+            assertEquals(listOf(expectedEvent), onSelect)
+            assertEquals(0, onChangePreference.size)
+        }
+    }
+
+    @Test
+    fun `event trySelectCached`() = runTest {
+        savedUserPreference.value = MediaPreference.Companion.Empty
+        savedDefaultPreference.value = MediaPreference.Companion.Empty
+        val target = media(
+            alliance = "字幕组",
+            subtitleLanguages = listOf("CHS"),
+            kind = MediaSourceKind.LocalCache,
+        )
+        addMedia(target)
+
+        runCollectEvents {
+            assertEquals(target, selector.trySelectCached())
+        }.run {
+            val expectedEvent = SelectEvent(
+                media = target,
+                subtitleLanguageId = null,
+                previousMedia = null,
+            )
+
+            assertEquals(listOf(expectedEvent), onBeforeSelect)
+            assertEquals(listOf(expectedEvent), onSelect)
+            assertEquals(0, onChangePreference.size)
+        }
+    }
+
+    @Test
+    fun `event trySelectDefault does not emit when already selected`() = runTest {
+        val current = media(alliance = "字幕组1", subtitleLanguages = listOf("CHS"))
+        val target = media(alliance = "字幕组2", subtitleLanguages = listOf("CHT"))
+        addMedia(current, target)
+        selector.select(current)
+
+        runCollectEvents {
+            assertEquals(null, selector.trySelectDefault())
+        }.run {
+            assertEquals(0, onBeforeSelect.size)
+            assertEquals(0, onSelect.size)
+            assertEquals(0, onChangePreference.size)
+        }
+    }
+
     class CollectedEvents(
+        val onBeforeSelect: MutableList<SelectEvent> = mutableListOf(),
         val onSelect: MutableList<SelectEvent> = mutableListOf(),
         val onChangePreference: MutableList<MediaPreference> = mutableListOf(),
     )
@@ -1472,6 +1537,11 @@ class DefaultMediaSelectorTest : AbstractDefaultMediaSelectorTest() {
     private suspend fun runCollectEvents(block: suspend () -> Unit): CollectedEvents {
         return CollectedEvents().apply {
             cancellableCoroutineScope {
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    selector.events.onBeforeSelect.collect {
+                        onBeforeSelect.add(it)
+                    }
+                }
                 launch(start = CoroutineStart.UNDISPATCHED) {
                     selector.events.onSelect.collect {
                         onSelect.add(it)

--- a/app/shared/src/desktopTest/kotlin/data/TestMediaSelector.kt
+++ b/app/shared/src/desktopTest/kotlin/data/TestMediaSelector.kt
@@ -120,7 +120,7 @@ open class TestMediaSelector(
         throw UnsupportedOperationException()
     }
 
-    override suspend fun selectFromMediaSources(
+    override suspend fun awaitSelectFromMediaSources(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,


### PR DESCRIPTION
## Summary
- wait for the user's preferred web media source before allowing web fast-select to run
- make default media selection emit `onBeforeSelect` and `onSelect` events consistently
- add direct unit coverage for `MediaSelectorAutoSelectUseCase`, including preferred web source, fast select, cache, fallback, and auto-enable paths

## Why
When a user has a preferred web source, fast-select could otherwise pick another source before that preferred source finishes. The use case now lets cache and fallback continue to compete, but gates fast-select until preferred-source selection has either succeeded or failed.

Default selection also updates the selected state, so it now broadcasts selection events like explicit selection paths.

## Validation
- `./gradlew.bat :app:shared:app-data:desktopTest --tests "me.him188.ani.app.domain.media.selector.MediaSelectorAutoSelectUseCaseTest" --tests "me.him188.ani.app.domain.media.selector.legacy.DefaultMediaSelectorTest"`