### PR TITLE
[codex] fix Android WebView captcha threading

### DIFF
--- a/app/shared/app-data/src/androidDeviceTest/kotlin/domain/mediasource/web/AndroidWebCaptchaSessionReuseE2eTest.kt
+++ b/app/shared/app-data/src/androidDeviceTest/kotlin/domain/mediasource/web/AndroidWebCaptchaSessionReuseE2eTest.kt
@@ -341,4 +341,36 @@ class AndroidWebCaptchaSessionReuseE2eTest {
             assertTrue(site.streamRequests.isNotEmpty())
         }
     }
+
+    @Test
+    fun `video extraction can load nested page from intercepted subresource`() = runBlocking {
+        LocalCaptchaSite().use { site ->
+            val mediaSourceId = "e2e-loadpage-subresource"
+            val coordinator = AndroidWebCaptchaCoordinator(context)
+            val solved = coordinator.tryAutoSolve(
+                WebCaptchaRequest(
+                    mediaSourceId = mediaSourceId,
+                    pageUrl = site.searchUrl("Test Subject"),
+                    kind = WebCaptchaKind.Cloudflare,
+                ),
+            )
+            assertIs<WebCaptchaSolveResult.Solved>(solved)
+
+            val extracted = coordinator.extractVideoResourceInSolvedSession(
+                mediaSourceId = mediaSourceId,
+                pageUrl = site.embedTriggerUrl(),
+                timeoutMillis = 5_000,
+            ) { url ->
+                when {
+                    url == site.embedUrl() -> WebViewVideoExtractor.Instruction.LoadPage
+                    url.endsWith("/stream/1.m3u8") -> WebViewVideoExtractor.Instruction.FoundResource
+                    else -> WebViewVideoExtractor.Instruction.Continue
+                }
+            }
+
+            assertEquals("${site.baseUrl}/stream/1.m3u8", extracted?.url)
+            assertTrue(site.embedRequests.isNotEmpty())
+            assertTrue(site.streamRequests.isNotEmpty())
+        }
+    }
 }

--- a/app/shared/app-data/src/androidDeviceTest/kotlin/domain/mediasource/web/DummyCaptchaSelectorFixtures.kt
+++ b/app/shared/app-data/src/androidDeviceTest/kotlin/domain/mediasource/web/DummyCaptchaSelectorFixtures.kt
@@ -186,6 +186,10 @@ internal class LocalCaptchaSite(
 
     fun subjectUrl(): String = "$baseUrl/subject/1"
 
+    fun embedUrl(): String = "$baseUrl/embed/1"
+
+    fun embedTriggerUrl(): String = "$baseUrl/embed-trigger"
+
     override fun close() {
         running.set(false)
         runCatching { serverSocket.close() }
@@ -253,6 +257,10 @@ internal class LocalCaptchaSite(
             path == "/embed/1" -> {
                 embedRequests += SiteRequest(path, hasClearanceCookie)
                 respond(socket, okEmbedPage())
+            }
+
+            path == "/embed-trigger" -> {
+                respond(socket, okEmbedTriggerPage())
             }
 
             path == "/stream/1.m3u8" -> {
@@ -409,6 +417,18 @@ internal class LocalCaptchaSite(
             <html>
               <body>
                 <div class="missing-gate">$reason</div>
+              </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun okEmbedTriggerPage(): String {
+        return """
+            <html>
+              <body>
+                <script>
+                  fetch("$baseUrl/embed/1").catch(function(){});
+                </script>
               </body>
             </html>
         """.trimIndent()

--- a/app/shared/app-data/src/androidMain/kotlin/domain/mediasource/web/AndroidWebCaptchaCoordinator.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/mediasource/web/AndroidWebCaptchaCoordinator.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.domain.mediasource.web
 
 import android.annotation.SuppressLint
+import android.graphics.Bitmap
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebResourceError
@@ -385,12 +386,26 @@ class AndroidWebCaptchaCoordinator(
 
         private var pendingLoad by mutableStateOf<CompletableDeferred<WebCaptchaLoadedPage>?>(null)
         private val pageObservers = linkedMapOf<Int, (WebCaptchaLoadedPage) -> Unit>()
+        @Volatile
         private var videoExtractionState: VideoExtractionState? = null
+
+        @Volatile
+        private var currentPageUrl: String? = null
 
         init {
             configure(webView)
             webView.webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                    if (!url.isNullOrEmpty()) {
+                        currentPageUrl = url
+                    }
+                    super.onPageStarted(view, url, favicon)
+                }
+
                 override fun onPageFinished(view: WebView, url: String?) {
+                    if (!url.isNullOrEmpty()) {
+                        currentPageUrl = url
+                    }
                     dispatchCurrentPage(view)
                 }
 
@@ -402,7 +417,7 @@ class AndroidWebCaptchaCoordinator(
                     if (request?.isForMainFrame == true && pendingLoad?.isActive == true) {
                         pendingLoad?.complete(
                             WebCaptchaLoadedPage(
-                                finalUrl = view?.url ?: request.url.toString(),
+                                finalUrl = currentPageUrl ?: request.url.toString(),
                                 html = "",
                             ),
                         )
@@ -414,7 +429,7 @@ class AndroidWebCaptchaCoordinator(
                     request: WebResourceRequest,
                 ): WebResourceResponse? {
                     val url = request.url?.toString() ?: return super.shouldInterceptRequest(view, request)
-                    if (handleVideoResource(view, url)) {
+                    if (handleVideoResource(url)) {
                         return WebResourceResponse(
                             "text/plain",
                             "UTF-8",
@@ -428,7 +443,7 @@ class AndroidWebCaptchaCoordinator(
                 }
 
                 override fun onLoadResource(view: WebView, url: String) {
-                    handleVideoResource(view, url)
+                    handleVideoResource(url)
                     super.onLoadResource(view, url)
                 }
             }
@@ -451,6 +466,7 @@ class AndroidWebCaptchaCoordinator(
             val initialPage = withContext(Dispatchers.Main) {
                 val deferred = CompletableDeferred<WebCaptchaLoadedPage>()
                 pendingLoad = deferred
+                currentPageUrl = pageUrl
                 webView.loadUrl(pageUrl)
                 try {
                     withTimeoutOrNull(timeoutMillis.coerceAtMost(5_000)) {
@@ -466,11 +482,13 @@ class AndroidWebCaptchaCoordinator(
         }
 
         suspend fun loadUrl(pageUrl: String) = withContext(Dispatchers.Main) {
+            currentPageUrl = pageUrl
             webView.loadUrl(pageUrl)
         }
 
         suspend fun snapshotCurrentPage(): WebCaptchaLoadedPage? = withContext(Dispatchers.Main) {
             val currentUrl = webView.url ?: return@withContext null
+            currentPageUrl = currentUrl
             val deferred = CompletableDeferred<WebCaptchaLoadedPage>()
             webView.evaluateJavascript(
                 "(function(){var d=document.documentElement; return d ? d.outerHTML : '';})()",
@@ -500,6 +518,7 @@ class AndroidWebCaptchaCoordinator(
             )
             videoExtractionState = state
             try {
+                currentPageUrl = pageUrl
                 webView.loadUrl(pageUrl)
                 withTimeoutOrNull(timeoutMillis) {
                     deferred.await()
@@ -544,12 +563,13 @@ class AndroidWebCaptchaCoordinator(
         }
 
         private fun dispatchCurrentPage(webView: WebView) {
-            if (webView.url.isNullOrEmpty()) return
+            val currentUrl = webView.url?.takeIf { it.isNotEmpty() } ?: return
+            currentPageUrl = currentUrl
             webView.evaluateJavascript(
                 "(function(){var d=document.documentElement; return d ? d.outerHTML : '';})()",
             ) { rawHtml ->
                 val page = WebCaptchaLoadedPage(
-                    finalUrl = webView.url.orEmpty(),
+                    finalUrl = currentUrl,
                     html = decodeJavascriptString(rawHtml),
                 )
                 pendingLoad?.takeIf { it.isActive }?.complete(page)
@@ -565,7 +585,6 @@ class AndroidWebCaptchaCoordinator(
         }
 
         private fun handleVideoResource(
-            webView: WebView,
             url: String,
         ): Boolean {
             val state = videoExtractionState ?: return false
@@ -577,14 +596,15 @@ class AndroidWebCaptchaCoordinator(
                 }
 
                 WebViewVideoExtractor.Instruction.LoadPage -> {
-                    if (webView.url == url) {
+                    if (currentPageUrl == url) {
                         return false
                     }
                     if (!state.loadedNestedUrls.add(url)) {
                         return false
                     }
                     webView.post {
-                        if (state.deferred.isActive) {
+                        if (state.deferred.isActive && currentPageUrl != url) {
+                            currentPageUrl = url
                             webView.loadUrl(url)
                         }
                     }


### PR DESCRIPTION
## Summary
- Avoid calling Android WebView APIs from `shouldInterceptRequest` background threads in captcha video extraction.
- Track the current page URL in `AndroidCaptchaSession` and keep nested `loadUrl` navigation posted back to the WebView thread.
- Add an android device-test fixture path that exercises `shouldInterceptRequest -> LoadPage` before finding the video resource.

## Root Cause
`shouldInterceptRequest` can run on a WebView background thread. The captcha session's `LoadPage` branch read `webView.url`, which calls `WebView.getUrl()` and trips WebView's same-thread check when the callback is not on the main/WebView thread.

## Validation
- `./gradlew.bat :app:shared:app-data:compileAndroidDeviceTest` passed.
- `git diff --check` passed before commit.
- `connectedAndroidDeviceTest` was attempted but did not reach test execution because existing device-test bytecode fails D8 on test class names with spaces before DEX 040, e.g. `DualSourceEpisodeCommentPagingSourceTest$append advances...`.