### PR TITLE
[codex] Limit browser concurrency to data source queries

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -269,9 +269,9 @@ object AniDesktop {
 
         coroutineScope.launch {
             settingsRepository.videoResolverSettings.flow
-                .map { it.effectiveBrowserConcurrency }
+                .map { it.effectiveDataSourceBrowserConcurrency }
                 .distinctUntilChanged()
-                .collect { AniCefApp.configureBrowserLifecycleLimit(it) }
+                .collect { AniCefApp.configureDataSourceBrowserLimit(it) }
         }
 
         val setLocaleJob = coroutineScope.launch {

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoResolverSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoResolverSettings.kt
@@ -20,7 +20,7 @@ data class VideoResolverSettings(
     val driver: WebViewDriver = WebViewDriver.AUTO,
     val headless: Boolean = true,
     val resourceExtractionTimeoutSeconds: Int = DEFAULT_RESOURCE_EXTRACTION_TIMEOUT_SECONDS,
-    val browserConcurrency: Int = DEFAULT_BROWSER_CONCURRENCY,
+    val dataSourceBrowserConcurrency: Int = DEFAULT_DATA_SOURCE_BROWSER_CONCURRENCY,
 
     @Suppress("PropertyName")
     @Transient val _placeholder: Int = 0,
@@ -35,18 +35,18 @@ data class VideoResolverSettings(
     val effectiveResourceExtractionTimeoutMillis: Long
         get() = effectiveResourceExtractionTimeoutSeconds * 1_000L
 
-    val effectiveBrowserConcurrency: Int
-        get() = if (browserConcurrency in BrowserConcurrencyOptions) {
-            browserConcurrency
+    val effectiveDataSourceBrowserConcurrency: Int
+        get() = if (dataSourceBrowserConcurrency in DataSourceBrowserConcurrencyOptions) {
+            dataSourceBrowserConcurrency
         } else {
-            DEFAULT_BROWSER_CONCURRENCY
+            DEFAULT_DATA_SOURCE_BROWSER_CONCURRENCY
         }
 
     companion object {
         const val DEFAULT_RESOURCE_EXTRACTION_TIMEOUT_SECONDS = 8
         val ResourceExtractionTimeoutSecondsOptions = listOf(3, 5, 8, 10, 15, 20, 30)
-        const val DEFAULT_BROWSER_CONCURRENCY = 8
-        val BrowserConcurrencyOptions = listOf(1, 2, 4, 8, 12, 16, 24, 32)
+        const val DEFAULT_DATA_SOURCE_BROWSER_CONCURRENCY = 8
+        val DataSourceBrowserConcurrencyOptions = listOf(1, 2, 4, 8, 12, 16, 24, 32)
 
         val Default = VideoResolverSettings()
     }

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
@@ -150,126 +150,124 @@ class CefVideoExtractor(
         config: WebViewConfig,
         resourceMatcher: (String) -> Instruction
     ): WebResource? = withContext(Dispatchers.IO) {
-        AniCefApp.withBrowserCreationPermit {
-            var client: org.cef.CefClient? = null
-            var browser: CefBrowser? = null
-            val deferred = CompletableDeferred<WebResource>()
+        var client: org.cef.CefClient? = null
+        var browser: CefBrowser? = null
+        val deferred = CompletableDeferred<WebResource>()
 
-            try {
-                val createdClient = AniCefApp.suspendCoroutineOnCefContext {
-                    AniCefApp.createClient()
-                } ?: kotlin.run {
-                    logger.warn { "AniCefApp isn't initialized yet." }
-                    return@withBrowserCreationPermit null
-                }
-                client = createdClient
-
-                val createdBrowser = AniCefApp.suspendCoroutineOnCefContext {
-                    val lastUrl = object {
-                        // browser.url is not updated immediately, so we need to keep track of the current url.
-                        var value: String? by atomic(null)
-                    }
-                    createdClient.createBrowser(
-                        pageUrl,
-                        CefRendering.DEFAULT,
-                        true,
-                        CefRequestContext.createContext { _, _, _, _, _, _, _ ->
-                            object : CefResourceRequestHandlerAdapter() {
-                                override fun onBeforeResourceLoad(
-                                    browser: CefBrowser?,
-                                    frame: CefFrame?,
-                                    request: CefRequest?
-                                ): Boolean {
-                                    if (request != null && browser != null) {
-                                        if (handleUrl(request, browser)) {
-                                            return true
-                                        }
-                                    }
-                                    return super.onBeforeResourceLoad(browser, frame, request)
-                                }
-
-                                /**
-                                 * @return `true` to intercept
-                                 */
-                                private fun handleUrl(
-                                    request: CefRequest,
-                                    browser: CefBrowser
-                                ): Boolean = synchronized(this) {
-                                    val url = request.url
-                                    val matched = resourceMatcher(url)
-                                    when (matched) {
-                                        Instruction.Continue -> return false
-                                        Instruction.FoundResource -> {
-                                            deferred.complete(WebResource(url))
-                                            logger.info { "Found video stream resource: $url" }
-                                            return true
-                                        }
-
-                                        Instruction.LoadPage -> {
-                                            if (browser.url == url || lastUrl.value == url) return false // don't recurse
-                                            logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
-                                            lastUrl.value = url
-                                            val escapedUrl = json.encodeToString(String.serializer(), url)
-                                            AniCefApp.runOnCefContext {
-                                                browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
-                                            }
-                                            return true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                    )
-                }
-                browser = createdBrowser
-
-                AniCefApp.suspendCoroutineOnCefContext {
-                    createdBrowser.setCloseAllowed()
-                    createdClient.addDisplayHandler(
-                        object : CefDisplayHandlerAdapter() {
-                            override fun onConsoleMessage(
-                                browser: CefBrowser?,
-                                level: CefSettings.LogSeverity?,
-                                message: String?,
-                                source: String?,
-                                line: Int
-                            ): Boolean {
-                                logger.info { "CEF client console: ${message?.replace("\n", "\\n")} ($source:$line)" }
-                                return super.onConsoleMessage(browser, level, message, source, line)
-                            }
-                        },
-                    )
-
-                    // set cookie
-                    val cookieManager = CefCookieManager.getGlobalManager()
-                    val url = Url(pageUrl)
-                    for (cookie in config.cookies) {
-                        val ktorCookie = parseServerSetCookieHeader(cookie)
-                        cookieManager.setCookie(url.host, ktorCookie.toCefCookie())
-                    }
-
-                    logger.info { "Fetching $pageUrl" }
-                    // start browser immediately
-                    createdBrowser.createImmediately()
-                }
-
-                withTimeoutOrNull(videoResolverSettings.effectiveResourceExtractionTimeoutMillis) {
-                    deferred.await()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                logger.error(e) { "Failed to get video url." }
-                if (deferred.isActive) {
-                    deferred.cancel()
-                }
-                null
-            } finally {
-                withContext(NonCancellable) {
-                    AniCefApp.closeBrowserAndDisposeClient(browser, client)
-                }
-                logger.info { "CEF client is disposed." }
+        try {
+            val createdClient = AniCefApp.suspendCoroutineOnCefContext {
+                AniCefApp.createClient()
+            } ?: kotlin.run {
+                logger.warn { "AniCefApp isn't initialized yet." }
+                return@withContext null
             }
+            client = createdClient
+
+            val createdBrowser = AniCefApp.suspendCoroutineOnCefContext {
+                val lastUrl = object {
+                    // browser.url is not updated immediately, so we need to keep track of the current url.
+                    var value: String? by atomic(null)
+                }
+                createdClient.createBrowser(
+                    pageUrl,
+                    CefRendering.DEFAULT,
+                    true,
+                    CefRequestContext.createContext { _, _, _, _, _, _, _ ->
+                        object : CefResourceRequestHandlerAdapter() {
+                            override fun onBeforeResourceLoad(
+                                browser: CefBrowser?,
+                                frame: CefFrame?,
+                                request: CefRequest?
+                            ): Boolean {
+                                if (request != null && browser != null) {
+                                    if (handleUrl(request, browser)) {
+                                        return true
+                                    }
+                                }
+                                return super.onBeforeResourceLoad(browser, frame, request)
+                            }
+
+                            /**
+                             * @return `true` to intercept
+                             */
+                            private fun handleUrl(
+                                request: CefRequest,
+                                browser: CefBrowser
+                            ): Boolean = synchronized(this) {
+                                val url = request.url
+                                val matched = resourceMatcher(url)
+                                when (matched) {
+                                    Instruction.Continue -> return false
+                                    Instruction.FoundResource -> {
+                                        deferred.complete(WebResource(url))
+                                        logger.info { "Found video stream resource: $url" }
+                                        return true
+                                    }
+
+                                    Instruction.LoadPage -> {
+                                        if (browser.url == url || lastUrl.value == url) return false // don't recurse
+                                        logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
+                                        lastUrl.value = url
+                                        val escapedUrl = json.encodeToString(String.serializer(), url)
+                                        AniCefApp.runOnCefContext {
+                                            browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
+                                        }
+                                        return true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+            }
+            browser = createdBrowser
+
+            AniCefApp.suspendCoroutineOnCefContext {
+                createdBrowser.setCloseAllowed()
+                createdClient.addDisplayHandler(
+                    object : CefDisplayHandlerAdapter() {
+                        override fun onConsoleMessage(
+                            browser: CefBrowser?,
+                            level: CefSettings.LogSeverity?,
+                            message: String?,
+                            source: String?,
+                            line: Int
+                        ): Boolean {
+                            logger.info { "CEF client console: ${message?.replace("\n", "\\n")} ($source:$line)" }
+                            return super.onConsoleMessage(browser, level, message, source, line)
+                        }
+                    },
+                )
+
+                // set cookie
+                val cookieManager = CefCookieManager.getGlobalManager()
+                val url = Url(pageUrl)
+                for (cookie in config.cookies) {
+                    val ktorCookie = parseServerSetCookieHeader(cookie)
+                    cookieManager.setCookie(url.host, ktorCookie.toCefCookie())
+                }
+
+                logger.info { "Fetching $pageUrl" }
+                // start browser immediately
+                createdBrowser.createImmediately()
+            }
+
+            withTimeoutOrNull(videoResolverSettings.effectiveResourceExtractionTimeoutMillis) {
+                deferred.await()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.error(e) { "Failed to get video url." }
+            if (deferred.isActive) {
+                deferred.cancel()
+            }
+            null
+        } finally {
+            withContext(NonCancellable) {
+                AniCefApp.closeBrowserAndDisposeClient(browser, client)
+            }
+            logger.info { "CEF client is disposed." }
         }
     }
 }

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/mediasource/web/DesktopWebCaptchaCoordinator.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/mediasource/web/DesktopWebCaptchaCoordinator.kt
@@ -457,7 +457,7 @@ class DesktopWebCaptchaCoordinator(
     }
 
     private suspend fun createSession(): DesktopCaptchaSession {
-        var permit: AniCefApp.BrowserLifecyclePermit? = AniCefApp.acquireBrowserLifecyclePermit()
+        var permit: AniCefApp.BrowserLifecyclePermit? = AniCefApp.acquireDataSourceBrowserPermit()
         var client: CefClient? = null
         var browser: CefBrowser? = null
         var session: DesktopCaptchaSession? = null

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -60,8 +60,8 @@ object AniCefApp {
         private set
 
     private val lock = Mutex()
-    private const val DEFAULT_BROWSER_LIFECYCLE_LIMIT = 8
-    private val browserLifecycleGate = BrowserLifecycleGate(DEFAULT_BROWSER_LIFECYCLE_LIMIT)
+    private const val DEFAULT_DATA_SOURCE_BROWSER_LIMIT = 8
+    private val dataSourceBrowserGate = DataSourceBrowserGate(DEFAULT_DATA_SOURCE_BROWSER_LIMIT)
     private val disposedApps = Collections.newSetFromMap(IdentityHashMap<CefApp, Boolean>())
 
     private var proxyServer: Url? = null
@@ -292,21 +292,12 @@ object AniCefApp {
             ?.apply { addRequestHandler(proxiedRequestHandler) }
     }
 
-    fun configureBrowserLifecycleLimit(limit: Int) {
-        browserLifecycleGate.configureLimit(limit)
+    fun configureDataSourceBrowserLimit(limit: Int) {
+        dataSourceBrowserGate.configureLimit(limit)
     }
 
-    suspend fun <T> withBrowserCreationPermit(block: suspend () -> T): T {
-        val permit = acquireBrowserLifecyclePermit()
-        return try {
-            block()
-        } finally {
-            permit.release()
-        }
-    }
-
-    suspend fun acquireBrowserLifecyclePermit(): BrowserLifecyclePermit {
-        return browserLifecycleGate.acquire()
+    suspend fun acquireDataSourceBrowserPermit(): BrowserLifecyclePermit {
+        return dataSourceBrowserGate.acquire()
     }
 
     class BrowserLifecyclePermit internal constructor(
@@ -418,7 +409,7 @@ object AniCefApp {
 private class JCEFInitializationException(message: String, cause: Throwable? = null) :
     RuntimeException(message, cause)
 
-private class BrowserLifecycleGate(initialLimit: Int) {
+private class DataSourceBrowserGate(initialLimit: Int) {
     private val lock = ReentrantLock()
     private val waiters = ArrayDeque<CompletableDeferred<Unit>>()
     private var limit = initialLimit.coerceAtLeast(1)

--- a/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
+++ b/app/shared/ui-comment/src/desktopMain/kotlin/ui/comment/Turnstile.desktop.kt
@@ -39,7 +39,6 @@ class DesktopTurnstileState(
 ) : TurnstileState {
     private var client: CefClient? = null
     private var browser: CefBrowser? = null
-    private var browserPermit: AniCefApp.BrowserLifecyclePermit? = null
 
     var isDarkTheme: Boolean = false
 
@@ -53,16 +52,11 @@ class DesktopTurnstileState(
     fun initializeBrowser(): Component = runBlocking {
         browser?.uiComponent?.let { return@runBlocking it }
 
-        var createdPermit: AniCefApp.BrowserLifecyclePermit? = AniCefApp.acquireBrowserLifecyclePermit()
         var createdClient: CefClient? = null
         var createdBrowser: CefBrowser? = null
         try {
             AniCefApp.suspendCoroutineOnCefContext {
-                browser?.uiComponent?.let {
-                    createdPermit?.release()
-                    createdPermit = null
-                    return@suspendCoroutineOnCefContext it
-                }
+                browser?.uiComponent?.let { return@suspendCoroutineOnCefContext it }
 
                 val newClient = AniCefApp.createClient()
                     ?: throw IllegalStateException("AniCefApp should be initialized.")
@@ -122,15 +116,11 @@ class DesktopTurnstileState(
                 val component = newBrowser.uiComponent
                 client = newClient
                 browser = newBrowser
-                browserPermit = createdPermit
-                createdPermit = null
                 component
             }
         } catch (e: Throwable) {
             AniCefApp.closeBrowserAndDisposeClientBlocking(createdBrowser, createdClient)
             throw e
-        } finally {
-            createdPermit?.release()
         }
     }
 
@@ -143,15 +133,9 @@ class DesktopTurnstileState(
     override fun cancel() {
         val currentBrowser = browser
         val currentClient = client
-        val currentBrowserPermit = browserPermit
         browser = null
         client = null
-        browserPermit = null
-        try {
-            AniCefApp.closeBrowserAndDisposeClientBlocking(currentBrowser, currentClient)
-        } finally {
-            currentBrowserPermit?.release()
-        }
+        AniCefApp.closeBrowserAndDisposeClientBlocking(currentBrowser, currentClient)
     }
     
     private companion object {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/VideoResolverGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/VideoResolverGroup.kt
@@ -53,18 +53,18 @@ internal fun SettingsScope.VideoResolverGroup(
             description = { Text("播放部分视频源时需要使用无头浏览器引擎，请在电脑上安装 Chrome 或 Edge 浏览器，Safari 不支持") },
         )
         DropdownItem(
-            selected = { config.effectiveBrowserConcurrency },
-            values = { VideoResolverSettings.BrowserConcurrencyOptions },
+            selected = { config.effectiveDataSourceBrowserConcurrency },
+            values = { VideoResolverSettings.DataSourceBrowserConcurrencyOptions },
             itemText = { Text("$it 个") },
             onSelect = {
                 videoResolverSettingsState.update(
                     config.copy(
-                        browserConcurrency = it,
+                        dataSourceBrowserConcurrency = it,
                     ),
                 )
             },
-            title = { Text("同时打开浏览器数") },
-            description = { Text("限制视频解析、验证码和评论验证可同时使用的浏览器数量") },
+            title = { Text("数据源查询浏览器数") },
+            description = { Text("限制数据源查询阶段可同时使用的浏览器数量，例如验证码处理") },
         )
     }
 }


### PR DESCRIPTION
## Summary

- Narrow the configurable CEF browser concurrency limit to data source query browser sessions.
- Remove that limit from playback-time video URL extraction and comment Turnstile browser creation.
- Rename the setting/API and settings UI copy to make the scope explicit.

## Why

The previous browser concurrency setting was applied too broadly. It limited video link resolution and comment verification, but the intended limit is only for data source query work such as captcha handling.

## Validation

- `./gradlew :app:desktop:compileKotlin`