### PR TITLE
feat(hls): 引入实验性 HLS 贴片广告过滤

### DIFF
--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -32,6 +32,8 @@ import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.engine.TorrentMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.PlatformHlsPlaybackPreparer
 import me.him188.ani.app.domain.media.resolver.AndroidWebMediaResolver
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
 import me.him188.ani.app.domain.media.resolver.LocalFileMediaResolver
@@ -96,6 +98,7 @@ fun getAndroidModules(
     }
     single<BrowserNavigator> { AndroidBrowserNavigator() }
     single<WebCaptchaCoordinator> { AndroidWebCaptchaCoordinator(androidContext()) }
+    single<HlsPlaybackPreparer> { PlatformHlsPlaybackPreparer(get()) }
 
     single<TorrentEngineAccess> { serviceConnectionManager }
     single<TorrentServiceConnection<IRemoteAniTorrentEngine>> { serviceConnectionManager.connection }

--- a/app/desktop/src/main/kotlin/DesktopModules.kt
+++ b/app/desktop/src/main/kotlin/DesktopModules.kt
@@ -29,6 +29,8 @@ import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.PlatformHlsPlaybackPreparer
 import me.him188.ani.app.domain.media.resolver.DesktopWebMediaResolver
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
 import me.him188.ani.app.domain.media.resolver.LocalFileMediaResolver
@@ -133,6 +135,7 @@ fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) =
     }
     single<BrowserNavigator> { DesktopBrowserNavigator() }
     single<WebCaptchaCoordinator> { DesktopWebCaptchaCoordinator(AniDesktopCaptchaTopBar) }
+    single<HlsPlaybackPreparer> { PlatformHlsPlaybackPreparer(get()) }
     single<OfflineDownloadEngine> {
         val settings = get<SettingsRepository>()
         val configState = settings.pikpakConfig.flow

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
@@ -72,6 +72,12 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
      */
     val autoSwitchMediaOnPlayerError: Boolean = true,
     /**
+     * 过滤 HLS 播放列表中的插播片段.
+     *
+     * @since 5.7
+     */
+    val enableExperimentalHlsSegmentFiltering: Boolean = false,
+    /**
      * 用于在安卓上设置屏幕刷新率, 解决某些设备会自动限制刷新率的问题 (三星).
      *
      * 0 为不设置 (使用系统默认).
@@ -111,6 +117,7 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
             autoPlayNext = false,
             autoSkipOpEd = false,
             autoSwitchMediaOnPlayerError = false,
+            enableExperimentalHlsSegmentFiltering = false,
         )
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/EpisodeFetchSelectPlayState.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/EpisodeFetchSelectPlayState.kt
@@ -176,9 +176,7 @@ class EpisodeFetchSelectPlayState(
 
                     // 4. 停止播放器, 清空播放器状态.
                     logger.info { "SwitchEpisode($episodeId): Stopping player" }
-                    withContext(mainDispatcher) {
-                        player.stopPlayback()
-                    }
+                    playerSession.stopPlayback()
 
                     // 5. 创建新的 fetchSelectSession
                     logger.info { "SwitchEpisode($episodeId): Propagate newEpisodeSession" }
@@ -225,6 +223,7 @@ class EpisodeFetchSelectPlayState(
      */
     suspend fun onClose() {
         extensionManager.call { it.onClose() }
+        playerSession.stopPlayback()
     }
 
     /**

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
 import me.him188.ani.app.domain.media.hls.HlsPlaybackProxySession
-import me.him188.ani.app.domain.media.hls.NoopHlsPlaybackPreparer
 import me.him188.ani.app.domain.media.fetch.MediaFetchSession
 import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
 import me.him188.ani.app.domain.media.resolver.MediaResolutionException
@@ -61,10 +60,8 @@ class PlayerSession(
     private val mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
 ) {
     val mediaResolver: MediaResolver by koin.inject()
-    private val hlsPlaybackPreparer: HlsPlaybackPreparer =
-        runCatching { koin.get<HlsPlaybackPreparer>() }.getOrDefault(NoopHlsPlaybackPreparer)
-    private val getVideoScaffoldConfigUseCase: GetVideoScaffoldConfigUseCase? =
-        runCatching { koin.get<GetVideoScaffoldConfigUseCase>() }.getOrNull()
+    private val hlsPlaybackPreparer: HlsPlaybackPreparer by koin.inject()
+    private val getVideoScaffoldConfigUseCase: GetVideoScaffoldConfigUseCase by koin.inject()
 
     private var hlsPlaybackProxySession: HlsPlaybackProxySession? = null
 
@@ -178,10 +175,9 @@ class PlayerSession(
             return PreparedMediaData(data)
         }
         val enabled = getVideoScaffoldConfigUseCase
-            ?.invoke()
-            ?.first()
-            ?.enableExperimentalHlsSegmentFiltering
-            ?: false
+            .invoke()
+            .first()
+            .enableExperimentalHlsSegmentFiltering
         if (!enabled) {
             return PreparedMediaData(data)
         }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
@@ -12,10 +12,14 @@ package me.him188.ani.app.domain.episode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.HlsPlaybackProxySession
+import me.him188.ani.app.domain.media.hls.NoopHlsPlaybackPreparer
 import me.him188.ani.app.domain.media.fetch.MediaFetchSession
 import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
 import me.him188.ani.app.domain.media.resolver.MediaResolutionException
@@ -27,6 +31,7 @@ import me.him188.ani.app.domain.media.resolver.TorrentBackedMediaDataProvider
 import me.him188.ani.app.domain.media.resolver.UnsupportedMediaException
 import me.him188.ani.app.domain.media.selector.MediaSelector
 import me.him188.ani.app.domain.player.VideoLoadingState
+import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.utils.logging.error
@@ -35,6 +40,8 @@ import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.logging.warn
 import org.koin.core.Koin
 import org.openani.mediamp.MediampPlayer
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.UriMediaData
 import kotlin.coroutines.CoroutineContext
 
 class MediaFetchSelectBundle(
@@ -54,6 +61,12 @@ class PlayerSession(
     private val mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
 ) {
     val mediaResolver: MediaResolver by koin.inject()
+    private val hlsPlaybackPreparer: HlsPlaybackPreparer =
+        runCatching { koin.get<HlsPlaybackPreparer>() }.getOrDefault(NoopHlsPlaybackPreparer)
+    private val getVideoScaffoldConfigUseCase: GetVideoScaffoldConfigUseCase? =
+        runCatching { koin.get<GetVideoScaffoldConfigUseCase>() }.getOrNull()
+
+    private var hlsPlaybackProxySession: HlsPlaybackProxySession? = null
 
     private val _videoLoadingStateFlow: MutableStateFlow<VideoLoadingState> =
         MutableStateFlow(VideoLoadingState.Initial)
@@ -70,10 +83,12 @@ class PlayerSession(
         val backgroundScope = this
         _videoLoadingStateFlow.value = VideoLoadingState.Initial // 避免一直显示已取消 (.Cancelled)
         stopPlayer()
+        closeHlsPlaybackProxySession()
         if (media == null) {
             return@coroutineScope
         }
 
+        var preparedHlsPlaybackProxySession: HlsPlaybackProxySession? = null
         try {
             _videoLoadingStateFlow.value = VideoLoadingState.ResolvingSource
             val source = mediaResolver.resolve(
@@ -86,9 +101,14 @@ class PlayerSession(
             )
 
             val data = source.open(scopeForCleanup = backgroundScope) // may throw MediaSourceOpenException
+            val preparedData = prepareHlsPlaybackIfEnabled(data).also {
+                preparedHlsPlaybackProxySession = it.session
+            }.data
 
-            logger.info { "Set media data to player: $data" }
-            player.setMediaData(data)
+            logger.info { "Set media data to player: $preparedData" }
+            player.setMediaData(preparedData)
+            hlsPlaybackProxySession = preparedHlsPlaybackProxySession
+            preparedHlsPlaybackProxySession = null
 
             _videoLoadingStateFlow.value = VideoLoadingState.Succeed(isBt = source is TorrentBackedMediaDataProvider)
             withContext(mainDispatcher) {
@@ -133,10 +153,13 @@ class PlayerSession(
             logger.error { IllegalStateException("Failed to resolve video source with unknown error", e) }
             _videoLoadingStateFlow.value = VideoLoadingState.UnknownError(e)
             stopPlayer()
+        } finally {
+            preparedHlsPlaybackProxySession?.close()
         }
     }
 
     fun close() {
+        closeHlsPlaybackProxySession()
         player.close()
     }
 
@@ -146,9 +169,35 @@ class PlayerSession(
         }
     }
 
+    private suspend fun prepareHlsPlaybackIfEnabled(data: MediaData): PreparedMediaData {
+        if (data !is UriMediaData) {
+            return PreparedMediaData(data)
+        }
+        val enabled = getVideoScaffoldConfigUseCase
+            ?.invoke()
+            ?.first()
+            ?.enableExperimentalHlsSegmentFiltering
+            ?: false
+        if (!enabled) {
+            return PreparedMediaData(data)
+        }
+        val result = hlsPlaybackPreparer.prepare(data)
+        return PreparedMediaData(result.data, result.session)
+    }
+
+    private fun closeHlsPlaybackProxySession() {
+        hlsPlaybackProxySession?.close()
+        hlsPlaybackProxySession = null
+    }
+
     companion object {
         private val logger = logger<PlayerSession>()
     }
+
+    private data class PreparedMediaData(
+        val data: MediaData,
+        val session: HlsPlaybackProxySession? = null,
+    )
 }
 
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
@@ -82,8 +82,7 @@ class PlayerSession(
     suspend fun loadMedia(media: Media?, episodeInfo: EpisodeMetadata) = coroutineScope {
         val backgroundScope = this
         _videoLoadingStateFlow.value = VideoLoadingState.Initial // 避免一直显示已取消 (.Cancelled)
-        stopPlayer()
-        closeHlsPlaybackProxySession()
+        stopPlayback()
         if (media == null) {
             return@coroutineScope
         }
@@ -118,7 +117,7 @@ class PlayerSession(
         } catch (e: UnsupportedMediaException) {
             logger.warn { IllegalStateException("Failed to resolve video source, unsupported media", e) }
             _videoLoadingStateFlow.value = VideoLoadingState.UnsupportedMedia
-            stopPlayer()
+            stopPlayback()
         } catch (e: MediaSourceOpenException) { // during playerState.setVideoSource
             logger.warn {
                 IllegalStateException(
@@ -131,7 +130,7 @@ class PlayerSession(
                 OpenFailures.UNSUPPORTED_VIDEO_SOURCE -> VideoLoadingState.UnsupportedMedia
                 OpenFailures.ENGINE_DISABLED -> VideoLoadingState.UnsupportedMedia
             }
-            stopPlayer()
+            stopPlayback()
         } catch (e: MediaResolutionException) { // during MediaResolver.resolve
             logger.warn {
                 IllegalStateException(
@@ -145,17 +144,22 @@ class PlayerSession(
                 ResolutionFailures.NETWORK_ERROR -> VideoLoadingState.NetworkError
                 ResolutionFailures.NO_MATCHING_RESOURCE -> VideoLoadingState.NoMatchingFile
             }
-            stopPlayer()
+            stopPlayback()
         } catch (e: CancellationException) { // 切换数据源
             _videoLoadingStateFlow.value = VideoLoadingState.Cancelled
             throw e
         } catch (e: Throwable) {
             logger.error { IllegalStateException("Failed to resolve video source with unknown error", e) }
             _videoLoadingStateFlow.value = VideoLoadingState.UnknownError(e)
-            stopPlayer()
+            stopPlayback()
         } finally {
             preparedHlsPlaybackProxySession?.close()
         }
+    }
+
+    suspend fun stopPlayback() {
+        stopPlayer()
+        closeHlsPlaybackProxySession()
     }
 
     fun close() {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.hls
+
+object HlsManifestFilter {
+    fun filter(content: String): HlsManifestFilterResult {
+        val lines = content.lines()
+        if (lines.firstOrNull()?.trimStart()?.startsWith("#EXTM3U") != true) {
+            return HlsManifestFilterResult.unsupported(content, "invalid_playlist")
+        }
+        if (lines.any { it.trim().startsWith("#EXT-X-STREAM-INF") }) {
+            return HlsManifestFilterResult.unsupported(content, "master_playlist")
+        }
+        if (lines.none { it.trim().startsWith("#EXT-X-ENDLIST") }) {
+            return HlsManifestFilterResult.unsupported(content, "live_or_incomplete_playlist")
+        }
+        if (lines.none { it.trim().startsWith("#EXT-X-DISCONTINUITY") }) {
+            return HlsManifestFilterResult.unchanged(content, "no_discontinuity")
+        }
+
+        val groups = parseGroups(lines)
+        if (groups.isEmpty()) {
+            return HlsManifestFilterResult.unchanged(content, "no_segments")
+        }
+
+        val candidates = detectCandidates(groups)
+        if (candidates.isEmpty()) {
+            return HlsManifestFilterResult.unchanged(content, "no_candidate")
+        }
+        if (hasAes128KeyWithoutExplicitIv(lines)) {
+            return HlsManifestFilterResult.unchanged(content, "encrypted_implicit_iv")
+        }
+        if (hasByteRangeWithoutExplicitOffset(lines)) {
+            return HlsManifestFilterResult.unchanged(content, "byterange_implicit_offset")
+        }
+
+        val removableIndexes = candidates.mapTo(mutableSetOf()) { it.group.index }
+        val remainingSegmentCount = groups
+            .filterNot { it.index in removableIndexes }
+            .sumOf { it.count }
+        if (remainingSegmentCount == 0) {
+            return HlsManifestFilterResult.unchanged(content, "all_segments_candidate")
+        }
+
+        val removedLines = candidates
+            .flatMapTo(mutableSetOf()) { candidate -> candidate.group.lineStart..candidate.group.lineEnd }
+        val filtered = lines
+            .filterIndexed { index, _ -> index + 1 !in removedLines }
+            .joinToString("\n")
+            .let { if (content.endsWith('\n')) "$it\n" else it }
+
+        return HlsManifestFilterResult(
+            status = HlsManifestFilterStatus.Filtered,
+            content = filtered,
+            reason = null,
+            removedGroups = candidates.map { candidate ->
+                HlsRemovedGroup(
+                    index = candidate.group.index,
+                    lineStart = candidate.group.lineStart,
+                    lineEnd = candidate.group.lineEnd,
+                    startSegmentIndex = candidate.group.startSegmentIndex,
+                    endSegmentIndex = candidate.group.endSegmentIndex,
+                    duration = candidate.group.duration,
+                    segmentCount = candidate.group.count,
+                    reasons = candidate.reasons.map { it.id },
+                )
+            },
+        )
+    }
+
+    private fun parseGroups(lines: List<String>): List<ManifestGroup> {
+        val groups = mutableListOf<ManifestGroup>()
+        val allSegments = mutableListOf<ManifestSegment>()
+        var builder = ManifestGroupBuilder(index = 0)
+        var pendingDuration: Double? = null
+        var pendingExtInfLine: Int? = null
+        var pendingDiscontinuityLine: Int? = null
+
+        fun close() {
+            val group = builder.build() ?: return
+            groups += group
+            builder = ManifestGroupBuilder(index = group.index + 1)
+        }
+
+        for ((zeroIndex, rawLine) in lines.withIndex()) {
+            val lineNo = zeroIndex + 1
+            val line = rawLine.trim()
+            when {
+                line.startsWith("#EXT-X-DISCONTINUITY") -> {
+                    close()
+                    pendingDiscontinuityLine = lineNo
+                }
+
+                line.startsWith("#EXTINF:") -> {
+                    pendingDuration = line.substringAfter(":").substringBefore(",").toDoubleOrNull()
+                    pendingExtInfLine = lineNo
+                }
+
+                line.isNotBlank() && !line.startsWith("#") && pendingDuration != null -> {
+                    val segment = ManifestSegment(
+                        index = allSegments.size,
+                        duration = pendingDuration,
+                        uri = line,
+                        fileName = segmentFileName(line),
+                        extInfLine = pendingExtInfLine ?: lineNo,
+                        uriLine = lineNo,
+                    )
+                    allSegments += segment
+                    builder.add(segment, pendingDiscontinuityLine)
+                    pendingDuration = null
+                    pendingExtInfLine = null
+                    pendingDiscontinuityLine = null
+                }
+            }
+        }
+        close()
+
+        return groups
+    }
+
+    private fun detectCandidates(groups: List<ManifestGroup>): List<CandidateGroup> {
+        val segments = groups.flatMap { it.segments }
+        val dense = groups.size >= 20 || groups.size.toDouble() / segments.size > 0.08
+        val signatureCounts = groups.groupingBy { it.fileSignature }.eachCount()
+        val sequencePrefix = if (dense) numericModel(segments) else null
+
+        return groups.mapIndexedNotNull { groupIndex, group ->
+            val reasons = mutableListOf<HlsCandidateReason>()
+            val previous = groups.getOrNull(groupIndex - 1)
+            val next = groups.getOrNull(groupIndex + 1)
+            val short = group.count <= 12 || group.duration <= 45.0
+
+            val paths = group.segments.joinToString(" ") { segmentPath(it.uri).lowercase() }
+            val strongPath = listOf("adjump", "/ad/", "/ads/", "advert").any { it in paths }
+            if (strongPath) {
+                reasons += HlsCandidateReason.StrongPath
+            }
+
+            val repeatShort = signatureCounts.getValue(group.fileSignature) > 1 &&
+                group.count <= 12 &&
+                group.duration <= 45.0
+            if (repeatShort) {
+                reasons += HlsCandidateReason.RepeatShort
+            }
+
+            val sandwichedShort = previous != null &&
+                next != null &&
+                previous.duration >= 60.0 &&
+                next.duration >= 60.0 &&
+                group.duration <= 45.0 &&
+                group.count >= 2
+            if (sandwichedShort) {
+                reasons += HlsCandidateReason.SandwichedShort
+            }
+
+            if (!dense && short && group.count >= 2) {
+                reasons += HlsCandidateReason.LowDensityShort
+            }
+
+            if (isSequenceIsland(dense, sequencePrefix, segments, group, short)) {
+                reasons += HlsCandidateReason.SequenceIsland
+            }
+
+            val denseTiny = dense &&
+                (group.count <= 3 || group.duration <= 12.0) &&
+                previous != null &&
+                next != null
+            if (denseTiny) {
+                reasons += HlsCandidateReason.DenseTiny
+            }
+
+            reasons.distinct().takeIf { it.isNotEmpty() }?.let {
+                CandidateGroup(group, it)
+            }
+        }
+    }
+
+    private fun isSequenceIsland(
+        dense: Boolean,
+        sequencePrefix: String?,
+        segments: List<ManifestSegment>,
+        group: ManifestGroup,
+        short: Boolean,
+    ): Boolean {
+        if (!dense || sequencePrefix == null || group.count < 2 || !short) {
+            return false
+        }
+
+        val numbers = group.segments.map { trailingNumber(it.fileName, sequencePrefix) }
+        val first = numbers.firstOrNull()
+        val last = numbers.lastOrNull()
+        val previous = segments.getOrNull(group.startSegmentIndex - 1)?.let { trailingNumber(it.fileName, sequencePrefix) }
+        val following = segments.getOrNull(group.endSegmentIndex + 1)?.let { trailingNumber(it.fileName, sequencePrefix) }
+        val linearIsland = numbers.all { it != null } &&
+            numbers.zipWithNext().all { (left, right) -> right == left?.plus(1) }
+
+        return previous != null &&
+            following != null &&
+            first != null &&
+            last != null &&
+            linearIsland &&
+            following == previous + 1 &&
+            kotlin.math.abs(first - previous) > 1000 &&
+            kotlin.math.abs(last - following) > 1000
+    }
+}
+
+enum class HlsManifestFilterStatus {
+    Filtered,
+    Unchanged,
+    Unsupported,
+}
+
+data class HlsManifestFilterResult(
+    val status: HlsManifestFilterStatus,
+    val content: String,
+    val reason: String?,
+    val removedGroups: List<HlsRemovedGroup>,
+) {
+    companion object {
+        fun unchanged(content: String, reason: String): HlsManifestFilterResult {
+            return HlsManifestFilterResult(HlsManifestFilterStatus.Unchanged, content, reason, emptyList())
+        }
+
+        fun unsupported(content: String, reason: String): HlsManifestFilterResult {
+            return HlsManifestFilterResult(HlsManifestFilterStatus.Unsupported, content, reason, emptyList())
+        }
+    }
+}
+
+data class HlsRemovedGroup(
+    val index: Int,
+    val lineStart: Int,
+    val lineEnd: Int,
+    val startSegmentIndex: Int,
+    val endSegmentIndex: Int,
+    val duration: Double,
+    val segmentCount: Int,
+    val reasons: List<String>,
+)
+
+private enum class HlsCandidateReason(val id: String) {
+    StrongPath("strong_path"),
+    RepeatShort("repeat_short"),
+    SandwichedShort("sandwiched_short"),
+    LowDensityShort("low_density_short"),
+    SequenceIsland("sequence_island"),
+    DenseTiny("dense_tiny"),
+}
+
+private data class ManifestSegment(
+    val index: Int,
+    val duration: Double,
+    val uri: String,
+    val fileName: String,
+    val extInfLine: Int,
+    val uriLine: Int,
+)
+
+private data class ManifestGroup(
+    val index: Int,
+    val lineStart: Int,
+    val lineEnd: Int,
+    val startSegmentIndex: Int,
+    val endSegmentIndex: Int,
+    val duration: Double,
+    val count: Int,
+    val fileSignature: String,
+    val segments: List<ManifestSegment>,
+)
+
+private class ManifestGroupBuilder(
+    val index: Int,
+) {
+    private val segments = mutableListOf<ManifestSegment>()
+    private var lineStart: Int? = null
+
+    fun add(segment: ManifestSegment, discontinuityLine: Int?) {
+        if (segments.isEmpty()) {
+            lineStart = discontinuityLine ?: segment.extInfLine
+        }
+        segments += segment
+    }
+
+    fun build(): ManifestGroup? {
+        if (segments.isEmpty()) return null
+        return ManifestGroup(
+            index = index,
+            lineStart = lineStart ?: segments.first().extInfLine,
+            lineEnd = segments.last().uriLine,
+            startSegmentIndex = segments.first().index,
+            endSegmentIndex = segments.last().index,
+            duration = segments.sumOf { it.duration },
+            count = segments.size,
+            fileSignature = segments.joinToString("|") { it.fileName },
+            segments = segments.toList(),
+        )
+    }
+}
+
+private data class CandidateGroup(
+    val group: ManifestGroup,
+    val reasons: List<HlsCandidateReason>,
+)
+
+private fun numericModel(segments: List<ManifestSegment>): String? {
+    val values = segments.mapNotNull { segment ->
+        NUMERIC_TS_REGEX.matchEntire(segment.fileName)?.let {
+            it.groupValues[1] to it.groupValues[2].toInt()
+        }
+    }
+    if (values.isEmpty()) return null
+
+    val prefix = values.groupingBy { it.first }.eachCount().maxByOrNull { it.value } ?: return null
+    if (prefix.value.toDouble() / segments.size < 0.8) return null
+
+    val numbers = values.filter { it.first == prefix.key }.map { it.second }
+    val deltas = numbers.zipWithNext().map { (left, right) -> right - left }
+    if (deltas.isEmpty()) return null
+
+    val delta = deltas.groupingBy { it }.eachCount().maxByOrNull { it.value } ?: return null
+    if (delta.key != 1 || delta.value.toDouble() / deltas.size < 0.5) return null
+    return prefix.key
+}
+
+private fun trailingNumber(fileName: String, prefix: String): Int? {
+    if (!fileName.startsWith(prefix) || !fileName.endsWith(".ts")) return null
+    return fileName.substring(prefix.length, fileName.length - ".ts".length).toIntOrNull()
+}
+
+private fun segmentFileName(uri: String): String {
+    return uri.substringBefore('?').substringBefore('#').substringAfterLast('/')
+}
+
+private fun segmentPath(uri: String): String {
+    val clean = uri.substringBefore('?').substringBefore('#')
+    val path = if ("://" in clean) {
+        clean.substringAfter("://").substringAfter('/', missingDelimiterValue = "")
+    } else {
+        clean
+    }
+    if (path.isEmpty()) return ""
+    return if (path.startsWith('/')) path else "/$path"
+}
+
+private fun hasAes128KeyWithoutExplicitIv(lines: List<String>): Boolean {
+    return lines.any { rawLine ->
+        val line = rawLine.trim()
+        line.startsWith("#EXT-X-KEY") &&
+            line.contains("METHOD=AES-128") &&
+            !line.contains("IV=")
+    }
+}
+
+private fun hasByteRangeWithoutExplicitOffset(lines: List<String>): Boolean {
+    return lines.any { rawLine ->
+        val line = rawLine.trim()
+        line.startsWith("#EXT-X-BYTERANGE:") && "@" !in line.substringAfter(":")
+    }
+}
+
+private val NUMERIC_TS_REGEX = Regex("""^(.*?)(\d{1,7})\.ts$""")

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
@@ -21,7 +21,7 @@ object HlsManifestFilter {
         if (lines.none { it.trim().startsWith("#EXT-X-ENDLIST") }) {
             return HlsManifestFilterResult.unsupported(content, "live_or_incomplete_playlist")
         }
-        if (lines.none { it.trim().startsWith("#EXT-X-DISCONTINUITY") }) {
+        if (lines.none { it.isDiscontinuityTag() }) {
             return HlsManifestFilterResult.unchanged(content, "no_discontinuity")
         }
 
@@ -93,7 +93,7 @@ object HlsManifestFilter {
             val lineNo = zeroIndex + 1
             val line = rawLine.trim()
             when {
-                line.startsWith("#EXT-X-DISCONTINUITY") -> {
+                line.isDiscontinuityTag() -> {
                     close()
                     pendingDiscontinuityLine = lineNo
                 }
@@ -348,6 +348,10 @@ private fun segmentPath(uri: String): String {
     }
     if (path.isEmpty()) return ""
     return if (path.startsWith('/')) path else "/$path"
+}
+
+private fun String.isDiscontinuityTag(): Boolean {
+    return trim() == "#EXT-X-DISCONTINUITY"
 }
 
 private fun hasAes128KeyWithoutExplicitIv(lines: List<String>): Boolean {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsManifestFilter.kt
@@ -9,23 +9,34 @@
 
 package me.him188.ani.app.domain.media.hls
 
+import me.him188.ani.utils.httpdownloader.m3u.DefaultM3u8Parser
+import me.him188.ani.utils.httpdownloader.m3u.M3u8Playlist
+
 object HlsManifestFilter {
-    fun filter(content: String): HlsManifestFilterResult {
+    fun filter(content: String, baseUrl: String = "http://127.0.0.1/playlist.m3u8"): HlsManifestFilterResult {
         val lines = content.lines()
-        if (lines.firstOrNull()?.trimStart()?.startsWith("#EXTM3U") != true) {
+        val playlist = try {
+            DefaultM3u8Parser.parse(content, baseUrl)
+        } catch (_: Exception) {
             return HlsManifestFilterResult.unsupported(content, "invalid_playlist")
         }
-        if (lines.any { it.trim().startsWith("#EXT-X-STREAM-INF") }) {
-            return HlsManifestFilterResult.unsupported(content, "master_playlist")
-        }
-        if (lines.none { it.trim().startsWith("#EXT-X-ENDLIST") }) {
-            return HlsManifestFilterResult.unsupported(content, "live_or_incomplete_playlist")
-        }
-        if (lines.none { it.isDiscontinuityTag() }) {
-            return HlsManifestFilterResult.unchanged(content, "no_discontinuity")
+
+        when (playlist) {
+            is M3u8Playlist.MasterPlaylist -> {
+                return HlsManifestFilterResult.unsupported(content, "master_playlist")
+            }
+
+            is M3u8Playlist.MediaPlaylist -> {
+                if (!playlist.isEndlist) {
+                    return HlsManifestFilterResult.unsupported(content, "live_or_incomplete_playlist")
+                }
+                if (playlist.segments.none { it.isDiscontinuity }) {
+                    return HlsManifestFilterResult.unchanged(content, "no_discontinuity")
+                }
+            }
         }
 
-        val groups = parseGroups(lines)
+        val groups = parseGroups(playlist)
         if (groups.isEmpty()) {
             return HlsManifestFilterResult.unchanged(content, "no_segments")
         }
@@ -34,10 +45,10 @@ object HlsManifestFilter {
         if (candidates.isEmpty()) {
             return HlsManifestFilterResult.unchanged(content, "no_candidate")
         }
-        if (hasAes128KeyWithoutExplicitIv(lines)) {
+        if (hasAes128KeyWithoutExplicitIv(playlist)) {
             return HlsManifestFilterResult.unchanged(content, "encrypted_implicit_iv")
         }
-        if (hasByteRangeWithoutExplicitOffset(lines)) {
+        if (hasByteRangeWithoutExplicitOffset(playlist)) {
             return HlsManifestFilterResult.unchanged(content, "byterange_implicit_offset")
         }
 
@@ -75,13 +86,10 @@ object HlsManifestFilter {
         )
     }
 
-    private fun parseGroups(lines: List<String>): List<ManifestGroup> {
+    private fun parseGroups(playlist: M3u8Playlist.MediaPlaylist): List<ManifestGroup> {
         val groups = mutableListOf<ManifestGroup>()
         val allSegments = mutableListOf<ManifestSegment>()
         var builder = ManifestGroupBuilder(index = 0)
-        var pendingDuration: Double? = null
-        var pendingExtInfLine: Int? = null
-        var pendingDiscontinuityLine: Int? = null
 
         fun close() {
             val group = builder.build() ?: return
@@ -89,36 +97,21 @@ object HlsManifestFilter {
             builder = ManifestGroupBuilder(index = group.index + 1)
         }
 
-        for ((zeroIndex, rawLine) in lines.withIndex()) {
-            val lineNo = zeroIndex + 1
-            val line = rawLine.trim()
-            when {
-                line.isDiscontinuityTag() -> {
-                    close()
-                    pendingDiscontinuityLine = lineNo
-                }
-
-                line.startsWith("#EXTINF:") -> {
-                    pendingDuration = line.substringAfter(":").substringBefore(",").toDoubleOrNull()
-                    pendingExtInfLine = lineNo
-                }
-
-                line.isNotBlank() && !line.startsWith("#") && pendingDuration != null -> {
-                    val segment = ManifestSegment(
-                        index = allSegments.size,
-                        duration = pendingDuration,
-                        uri = line,
-                        fileName = segmentFileName(line),
-                        extInfLine = pendingExtInfLine ?: lineNo,
-                        uriLine = lineNo,
-                    )
-                    allSegments += segment
-                    builder.add(segment, pendingDiscontinuityLine)
-                    pendingDuration = null
-                    pendingExtInfLine = null
-                    pendingDiscontinuityLine = null
-                }
+        for (parsedSegment in playlist.segments) {
+            if (parsedSegment.isDiscontinuity) {
+                close()
             }
+            val sourceRange = parsedSegment.sourceRange ?: return emptyList()
+            val segment = ManifestSegment(
+                index = allSegments.size,
+                duration = parsedSegment.duration.toDouble(),
+                uri = parsedSegment.uri,
+                fileName = segmentFileName(parsedSegment.uri),
+                lineStart = sourceRange.startLine,
+                lineEnd = sourceRange.endLine,
+            )
+            allSegments += segment
+            builder.add(segment)
         }
         close()
 
@@ -260,8 +253,8 @@ private data class ManifestSegment(
     val duration: Double,
     val uri: String,
     val fileName: String,
-    val extInfLine: Int,
-    val uriLine: Int,
+    val lineStart: Int,
+    val lineEnd: Int,
 )
 
 private data class ManifestGroup(
@@ -282,9 +275,9 @@ private class ManifestGroupBuilder(
     private val segments = mutableListOf<ManifestSegment>()
     private var lineStart: Int? = null
 
-    fun add(segment: ManifestSegment, discontinuityLine: Int?) {
+    fun add(segment: ManifestSegment) {
         if (segments.isEmpty()) {
-            lineStart = discontinuityLine ?: segment.extInfLine
+            lineStart = segment.lineStart
         }
         segments += segment
     }
@@ -293,8 +286,8 @@ private class ManifestGroupBuilder(
         if (segments.isEmpty()) return null
         return ManifestGroup(
             index = index,
-            lineStart = lineStart ?: segments.first().extInfLine,
-            lineEnd = segments.last().uriLine,
+            lineStart = lineStart ?: segments.first().lineStart,
+            lineEnd = segments.last().lineEnd,
             startSegmentIndex = segments.first().index,
             endSegmentIndex = segments.last().index,
             duration = segments.sumOf { it.duration },
@@ -350,23 +343,17 @@ private fun segmentPath(uri: String): String {
     return if (path.startsWith('/')) path else "/$path"
 }
 
-private fun String.isDiscontinuityTag(): Boolean {
-    return trim() == "#EXT-X-DISCONTINUITY"
-}
-
-private fun hasAes128KeyWithoutExplicitIv(lines: List<String>): Boolean {
-    return lines.any { rawLine ->
-        val line = rawLine.trim()
-        line.startsWith("#EXT-X-KEY") &&
-            line.contains("METHOD=AES-128") &&
-            !line.contains("IV=")
+private fun hasAes128KeyWithoutExplicitIv(playlist: M3u8Playlist.MediaPlaylist): Boolean {
+    return playlist.segments.any { segment ->
+        segment.encryption?.let { encryption ->
+            encryption.method.equals("AES-128", ignoreCase = true) && encryption.iv == null
+        } == true
     }
 }
 
-private fun hasByteRangeWithoutExplicitOffset(lines: List<String>): Boolean {
-    return lines.any { rawLine ->
-        val line = rawLine.trim()
-        line.startsWith("#EXT-X-BYTERANGE:") && "@" !in line.substringAfter(":")
+private fun hasByteRangeWithoutExplicitOffset(playlist: M3u8Playlist.MediaPlaylist): Boolean {
+    return playlist.segments.any { segment ->
+        segment.byteRange?.offset == null && segment.byteRange != null
     }
 }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/hls/HlsPlaybackPreparer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.hls
+
+import org.openani.mediamp.source.UriMediaData
+
+interface HlsPlaybackPreparer {
+    suspend fun prepare(data: UriMediaData): HlsPlaybackPreparerResult
+}
+
+data class HlsPlaybackPreparerResult(
+    val data: UriMediaData,
+    val session: HlsPlaybackProxySession? = null,
+)
+
+interface HlsPlaybackProxySession : AutoCloseable
+
+object NoopHlsPlaybackPreparer : HlsPlaybackPreparer {
+    override suspend fun prepare(data: UriMediaData): HlsPlaybackPreparerResult {
+        return HlsPlaybackPreparerResult(data)
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
@@ -18,8 +18,12 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
 import me.him188.ani.app.data.models.subject.SubjectSeriesInfo
 import me.him188.ani.app.data.models.subject.TestSubjectCollections
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.NoopHlsPlaybackPreparer
+import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
 import org.koin.core.Koin
 import org.koin.dsl.module
 import org.openani.mediamp.test.TestMediampPlayer
@@ -71,6 +75,14 @@ class EpisodePlayerTestSuite(
                                 ),
                             )
                         }
+                    }
+                    single<GetVideoScaffoldConfigUseCase> {
+                        GetVideoScaffoldConfigUseCase {
+                            flowOf(VideoScaffoldConfig.AllDisabled)
+                        }
+                    }
+                    single<HlsPlaybackPreparer> {
+                        NoopHlsPlaybackPreparer
                     }
                 },
             ),

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/PlayerSessionHlsPlaybackPreparerTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/PlayerSessionHlsPlaybackPreparerTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.episode
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
+import me.him188.ani.app.domain.media.TestMediaList
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparerResult
+import me.him188.ani.app.domain.media.hls.HlsPlaybackProxySession
+import me.him188.ani.app.domain.media.player.data.MediaDataProvider
+import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
+import me.him188.ani.app.domain.media.resolver.MediaResolver
+import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.Media
+import org.koin.core.Koin
+import org.koin.dsl.module
+import org.openani.mediamp.source.MediaExtraFiles
+import org.openani.mediamp.source.UriMediaData
+import org.openani.mediamp.test.TestMediampPlayer
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PlayerSessionHlsPlaybackPreparerTest {
+    private val episode = EpisodeMetadata(title = "EP1", ep = EpisodeSort(1), sort = EpisodeSort(1))
+
+    @Test
+    fun `does not prepare uri media data when setting is disabled`() = runTest {
+        val preparer = RecordingHlsPlaybackPreparer()
+        val playerSession = createPlayerSession(
+            hlsEnabled = false,
+            preparer = preparer,
+        )
+
+        playerSession.loadMedia(TestMediaList.first(), episode)
+
+        val data = assertIs<UriMediaData>(playerSession.player.mediaData.first())
+        assertEquals("https://example.com/original.m3u8", data.uri)
+        assertEquals(0, preparer.prepareCount)
+    }
+
+    @Test
+    fun `prepares uri media data when setting is enabled`() = runTest {
+        val preparer = RecordingHlsPlaybackPreparer()
+        val playerSession = createPlayerSession(
+            hlsEnabled = true,
+            preparer = preparer,
+        )
+
+        playerSession.loadMedia(TestMediaList.first(), episode)
+
+        val data = assertIs<UriMediaData>(playerSession.player.mediaData.first())
+        assertEquals("http://127.0.0.1:18080/proxied.m3u8", data.uri)
+        assertEquals(1, preparer.prepareCount)
+        assertFalse(preparer.sessions.single().closed)
+    }
+
+    @Test
+    fun `closes prepared proxy session on next load and player session close`() = runTest {
+        val preparer = RecordingHlsPlaybackPreparer()
+        val playerSession = createPlayerSession(
+            hlsEnabled = true,
+            preparer = preparer,
+        )
+
+        playerSession.loadMedia(TestMediaList.first(), episode)
+        val firstSession = preparer.sessions.single()
+
+        playerSession.loadMedia(TestMediaList.first(), episode)
+        val secondSession = preparer.sessions.last()
+
+        assertTrue(firstSession.closed)
+        assertFalse(secondSession.closed)
+
+        playerSession.close()
+
+        assertTrue(secondSession.closed)
+    }
+
+    private fun TestScope.createPlayerSession(
+        hlsEnabled: Boolean,
+        preparer: HlsPlaybackPreparer,
+    ): PlayerSession {
+        val koin = Koin()
+        koin.loadModules(
+            listOf(
+                module {
+                    single<MediaResolver> {
+                        StaticMediaResolver(
+                            UriMediaData(
+                                "https://example.com/original.m3u8",
+                                mapOf("User-Agent" to "AnimekoTest"),
+                            ),
+                        )
+                    }
+                    single<GetVideoScaffoldConfigUseCase> {
+                        GetVideoScaffoldConfigUseCase {
+                            flowOf(
+                                VideoScaffoldConfig.AllDisabled.copy(
+                                    enableExperimentalHlsSegmentFiltering = hlsEnabled,
+                                ),
+                            )
+                        }
+                    }
+                    single<HlsPlaybackPreparer> { preparer }
+                },
+            ),
+        )
+        val player = TestMediampPlayer(StandardTestDispatcher(testScheduler))
+        return PlayerSession(player, koin, mainDispatcher = EmptyCoroutineContext)
+    }
+
+    private class StaticMediaResolver(
+        private val data: UriMediaData,
+    ) : MediaResolver {
+        override fun supports(media: Media): Boolean = true
+
+        override suspend fun resolve(media: Media, episode: EpisodeMetadata): MediaDataProvider<*> {
+            return object : MediaDataProvider<UriMediaData> {
+                override val extraFiles: MediaExtraFiles = MediaExtraFiles.EMPTY
+
+                override suspend fun open(scopeForCleanup: CoroutineScope): UriMediaData {
+                    return data
+                }
+            }
+        }
+    }
+
+    private class RecordingHlsPlaybackPreparer : HlsPlaybackPreparer {
+        val sessions = mutableListOf<RecordingHlsPlaybackProxySession>()
+        var prepareCount: Int = 0
+            private set
+
+        override suspend fun prepare(data: UriMediaData): HlsPlaybackPreparerResult {
+            prepareCount++
+            val session = RecordingHlsPlaybackProxySession()
+            sessions += session
+            return HlsPlaybackPreparerResult(
+                data = UriMediaData(
+                    "http://127.0.0.1:18080/proxied.m3u8",
+                    data.headers,
+                    data.extraFiles,
+                ),
+                session = session,
+            )
+        }
+    }
+
+    private class RecordingHlsPlaybackProxySession : HlsPlaybackProxySession {
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/PlayerSessionHlsPlaybackPreparerTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/PlayerSessionHlsPlaybackPreparerTest.kt
@@ -94,6 +94,22 @@ class PlayerSessionHlsPlaybackPreparerTest {
         assertTrue(secondSession.closed)
     }
 
+    @Test
+    fun `closes prepared proxy session on stop playback`() = runTest {
+        val preparer = RecordingHlsPlaybackPreparer()
+        val playerSession = createPlayerSession(
+            hlsEnabled = true,
+            preparer = preparer,
+        )
+
+        playerSession.loadMedia(TestMediaList.first(), episode)
+        val session = preparer.sessions.single()
+
+        playerSession.stopPlayback()
+
+        assertTrue(session.closed)
+    }
+
     private fun TestScope.createPlayerSession(
         hlsEnabled: Boolean,
         preparer: HlsPlaybackPreparer,

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.hls
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HlsManifestFilterTest {
+    @Test
+    fun `filters repeated sandwiched short groups in low density playlist`() {
+        val result = HlsManifestFilter.filter(
+            mediaPlaylist(
+                group(30, duration = 3.0, uriPrefix = "https://cdn.example/main/seg0"),
+                group(3, duration = 6.0, uriPrefix = "https://cdn.example/ad/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "https://cdn.example/main/seg1"),
+                group(3, duration = 6.0, uriPrefix = "https://cdn.example/ad/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "https://cdn.example/main/seg2"),
+            ),
+        )
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertEquals(2, result.removedGroups.size)
+        assertTrue(result.removedGroups.all { "strong_path" in it.reasons })
+        assertTrue(result.removedGroups.all { "repeat_short" in it.reasons })
+        assertTrue(result.removedGroups.all { "sandwiched_short" in it.reasons })
+        assertTrue(result.removedGroups.all { "low_density_short" in it.reasons })
+        assertFalse("/ad/" in result.content)
+        assertEquals(90, result.content.mediaSegmentUriCount())
+    }
+
+    @Test
+    fun `detects relative ad directory as strong path`() {
+        val result = HlsManifestFilter.filter(
+            mediaPlaylist(
+                group(30, duration = 3.0, uriPrefix = "main/seg0"),
+                group(3, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "main/seg1"),
+            ),
+        )
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertEquals(1, result.removedGroups.size)
+        assertTrue("strong_path" in result.removedGroups.single().reasons)
+        assertFalse("ads/ad900.ts" in result.content)
+    }
+
+    @Test
+    fun `does not filter dense short groups without structural signals`() {
+        val groups = List(21) { index ->
+            group(4, duration = 10.0, uriPrefix = "https://cdn.example/main/g$index-", startNumber = index * 10)
+        }
+
+        val content = mediaPlaylist(*groups.toTypedArray())
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unchanged, result.status)
+        assertEquals("no_candidate", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `detects dense tiny group`() {
+        val groups = buildList {
+            repeat(10) { add(group(5, duration = 15.0, uriPrefix = "https://cdn.example/main/a$it-")) }
+            add(group(1, duration = 8.0, uriPrefix = "https://cdn.example/insert/tiny"))
+            repeat(10) { add(group(5, duration = 15.0, uriPrefix = "https://cdn.example/main/b$it-")) }
+        }
+
+        val result = HlsManifestFilter.filter(mediaPlaylist(*groups.toTypedArray()))
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertEquals(1, result.removedGroups.size)
+        assertEquals(listOf("dense_tiny"), result.removedGroups.single().reasons)
+        assertFalse("insert/tiny" in result.content)
+    }
+
+    @Test
+    fun `detects sequence island in dense playlist`() {
+        val groups = buildList {
+            repeat(9) { index ->
+                add(group(4, duration = 12.5, uriPrefix = "https://cdn.example/main/seg", startNumber = index * 4))
+            }
+            add(group(2, duration = 6.0, uriPrefix = "https://cdn.example/main/seg", startNumber = 9000))
+            repeat(12) { index ->
+                add(group(4, duration = 12.5, uriPrefix = "https://cdn.example/main/seg", startNumber = 36 + index * 4))
+            }
+        }
+
+        val result = HlsManifestFilter.filter(mediaPlaylist(*groups.toTypedArray()))
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertEquals(1, result.removedGroups.size)
+        assertTrue("sequence_island" in result.removedGroups.single().reasons)
+        assertFalse("seg9000.ts" in result.content)
+        assertTrue("seg9.ts" in result.content)
+    }
+
+    @Test
+    fun `keeps playlist without discontinuity unchanged`() {
+        val content = mediaPlaylist(
+            group(4, duration = 10.0, uriPrefix = "https://cdn.example/main/seg"),
+            discontinuity = false,
+        )
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unchanged, result.status)
+        assertEquals("no_discontinuity", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `keeps encrypted single group playlist unchanged when there is no manifest boundary`() {
+        val content = """
+            #EXTM3U
+            #EXT-X-VERSION:3
+            #EXT-X-TARGETDURATION:10
+            #EXT-X-KEY:METHOD=AES-128,URI="enc.key",IV=0x00000000000000000000000000000000
+            #EXTINF:10,
+            plist0.ts
+            #EXTINF:10,
+            plist1.ts
+            #EXT-X-ENDLIST
+        """.trimIndent()
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unchanged, result.status)
+        assertEquals("no_discontinuity", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `keeps encrypted playlist with implicit iv unchanged when candidate exists`() {
+        val content = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXT-X-VERSION:3")
+            appendLine("#EXT-X-TARGETDURATION:10")
+            appendLine("#EXT-X-MEDIA-SEQUENCE:10")
+            appendLine("#EXT-X-KEY:METHOD=AES-128,URI=\"enc.key\"")
+            mediaPlaylistBody(
+                group(30, duration = 3.0, uriPrefix = "main/seg0"),
+                group(3, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "main/seg1"),
+            )
+            append("#EXT-X-ENDLIST")
+        }
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unchanged, result.status)
+        assertEquals("encrypted_implicit_iv", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `filters encrypted playlist with explicit iv`() {
+        val content = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXT-X-VERSION:3")
+            appendLine("#EXT-X-TARGETDURATION:10")
+            appendLine("#EXT-X-KEY:METHOD=AES-128,URI=\"enc.key\",IV=0x00000000000000000000000000000000")
+            mediaPlaylistBody(
+                group(30, duration = 3.0, uriPrefix = "main/seg0"),
+                group(3, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "main/seg1"),
+            )
+            append("#EXT-X-ENDLIST")
+        }
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertFalse("ads/ad900.ts" in result.content)
+    }
+
+    @Test
+    fun `keeps byte range playlist with implicit offset unchanged when candidate exists`() {
+        val content = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXT-X-VERSION:4")
+            appendLine("#EXT-X-TARGETDURATION:10")
+            appendLine("#EXT-X-BYTERANGE:3000@0")
+            mediaPlaylistBody(
+                group(30, duration = 3.0, uriPrefix = "main/seg0"),
+                group(3, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "main/seg1"),
+            )
+            appendLine("#EXT-X-BYTERANGE:3000")
+            append("#EXT-X-ENDLIST")
+        }
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unchanged, result.status)
+        assertEquals("byterange_implicit_offset", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `does not rewrite master playlist`() {
+        val content = """
+            #EXTM3U
+            #EXT-X-STREAM-INF:BANDWIDTH=1280000
+            low/index.m3u8
+            #EXT-X-STREAM-INF:BANDWIDTH=2560000
+            high/index.m3u8
+        """.trimIndent()
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unsupported, result.status)
+        assertEquals("master_playlist", result.reason)
+        assertEquals(content, result.content)
+    }
+
+    @Test
+    fun `does not rewrite live playlist`() {
+        val content = """
+            #EXTM3U
+            #EXT-X-VERSION:3
+            #EXT-X-TARGETDURATION:10
+            #EXTINF:10,
+            seg0.ts
+            #EXT-X-DISCONTINUITY
+            #EXTINF:10,
+            seg1.ts
+        """.trimIndent()
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Unsupported, result.status)
+        assertEquals("live_or_incomplete_playlist", result.reason)
+        assertEquals(content, result.content)
+    }
+}
+
+private fun mediaPlaylist(
+    vararg groups: List<TestSegment>,
+    discontinuity: Boolean = true,
+): String {
+    return buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:3")
+        appendLine("#EXT-X-TARGETDURATION:15")
+        mediaPlaylistBody(*groups, discontinuity = discontinuity)
+        append("#EXT-X-ENDLIST")
+    }
+}
+
+private fun StringBuilder.mediaPlaylistBody(
+    vararg groups: List<TestSegment>,
+    discontinuity: Boolean = true,
+) {
+    groups.forEachIndexed { groupIndex, group ->
+        if (discontinuity && groupIndex > 0) {
+            appendLine("#EXT-X-DISCONTINUITY")
+        }
+        group.forEach { segment ->
+            appendLine("#EXTINF:${segment.duration},")
+            appendLine(segment.uri)
+        }
+    }
+}
+
+private fun group(
+    count: Int,
+    duration: Double,
+    uriPrefix: String,
+    startNumber: Int = 0,
+): List<TestSegment> {
+    return List(count) { index ->
+        TestSegment(
+            duration = duration,
+            uri = "$uriPrefix${startNumber + index}.ts",
+        )
+    }
+}
+
+private data class TestSegment(
+    val duration: Double,
+    val uri: String,
+)
+
+private fun String.mediaSegmentUriCount(): Int {
+    return lines().count { line ->
+        val trimmed = line.trim()
+        trimmed.isNotEmpty() && !trimmed.startsWith("#")
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
@@ -54,6 +54,27 @@ class HlsManifestFilterTest {
     }
 
     @Test
+    fun `does not treat discontinuity sequence as segment boundary`() {
+        val content = buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXT-X-VERSION:3")
+            appendLine("#EXT-X-DISCONTINUITY-SEQUENCE:7")
+            appendLine("#EXT-X-TARGETDURATION:10")
+            mediaPlaylistBody(
+                group(2, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
+                group(30, duration = 3.0, uriPrefix = "main/seg0"),
+            )
+            append("#EXT-X-ENDLIST")
+        }
+
+        val result = HlsManifestFilter.filter(content)
+
+        assertEquals(HlsManifestFilterStatus.Filtered, result.status)
+        assertTrue("#EXT-X-DISCONTINUITY-SEQUENCE:7" in result.content)
+        assertFalse("ads/ad900.ts" in result.content)
+    }
+
+    @Test
     fun `does not filter dense short groups without structural signals`() {
         val groups = List(21) { index ->
             group(4, duration = 10.0, uriPrefix = "https://cdn.example/main/g$index-", startNumber = index * 10)

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/hls/HlsManifestFilterTest.kt
@@ -210,13 +210,12 @@ class HlsManifestFilterTest {
             appendLine("#EXTM3U")
             appendLine("#EXT-X-VERSION:4")
             appendLine("#EXT-X-TARGETDURATION:10")
-            appendLine("#EXT-X-BYTERANGE:3000@0")
+            appendLine("#EXT-X-BYTERANGE:3000")
             mediaPlaylistBody(
                 group(30, duration = 3.0, uriPrefix = "main/seg0"),
                 group(3, duration = 6.0, uriPrefix = "ads/ad", startNumber = 900),
                 group(30, duration = 3.0, uriPrefix = "main/seg1"),
             )
-            appendLine("#EXT-X-BYTERANGE:3000")
             append("#EXT-X-ENDLIST")
         }
 

--- a/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
+++ b/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
@@ -88,8 +88,56 @@ class PlatformHlsPlaybackPreparerTest {
         }
     }
 
+    @Test
+    fun `proxies master playlist and filters variant media playlist`() = runTest {
+        val server = StaticManifestServer(
+            content = "",
+            contentByPath = mapOf(
+                "/master/index.m3u8" to masterManifest,
+                "/master/media/low.m3u8" to manifest,
+            ),
+        )
+        val provider = DefaultHttpClientProvider(NoProxyProvider, backgroundScope)
+        val preparer = PlatformHlsPlaybackPreparer(provider)
+
+        val result = preparer.prepare(
+            UriMediaData(
+                uri = "${server.baseUrl}/master/index.m3u8",
+                headers = mapOf("Referer" to "https://media.example.com/watch/master"),
+            ),
+        )
+
+        try {
+            assertIs<HlsPlaybackProxySession>(result.session)
+            assertNotEquals("${server.baseUrl}/master/index.m3u8", result.data.uri)
+
+            val localMaster = URI(result.data.uri).toURL().readText()
+            val localVariantUri = localMaster.lineSequence()
+                .first { it.isNotBlank() && !it.startsWith("#") }
+            assertContains(localVariantUri, "http://127.0.0.1:")
+            assertContains(localMaster, "#EXT-X-SESSION-KEY:METHOD=AES-128,URI=\"${server.baseUrl}/master/keys/session.key\"")
+            assertEquals(false, "media/low.m3u8" in localMaster)
+            assertEquals(false, "URI=\"keys/session.key\"" in localMaster)
+
+            val localVariant = URI(localVariantUri).toURL().readText()
+            assertContains(localVariant, "${server.baseUrl}/master/media/main000.ts")
+            assertContains(localVariant, "${server.baseUrl}/master/media/main004.ts")
+            assertEquals(false, "ad001.ts" in localVariant)
+            assertEquals(false, "ad002.ts" in localVariant)
+            assertEquals(
+                listOf("https://media.example.com/watch/master", "https://media.example.com/watch/master"),
+                server.referers,
+            )
+        } finally {
+            result.session?.close()
+            provider.forceReleaseAll()
+            server.close()
+        }
+    }
+
     private class StaticManifestServer(
         content: String,
+        private val contentByPath: Map<String, String> = emptyMap(),
         private val redirectFrom: String? = null,
         private val redirectTo: String? = null,
     ) : AutoCloseable {
@@ -129,8 +177,11 @@ class PlatformHlsPlaybackPreparerTest {
                             if (requestPath == redirectFrom && redirectTo != null) {
                                 output.write(redirectHeader("$baseUrl$redirectTo").toByteArray(StandardCharsets.US_ASCII))
                             } else {
-                                output.write(responseHeader(bytes.size).toByteArray(StandardCharsets.US_ASCII))
-                                output.write(bytes)
+                                val responseBytes = contentByPath[requestPath]
+                                    ?.toByteArray(StandardCharsets.UTF_8)
+                                    ?: bytes
+                                output.write(responseHeader(responseBytes.size).toByteArray(StandardCharsets.US_ASCII))
+                                output.write(responseBytes)
                             }
                             output.flush()
                         }
@@ -183,6 +234,13 @@ class PlatformHlsPlaybackPreparerTest {
         appendAdGroup()
         appendMainGroup(start = 60)
         append("#EXT-X-ENDLIST")
+    }
+
+    private val masterManifest = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-SESSION-KEY:METHOD=AES-128,URI=\"keys/session.key\"")
+        appendLine("#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=800000,RESOLUTION=1080x608")
+        appendLine("media/low.m3u8")
     }
 
     private fun StringBuilder.appendMainGroup(start: Int, absoluteIndex: Int? = null) {

--- a/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
+++ b/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.hls
+
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.domain.foundation.DefaultHttpClientProvider
+import me.him188.ani.app.domain.settings.NoProxyProvider
+import org.openani.mediamp.source.UriMediaData
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.SocketException
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+
+class PlatformHlsPlaybackPreparerTest {
+    @Test
+    fun `filters playlist and serves rewritten local manifest`() = runTest {
+        val server = StaticManifestServer(manifest)
+        val provider = DefaultHttpClientProvider(NoProxyProvider, backgroundScope)
+        val preparer = PlatformHlsPlaybackPreparer(provider)
+
+        val result = preparer.prepare(
+            UriMediaData(
+                uri = "${server.baseUrl}/anime/01/index.m3u8",
+                headers = mapOf("Referer" to "https://media.example.com/watch/01"),
+            ),
+        )
+
+        try {
+            assertEquals(listOf("https://media.example.com/watch/01"), server.referers)
+            assertNotEquals("${server.baseUrl}/anime/01/index.m3u8", result.data.uri)
+            assertEquals("https://media.example.com/watch/01", result.data.headers["Referer"])
+            assertIs<HlsPlaybackProxySession>(result.session)
+
+            val localManifest = URI(result.data.uri).toURL().readText()
+            assertContains(localManifest, "#EXT-X-KEY:METHOD=AES-128,URI=\"${server.baseUrl}/anime/01/keys/main.key\"")
+            assertContains(localManifest, "${server.baseUrl}/anime/01/main000.ts")
+            assertContains(localManifest, "https://cdn.example.com/main003.ts")
+            assertContains(localManifest, "${server.baseUrl}/anime/01/main004.ts")
+            assertEquals(false, "ad001.ts" in localManifest)
+            assertEquals(false, "ad002.ts" in localManifest)
+        } finally {
+            result.session?.close()
+            provider.forceReleaseAll()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `rewrites relative urls against redirected manifest url`() = runTest {
+        val server = StaticManifestServer(
+            manifest,
+            redirectFrom = "/entry/index.m3u8",
+            redirectTo = "/cdn/final/index.m3u8",
+        )
+        val provider = DefaultHttpClientProvider(NoProxyProvider, backgroundScope)
+        val preparer = PlatformHlsPlaybackPreparer(provider)
+
+        val result = preparer.prepare(UriMediaData("${server.baseUrl}/entry/index.m3u8"))
+
+        try {
+            assertIs<HlsPlaybackProxySession>(result.session)
+
+            val localManifest = URI(result.data.uri).toURL().readText()
+            assertContains(localManifest, "#EXT-X-KEY:METHOD=AES-128,URI=\"${server.baseUrl}/cdn/final/keys/main.key\"")
+            assertContains(localManifest, "${server.baseUrl}/cdn/final/main000.ts")
+            assertEquals(false, "${server.baseUrl}/entry/main000.ts" in localManifest)
+        } finally {
+            result.session?.close()
+            provider.forceReleaseAll()
+            server.close()
+        }
+    }
+
+    private class StaticManifestServer(
+        content: String,
+        private val redirectFrom: String? = null,
+        private val redirectTo: String? = null,
+    ) : AutoCloseable {
+        private val closed = AtomicBoolean(false)
+        private val bytes = content.toByteArray(StandardCharsets.UTF_8)
+        private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        private val mutableReferers = mutableListOf<String?>()
+
+        val baseUrl: String = "http://127.0.0.1:${serverSocket.localPort}"
+        val referers: List<String?> get() = mutableReferers.toList()
+
+        private val thread = thread(
+            name = "PlatformHlsPlaybackPreparerTest-${serverSocket.localPort}",
+            isDaemon = true,
+            start = true,
+        ) {
+            while (!closed.get()) {
+                try {
+                    serverSocket.accept().use { socket ->
+                        val reader = BufferedReader(InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII))
+                        val lines = buildList {
+                            while (true) {
+                                val line = reader.readLine() ?: break
+                                if (line.isEmpty()) break
+                                add(line)
+                            }
+                        }
+                        mutableReferers += lines
+                            .firstOrNull { it.startsWith("Referer:", ignoreCase = true) }
+                            ?.substringAfter(":")
+                            ?.trim()
+
+                        socket.getOutputStream().use { output ->
+                            val requestPath = lines.firstOrNull()
+                                ?.substringAfter(" ")
+                                ?.substringBefore(" ")
+                            if (requestPath == redirectFrom && redirectTo != null) {
+                                output.write(redirectHeader("$baseUrl$redirectTo").toByteArray(StandardCharsets.US_ASCII))
+                            } else {
+                                output.write(responseHeader(bytes.size).toByteArray(StandardCharsets.US_ASCII))
+                                output.write(bytes)
+                            }
+                            output.flush()
+                        }
+                    }
+                } catch (e: SocketException) {
+                    if (!closed.get()) throw e
+                }
+            }
+        }
+
+        override fun close() {
+            if (closed.compareAndSet(false, true)) {
+                serverSocket.close()
+            }
+        }
+
+        @Suppress("unused")
+        private fun keepThreadReachable(): Thread = thread
+
+        private fun responseHeader(contentLength: Int): String {
+            return buildString {
+                append("HTTP/1.1 200 OK\r\n")
+                append("Content-Type: application/vnd.apple.mpegurl; charset=utf-8\r\n")
+                append("Content-Length: ").append(contentLength).append("\r\n")
+                append("Connection: close\r\n")
+                append("\r\n")
+            }
+        }
+
+        private fun redirectHeader(location: String): String {
+            return buildString {
+                append("HTTP/1.1 302 Found\r\n")
+                append("Location: ").append(location).append("\r\n")
+                append("Content-Length: 0\r\n")
+                append("Connection: close\r\n")
+                append("\r\n")
+            }
+        }
+    }
+
+    private val manifest = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:3")
+        appendLine("#EXT-X-TARGETDURATION:10")
+        appendLine("#EXT-X-MEDIA-SEQUENCE:1")
+        appendLine("#EXT-X-KEY:METHOD=AES-128,URI=\"keys/main.key\",IV=0x00000000000000000000000000000001")
+        appendMainGroup(start = 0, absoluteIndex = 3)
+        appendAdGroup()
+        appendMainGroup(start = 30)
+        appendAdGroup()
+        appendMainGroup(start = 60)
+        append("#EXT-X-ENDLIST")
+    }
+
+    private fun StringBuilder.appendMainGroup(start: Int, absoluteIndex: Int? = null) {
+        if (start != 0) appendLine("#EXT-X-DISCONTINUITY")
+        repeat(30) { offset ->
+            val number = start + offset
+            appendLine("#EXTINF:3,")
+            if (number == absoluteIndex) {
+                appendLine("https://cdn.example.com/main${number.toString().padStart(3, '0')}.ts")
+            } else {
+                appendLine("main${number.toString().padStart(3, '0')}.ts")
+            }
+        }
+    }
+
+    private fun StringBuilder.appendAdGroup() {
+        appendLine("#EXT-X-DISCONTINUITY")
+        appendLine("#EXTINF:6,")
+        appendLine("/ads/ad001.ts")
+        appendLine("#EXTINF:6,")
+        appendLine("/ads/ad002.ts")
+    }
+}

--- a/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
+++ b/app/shared/app-data/src/desktopTest/kotlin/domain/media/hls/PlatformHlsPlaybackPreparerTest.kt
@@ -135,6 +135,68 @@ class PlatformHlsPlaybackPreparerTest {
         }
     }
 
+    @Test
+    fun `rewrites media playlist uri attributes when proxying master variant`() = runTest {
+        val server = StaticManifestServer(
+            content = "",
+            contentByPath = mapOf(
+                "/partial/master.m3u8" to partialMasterManifest,
+                "/partial/low/index.m3u8" to partialMediaManifest,
+            ),
+        )
+        val provider = DefaultHttpClientProvider(NoProxyProvider, backgroundScope)
+        val preparer = PlatformHlsPlaybackPreparer(provider)
+
+        val result = preparer.prepare(UriMediaData("${server.baseUrl}/partial/master.m3u8"))
+
+        try {
+            assertIs<HlsPlaybackProxySession>(result.session)
+
+            val localMaster = URI(result.data.uri).toURL().readText()
+            val localVariantUri = localMaster.lineSequence()
+                .first { it.isNotBlank() && !it.startsWith("#") }
+            val localVariant = URI(localVariantUri).toURL().readText()
+
+            assertContains(localVariant, "#EXT-X-PART:DURATION=1.0,URI=\"${server.baseUrl}/partial/low/part0.m4s\"")
+            assertContains(
+                localVariant,
+                "#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"${server.baseUrl}/partial/low/next.m4s\"",
+            )
+            assertContains(localVariant, "${server.baseUrl}/partial/low/seg0.ts")
+        } finally {
+            result.session?.close()
+            provider.forceReleaseAll()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `does not filter direct media playlist twice`() = runTest {
+        val firstPass = HlsManifestFilter.filter(doubleFilterRegressionManifest)
+        assertEquals(HlsManifestFilterStatus.Filtered, firstPass.status)
+        assertEquals(1, firstPass.removedGroups.size)
+        assertContains(firstPass.content, "short-normal000.ts")
+
+        val server = StaticManifestServer(doubleFilterRegressionManifest)
+        val provider = DefaultHttpClientProvider(NoProxyProvider, backgroundScope)
+        val preparer = PlatformHlsPlaybackPreparer(provider)
+
+        val result = preparer.prepare(UriMediaData("${server.baseUrl}/dense/index.m3u8"))
+
+        try {
+            assertIs<HlsPlaybackProxySession>(result.session)
+
+            val localManifest = URI(result.data.uri).toURL().readText()
+            assertContains(localManifest, "${server.baseUrl}/dense/short-normal000.ts")
+            assertContains(localManifest, "${server.baseUrl}/dense/short-normal003.ts")
+            assertEquals(false, "ad-double000.ts" in localManifest)
+        } finally {
+            result.session?.close()
+            provider.forceReleaseAll()
+            server.close()
+        }
+    }
+
     private class StaticManifestServer(
         content: String,
         private val contentByPath: Map<String, String> = emptyMap(),
@@ -243,6 +305,36 @@ class PlatformHlsPlaybackPreparerTest {
         appendLine("media/low.m3u8")
     }
 
+    private val partialMasterManifest = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-STREAM-INF:BANDWIDTH=800000")
+        appendLine("low/index.m3u8")
+    }
+
+    private val partialMediaManifest = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:9")
+        appendLine("#EXT-X-TARGETDURATION:4")
+        appendLine("#EXT-X-PART-INF:PART-TARGET=1.0")
+        appendLine("#EXT-X-PART:DURATION=1.0,URI=\"part0.m4s\"")
+        appendLine("#EXTINF:4,")
+        appendLine("seg0.ts")
+        append("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"next.m4s\"")
+    }
+
+    private val doubleFilterRegressionManifest = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:3")
+        appendLine("#EXT-X-TARGETDURATION:10")
+        appendMainGroup(start = 0)
+        appendAdGroup(uriPrefix = "/ads/ad-double")
+        appendShortNormalGroup()
+        repeat(17) { index ->
+            appendMainGroup(start = 30 + index * 30)
+        }
+        append("#EXT-X-ENDLIST")
+    }
+
     private fun StringBuilder.appendMainGroup(start: Int, absoluteIndex: Int? = null) {
         if (start != 0) appendLine("#EXT-X-DISCONTINUITY")
         repeat(30) { offset ->
@@ -256,11 +348,19 @@ class PlatformHlsPlaybackPreparerTest {
         }
     }
 
-    private fun StringBuilder.appendAdGroup() {
+    private fun StringBuilder.appendAdGroup(uriPrefix: String = "/ads/ad") {
         appendLine("#EXT-X-DISCONTINUITY")
         appendLine("#EXTINF:6,")
-        appendLine("/ads/ad001.ts")
+        appendLine("${uriPrefix}001.ts")
         appendLine("#EXTINF:6,")
-        appendLine("/ads/ad002.ts")
+        appendLine("${uriPrefix}002.ts")
+    }
+
+    private fun StringBuilder.appendShortNormalGroup() {
+        appendLine("#EXT-X-DISCONTINUITY")
+        repeat(4) { index ->
+            appendLine("#EXTINF:4,")
+            appendLine("short-normal${index.toString().padStart(3, '0')}.ts")
+        }
     }
 }

--- a/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
@@ -84,6 +84,7 @@ class PlatformHlsPlaybackPreparer(
 
 private class LocalHlsPlaylistSession(
     initialPlaylistContent: LocalPlaylistContent,
+    rewriteInitialPlaylist: Boolean,
     private val headers: Map<String, String>,
     private val httpClientProvider: HttpClientProvider?,
 ) : HlsPlaybackProxySession {
@@ -91,7 +92,11 @@ private class LocalHlsPlaylistSession(
     private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
     private val nextRouteId = AtomicInteger(1)
     private val remoteRoutes = ConcurrentHashMap<String, URI>()
-    private val initialContent = initialPlaylistContent.rewriteMasterPlaylistUrisIfNeeded()
+    private val initialContent = if (rewriteInitialPlaylist) {
+        initialPlaylistContent.rewriteMasterPlaylistUrisIfNeeded()
+    } else {
+        initialPlaylistContent
+    }
 
     val playlistUri: String = "http://127.0.0.1:${serverSocket.localPort}/playlist.m3u8"
 
@@ -246,6 +251,7 @@ private class LocalHlsPlaylistSession(
         fun static(content: String): LocalHlsPlaylistSession {
             return LocalHlsPlaylistSession(
                 initialPlaylistContent = LocalPlaylistContent(content, URI("http://127.0.0.1/")),
+                rewriteInitialPlaylist = false,
                 headers = emptyMap(),
                 httpClientProvider = null,
             )
@@ -259,6 +265,7 @@ private class LocalHlsPlaylistSession(
         ): LocalHlsPlaylistSession {
             return LocalHlsPlaylistSession(
                 initialPlaylistContent = LocalPlaylistContent(content, baseUri),
+                rewriteInitialPlaylist = true,
                 headers = headers,
                 httpClientProvider = httpClientProvider,
             )
@@ -283,13 +290,12 @@ private fun String.rewriteMediaPlaylistUris(baseUri: URI): String {
     return lineSequence().joinToString("\n") { line ->
         when {
             line.isBlank() -> line
-            line.startsWith("#EXT-X-KEY") || line.startsWith("#EXT-X-MAP") -> {
+            line.startsWith("#") -> {
                 line.replace(URI_ATTRIBUTE_REGEX) { match ->
                     val uri = match.groupValues[2]
                     match.groupValues[1] + baseUri.resolveIfRelative(uri) + match.groupValues[3]
                 }
             }
-            line.startsWith("#") -> line
             else -> baseUri.resolveIfRelative(line)
         }
     } + if (endsWith('\n')) "\n" else ""

--- a/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
@@ -56,7 +56,7 @@ class PlatformHlsPlaybackPreparer(
             return HlsPlaybackPreparerResult(data)
         }
 
-        val filterResult = HlsManifestFilter.filter(manifest)
+        val filterResult = HlsManifestFilter.filter(manifest, baseUri.toString())
         val session = when {
             filterResult.status == HlsManifestFilterStatus.Filtered -> {
                 LocalHlsPlaylistSession.static(filterResult.content.rewriteMediaPlaylistUris(baseUri))
@@ -179,7 +179,7 @@ private class LocalHlsPlaylistSession(
     }
 
     private fun LocalPlaylistContent.rewriteMasterPlaylistUrisIfNeeded(): LocalPlaylistContent {
-        val filterResult = HlsManifestFilter.filter(content)
+        val filterResult = HlsManifestFilter.filter(content, baseUri.toString())
         val rewrittenContent = when {
             filterResult.status == HlsManifestFilterStatus.Filtered -> {
                 filterResult.content.rewriteMediaPlaylistUris(baseUri)

--- a/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.hls
+
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import me.him188.ani.app.domain.foundation.HttpClientProvider
+import me.him188.ani.app.domain.foundation.ScopedHttpClientUserAgent
+import me.him188.ani.app.domain.foundation.get
+import me.him188.ani.utils.logging.warn
+import org.openani.mediamp.source.UriMediaData
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.SocketException
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.coroutines.cancellation.CancellationException
+
+class PlatformHlsPlaybackPreparer(
+    private val httpClientProvider: HttpClientProvider,
+) : HlsPlaybackPreparer {
+    override suspend fun prepare(data: UriMediaData): HlsPlaybackPreparerResult {
+        if (!data.uri.isCandidateHlsUri()) {
+            return HlsPlaybackPreparerResult(data)
+        }
+
+        val requestedUri = runCatching { URI(data.uri) }.getOrNull() ?: return HlsPlaybackPreparerResult(data)
+        var baseUri = requestedUri
+        val manifest = try {
+            httpClientProvider.get(ScopedHttpClientUserAgent.BROWSER).use {
+                val response = get(data.uri) {
+                    data.headers.forEach { (name, value) -> header(name, value) }
+                }
+                baseUri = runCatching { URI(response.call.request.url.toString()) }.getOrDefault(requestedUri)
+                response.bodyAsText()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            return HlsPlaybackPreparerResult(data)
+        }
+
+        val filterResult = HlsManifestFilter.filter(manifest)
+        if (filterResult.status != HlsManifestFilterStatus.Filtered) {
+            return HlsPlaybackPreparerResult(data)
+        }
+
+        val rewrittenManifest = filterResult.content.rewriteRelativeUris(baseUri)
+        val session = LocalHlsPlaylistSession(rewrittenManifest)
+        return HlsPlaybackPreparerResult(
+            data = UriMediaData(session.playlistUri, data.headers, data.extraFiles),
+            session = session,
+        )
+    }
+}
+
+private class LocalHlsPlaylistSession(
+    content: String,
+) : HlsPlaybackProxySession {
+    private val closed = AtomicBoolean(false)
+    private val bytes = content.toByteArray(StandardCharsets.UTF_8)
+    private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+
+    val playlistUri: String = "http://127.0.0.1:${serverSocket.localPort}/playlist.m3u8"
+
+    private val thread = thread(
+        name = "HlsPlaylistProxy-${serverSocket.localPort}",
+        isDaemon = true,
+        start = true,
+    ) {
+        while (!closed.get()) {
+            try {
+                serverSocket.accept().use { socket ->
+                    val reader = BufferedReader(InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII))
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (line.isEmpty()) break
+                    }
+                    socket.getOutputStream().use { output ->
+                        output.write(responseHeader(bytes.size).toByteArray(StandardCharsets.US_ASCII))
+                        output.write(bytes)
+                        output.flush()
+                    }
+                }
+            } catch (e: SocketException) {
+                if (!closed.get()) {
+                    logger.warn(e) { "Failed to serve HLS playlist request" }
+                }
+            } catch (e: IOException) {
+                logger.warn(e) { "Failed to serve HLS playlist request" }
+            }
+        }
+    }
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            serverSocket.close()
+        }
+    }
+
+    @Suppress("unused")
+    private fun keepThreadReachable(): Thread = thread
+
+    private fun responseHeader(contentLength: Int): String {
+        return buildString {
+            append("HTTP/1.1 200 OK\r\n")
+            append("Content-Type: application/vnd.apple.mpegurl; charset=utf-8\r\n")
+            append("Content-Length: ").append(contentLength).append("\r\n")
+            append("Cache-Control: no-store\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+        }
+    }
+}
+
+private val logger = me.him188.ani.utils.logging.logger<PlatformHlsPlaybackPreparer>()
+
+private fun String.isCandidateHlsUri(): Boolean {
+    val uri = runCatching { URI(this) }.getOrNull() ?: return false
+    val scheme = uri.scheme?.lowercase()
+    return (scheme == "http" || scheme == "https") && lowercase().contains(".m3u8")
+}
+
+private fun String.rewriteRelativeUris(baseUri: URI): String {
+    return lineSequence().joinToString("\n") { line ->
+        when {
+            line.isBlank() -> line
+            line.startsWith("#EXT-X-KEY") || line.startsWith("#EXT-X-MAP") -> {
+                line.replace(URI_ATTRIBUTE_REGEX) { match ->
+                    val uri = match.groupValues[2]
+                    match.groupValues[1] + baseUri.resolveIfRelative(uri) + match.groupValues[3]
+                }
+            }
+            line.startsWith("#") -> line
+            else -> baseUri.resolveIfRelative(line)
+        }
+    } + if (endsWith('\n')) "\n" else ""
+}
+
+private fun URI.resolveIfRelative(uri: String): String {
+    val parsed = runCatching { URI(uri) }.getOrNull() ?: return uri
+    return if (parsed.isAbsolute) uri else resolve(parsed).toString()
+}
+
+private val URI_ATTRIBUTE_REGEX = Regex("""(URI=")([^"]+)(")""")

--- a/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.domain.media.hls
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.domain.foundation.HttpClientProvider
 import me.him188.ani.app.domain.foundation.ScopedHttpClientUserAgent
 import me.him188.ani.app.domain.foundation.get
@@ -25,7 +26,9 @@ import java.net.ServerSocket
 import java.net.SocketException
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -54,12 +57,24 @@ class PlatformHlsPlaybackPreparer(
         }
 
         val filterResult = HlsManifestFilter.filter(manifest)
-        if (filterResult.status != HlsManifestFilterStatus.Filtered) {
-            return HlsPlaybackPreparerResult(data)
+        val session = when {
+            filterResult.status == HlsManifestFilterStatus.Filtered -> {
+                LocalHlsPlaylistSession.static(filterResult.content.rewriteMediaPlaylistUris(baseUri))
+            }
+
+            filterResult.status == HlsManifestFilterStatus.Unsupported &&
+                filterResult.reason == "master_playlist" -> {
+                LocalHlsPlaylistSession.master(
+                    content = manifest,
+                    baseUri = baseUri,
+                    headers = data.headers,
+                    httpClientProvider = httpClientProvider,
+                )
+            }
+
+            else -> return HlsPlaybackPreparerResult(data)
         }
 
-        val rewrittenManifest = filterResult.content.rewriteRelativeUris(baseUri)
-        val session = LocalHlsPlaylistSession(rewrittenManifest)
         return HlsPlaybackPreparerResult(
             data = UriMediaData(session.playlistUri, data.headers, data.extraFiles),
             session = session,
@@ -68,11 +83,15 @@ class PlatformHlsPlaybackPreparer(
 }
 
 private class LocalHlsPlaylistSession(
-    content: String,
+    initialPlaylistContent: LocalPlaylistContent,
+    private val headers: Map<String, String>,
+    private val httpClientProvider: HttpClientProvider?,
 ) : HlsPlaybackProxySession {
     private val closed = AtomicBoolean(false)
-    private val bytes = content.toByteArray(StandardCharsets.UTF_8)
     private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+    private val nextRouteId = AtomicInteger(1)
+    private val remoteRoutes = ConcurrentHashMap<String, URI>()
+    private val initialContent = initialPlaylistContent.rewriteMasterPlaylistUrisIfNeeded()
 
     val playlistUri: String = "http://127.0.0.1:${serverSocket.localPort}/playlist.m3u8"
 
@@ -85,13 +104,31 @@ private class LocalHlsPlaylistSession(
             try {
                 serverSocket.accept().use { socket ->
                     val reader = BufferedReader(InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII))
+                    val requestLine = reader.readLine()
                     while (true) {
                         val line = reader.readLine() ?: break
                         if (line.isEmpty()) break
                     }
+                    val path = requestLine
+                        ?.substringAfter(" ", missingDelimiterValue = "")
+                        ?.substringBefore(" ", missingDelimiterValue = "")
+                        ?.substringBefore("?")
+
+                    val content = runCatching {
+                        contentFor(path ?: "/playlist.m3u8")
+                    }.getOrElse { e ->
+                        logger.warn(e) { "Failed to prepare HLS playlist proxy response" }
+                        null
+                    }
+
                     socket.getOutputStream().use { output ->
-                        output.write(responseHeader(bytes.size).toByteArray(StandardCharsets.US_ASCII))
-                        output.write(bytes)
+                        if (content == null) {
+                            output.write(errorResponseHeader().toByteArray(StandardCharsets.US_ASCII))
+                        } else {
+                            val bytes = content.toByteArray(StandardCharsets.UTF_8)
+                            output.write(responseHeader(bytes.size).toByteArray(StandardCharsets.US_ASCII))
+                            output.write(bytes)
+                        }
                         output.flush()
                     }
                 }
@@ -114,6 +151,76 @@ private class LocalHlsPlaylistSession(
     @Suppress("unused")
     private fun keepThreadReachable(): Thread = thread
 
+    private fun contentFor(path: String): String? {
+        if (path == "/playlist.m3u8") {
+            return initialContent.content
+        }
+        val remoteUri = remoteRoutes[path] ?: return null
+        val remoteContent = fetchRemote(remoteUri) ?: return null
+        return remoteContent.rewriteMasterPlaylistUrisIfNeeded().content
+    }
+
+    private fun fetchRemote(uri: URI): LocalPlaylistContent? {
+        val provider = httpClientProvider ?: return null
+        return runBlocking {
+            provider.get(ScopedHttpClientUserAgent.BROWSER).use {
+                val response = get(uri.toString()) {
+                    this@LocalHlsPlaylistSession.headers.forEach { (name, value) -> header(name, value) }
+                }
+                val finalUri = runCatching { URI(response.call.request.url.toString()) }.getOrDefault(uri)
+                LocalPlaylistContent(response.bodyAsText(), finalUri)
+            }
+        }
+    }
+
+    private fun LocalPlaylistContent.rewriteMasterPlaylistUrisIfNeeded(): LocalPlaylistContent {
+        val filterResult = HlsManifestFilter.filter(content)
+        val rewrittenContent = when {
+            filterResult.status == HlsManifestFilterStatus.Filtered -> {
+                filterResult.content.rewriteMediaPlaylistUris(baseUri)
+            }
+
+            filterResult.status == HlsManifestFilterStatus.Unsupported &&
+                filterResult.reason == "master_playlist" -> {
+                content.rewriteMasterPlaylistUris(baseUri)
+            }
+
+            else -> {
+                content.rewriteMediaPlaylistUris(baseUri)
+            }
+        }
+        return copy(content = rewrittenContent)
+    }
+
+    private fun String.rewriteMasterPlaylistUris(baseUri: URI): String {
+        return lineSequence().joinToString("\n") { line ->
+            when {
+                line.startsWith("#EXT-X-MEDIA") || line.startsWith("#EXT-X-I-FRAME-STREAM-INF") -> {
+                    line.replace(URI_ATTRIBUTE_REGEX) { match ->
+                        val uri = baseUri.resolveIfRelative(match.groupValues[2])
+                        match.groupValues[1] + localPlaylistUri(uri) + match.groupValues[3]
+                    }
+                }
+
+                line.startsWith("#") -> {
+                    line.replace(URI_ATTRIBUTE_REGEX) { match ->
+                        val uri = baseUri.resolveIfRelative(match.groupValues[2])
+                        match.groupValues[1] + uri + match.groupValues[3]
+                    }
+                }
+
+                line.isBlank() -> line
+                else -> localPlaylistUri(baseUri.resolveIfRelative(line))
+            }
+        } + if (endsWith('\n')) "\n" else ""
+    }
+
+    private fun localPlaylistUri(remoteUri: String): String {
+        val route = "/playlist/${nextRouteId.getAndIncrement()}.m3u8"
+        remoteRoutes[route] = URI(remoteUri)
+        return "http://127.0.0.1:${serverSocket.localPort}$route"
+    }
+
     private fun responseHeader(contentLength: Int): String {
         return buildString {
             append("HTTP/1.1 200 OK\r\n")
@@ -124,9 +231,47 @@ private class LocalHlsPlaylistSession(
             append("\r\n")
         }
     }
+
+    private fun errorResponseHeader(): String {
+        return buildString {
+            append("HTTP/1.1 502 Bad Gateway\r\n")
+            append("Content-Length: 0\r\n")
+            append("Cache-Control: no-store\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+        }
+    }
+
+    companion object {
+        fun static(content: String): LocalHlsPlaylistSession {
+            return LocalHlsPlaylistSession(
+                initialPlaylistContent = LocalPlaylistContent(content, URI("http://127.0.0.1/")),
+                headers = emptyMap(),
+                httpClientProvider = null,
+            )
+        }
+
+        fun master(
+            content: String,
+            baseUri: URI,
+            headers: Map<String, String>,
+            httpClientProvider: HttpClientProvider,
+        ): LocalHlsPlaylistSession {
+            return LocalHlsPlaylistSession(
+                initialPlaylistContent = LocalPlaylistContent(content, baseUri),
+                headers = headers,
+                httpClientProvider = httpClientProvider,
+            )
+        }
+    }
 }
 
 private val logger = me.him188.ani.utils.logging.logger<PlatformHlsPlaybackPreparer>()
+
+private data class LocalPlaylistContent(
+    val content: String,
+    val baseUri: URI,
+)
 
 private fun String.isCandidateHlsUri(): Boolean {
     val uri = runCatching { URI(this) }.getOrNull() ?: return false
@@ -134,7 +279,7 @@ private fun String.isCandidateHlsUri(): Boolean {
     return (scheme == "http" || scheme == "https") && lowercase().contains(".m3u8")
 }
 
-private fun String.rewriteRelativeUris(baseUri: URI): String {
+private fun String.rewriteMediaPlaylistUris(baseUri: URI): String {
     return lineSequence().joinToString("\n") { line ->
         when {
             line.isBlank() -> line

--- a/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
+++ b/app/shared/app-data/src/jvmMain/kotlin/domain/media/hls/PlatformHlsPlaybackPreparer.kt
@@ -56,24 +56,31 @@ class PlatformHlsPlaybackPreparer(
             return HlsPlaybackPreparerResult(data)
         }
 
-        val filterResult = HlsManifestFilter.filter(manifest, baseUri.toString())
-        val session = when {
-            filterResult.status == HlsManifestFilterStatus.Filtered -> {
-                LocalHlsPlaylistSession.static(filterResult.content.rewriteMediaPlaylistUris(baseUri))
-            }
+        val session = try {
+            val filterResult = HlsManifestFilter.filter(manifest, baseUri.toString())
+            when {
+                filterResult.status == HlsManifestFilterStatus.Filtered -> {
+                    LocalHlsPlaylistSession.static(filterResult.content.rewriteMediaPlaylistUris(baseUri))
+                }
 
-            filterResult.status == HlsManifestFilterStatus.Unsupported &&
-                filterResult.reason == "master_playlist" -> {
-                LocalHlsPlaylistSession.master(
-                    content = manifest,
-                    baseUri = baseUri,
-                    headers = data.headers,
-                    httpClientProvider = httpClientProvider,
-                )
-            }
+                filterResult.status == HlsManifestFilterStatus.Unsupported &&
+                    filterResult.reason == "master_playlist" -> {
+                    LocalHlsPlaylistSession.master(
+                        content = manifest,
+                        baseUri = baseUri,
+                        headers = data.headers,
+                        httpClientProvider = httpClientProvider,
+                    )
+                }
 
-            else -> return HlsPlaybackPreparerResult(data)
-        }
+                else -> null
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.warn(e) { "Failed to prepare HLS playback proxy; falling back to original media data" }
+            null
+        } ?: return HlsPlaybackPreparerResult(data)
 
         return HlsPlaybackPreparerResult(
             data = UriMediaData(session.playlistUri, data.headers, data.extraFiles),

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -280,6 +280,8 @@
     <string name="settings_player_auto_skip_op_ed">自动跳过 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只对 BT 数据源的部分资源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失败时自动切换资源</string>
+    <string name="settings_player_experimental_hls_segment_filter">插播片段过滤（实验性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">尝试过滤在线播放列表中的插播片段。可能不适用于所有视频源，识别错误时可能跳过正常内容。</string>
     <string name="settings_player_long_press_fast_forward_speed">长按快进速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">长按快进时的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -280,8 +280,8 @@
     <string name="settings_player_auto_skip_op_ed">自动跳过 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只对 BT 数据源的部分资源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失败时自动切换资源</string>
-    <string name="settings_player_experimental_hls_segment_filter">插播片段过滤（实验性）</string>
-    <string name="settings_player_experimental_hls_segment_filter_description">尝试过滤在线播放列表中的插播片段。可能不适用于所有视频源，识别错误时可能跳过正常内容。</string>
+    <string name="settings_player_experimental_hls_segment_filter">过滤贴片广告（实验性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">尝试过滤部分在线源插入的贴片广告。只对以独立片段插入的广告有效，识别错误时可能跳过正常内容。</string>
     <string name="settings_player_long_press_fast_forward_speed">长按快进速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">长按快进时的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -265,8 +265,8 @@
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只對 BT 數據源的部分資源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失敗時自動切換資源</string>
-    <string name="settings_player_experimental_hls_segment_filter">插播片段過濾（實驗性）</string>
-    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾線上播放列表中的插播片段。可能不適用於所有影片源，識別錯誤時可能跳過正常內容。</string>
+    <string name="settings_player_experimental_hls_segment_filter">過濾貼片廣告（實驗性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾部分線上來源插入的貼片廣告。只對以獨立片段插入的廣告有效，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按快進速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">長按快進時的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -265,6 +265,8 @@
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只對 BT 數據源的部分資源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失敗時自動切換資源</string>
+    <string name="settings_player_experimental_hls_segment_filter">插播片段過濾（實驗性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾線上播放列表中的插播片段。可能不適用於所有影片源，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按快進速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">長按快進時的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -265,6 +265,8 @@
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">僅對 BT 資料源的部分資源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失敗時自動切換資源</string>
+    <string name="settings_player_experimental_hls_segment_filter">插播片段過濾（實驗性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾線上播放列表中的插播片段。可能不適用於所有影片源，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按快進速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">長按快進時的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -265,8 +265,8 @@
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">僅對 BT 資料源的部分資源有效</string>
     <string name="settings_player_auto_switch_media_on_error">播放失敗時自動切換資源</string>
-    <string name="settings_player_experimental_hls_segment_filter">插播片段過濾（實驗性）</string>
-    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾線上播放列表中的插播片段。可能不適用於所有影片源，識別錯誤時可能跳過正常內容。</string>
+    <string name="settings_player_experimental_hls_segment_filter">過濾貼片廣告（實驗性）</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾部分線上來源插入的貼片廣告。僅對以獨立片段插入的廣告有效，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按快進速度</string>
     <string name="settings_player_long_press_fast_forward_speed_description">長按快進時的速度倍率</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -267,6 +267,8 @@
     <string name="settings_player_auto_skip_op_ed">Automatically skip OP and ED</string>
     <string name="settings_player_auto_skip_op_ed_description">Only works for some resources from BT data sources</string>
     <string name="settings_player_auto_switch_media_on_error">Automatically switch resources on playback failure</string>
+    <string name="settings_player_experimental_hls_segment_filter">Inserted segment filtering (experimental)</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">Attempts to filter inserted segments in online HLS playlists. It may not work for all sources and incorrect detection may skip normal content.</string>
     <string name="settings_player_long_press_fast_forward_speed">Long-press fast-forward speed</string>
     <string name="settings_player_long_press_fast_forward_speed_description">Speed when long-pressing to fast-forward</string>
     <string name="settings_storage_title">Storage settings</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -267,8 +267,8 @@
     <string name="settings_player_auto_skip_op_ed">Automatically skip OP and ED</string>
     <string name="settings_player_auto_skip_op_ed_description">Only works for some resources from BT data sources</string>
     <string name="settings_player_auto_switch_media_on_error">Automatically switch resources on playback failure</string>
-    <string name="settings_player_experimental_hls_segment_filter">Inserted segment filtering (experimental)</string>
-    <string name="settings_player_experimental_hls_segment_filter_description">Attempts to filter inserted segments in online HLS playlists. It may not work for all sources and incorrect detection may skip normal content.</string>
+    <string name="settings_player_experimental_hls_segment_filter">Filter inserted ads (experimental)</string>
+    <string name="settings_player_experimental_hls_segment_filter_description">Attempts to filter inserted ads from some online sources. Only works when ads are inserted as separate segments; incorrect detection may skip normal content.</string>
     <string name="settings_player_long_press_fast_forward_speed">Long-press fast-forward speed</string>
     <string name="settings_player_long_press_fast_forward_speed_description">Speed when long-pressing to fast-forward</string>
     <string name="settings_storage_title">Storage settings</string>

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -44,6 +44,8 @@ import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
+import me.him188.ani.app.domain.media.hls.HlsPlaybackPreparer
+import me.him188.ani.app.domain.media.hls.NoopHlsPlaybackPreparer
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
 import me.him188.ani.app.domain.media.resolver.IosWebMediaResolver
 import me.him188.ani.app.domain.media.resolver.LocalFileUriMediaResolver
@@ -303,6 +305,7 @@ fun getIosModules(
     // TODO(#3039): Add an iOS HLS playback preparer after the AVKit/localhost proxy path
     // can be tested on macOS or iOS hardware. The JVM preparer uses java.net and is only
     // registered by Android/Desktop modules, so iOS intentionally falls back to no-op for now.
+    single<HlsPlaybackPreparer> { NoopHlsPlaybackPreparer }
     single<MediaSaveDirProvider> {
         object : MediaSaveDirProvider {
             override val saveDir: String

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -300,6 +300,9 @@ fun getIosModules(
     single<MediampPlayerFactory<*>> {
         AVKitMediampPlayerFactory()
     }
+    // TODO(#3039): Add an iOS HLS playback preparer after the AVKit/localhost proxy path
+    // can be tested on macOS or iOS hardware. The JVM preparer uses java.net and is only
+    // registered by Android/Desktop modules, so iOS intentionally falls back to no-op for now.
     single<MediaSaveDirProvider> {
         object : MediaSaveDirProvider {
             override val saveDir: String

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -1011,9 +1011,6 @@ class EpisodeViewModel(
         webCaptchaCoordinator.cancelAutoResolutionRequests()
         backgroundScope.launch(NonCancellable + CoroutineName("EpisodeViewModel#onCleared")) {
             fetchPlayState.onClose()
-            withContext(Dispatchers.Main) {
-                player.stopPlayback()
-            }
         }
     }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
@@ -70,6 +70,8 @@ import me.him188.ani.app.ui.lang.settings_player_auto_play_next
 import me.him188.ani.app.ui.lang.settings_player_auto_skip_op_ed
 import me.him188.ani.app.ui.lang.settings_player_auto_skip_op_ed_description
 import me.him188.ani.app.ui.lang.settings_player_auto_switch_media_on_error
+import me.him188.ani.app.ui.lang.settings_player_experimental_hls_segment_filter
+import me.him188.ani.app.ui.lang.settings_player_experimental_hls_segment_filter_description
 import me.him188.ani.app.ui.lang.settings_player_enable_regex_filter
 import me.him188.ani.app.ui.lang.settings_player_fullscreen_always_show
 import me.him188.ani.app.ui.lang.settings_player_fullscreen_auto_hide
@@ -504,6 +506,15 @@ fun SettingsScope.PlayerGroup(
                 videoScaffoldConfig.update(config.copy(autoSwitchMediaOnPlayerError = it))
             },
             title = { Text(stringResource(Lang.settings_player_auto_switch_media_on_error)) },
+        )
+        HorizontalDividerItem()
+        SwitchItem(
+            checked = config.enableExperimentalHlsSegmentFiltering,
+            onCheckedChange = {
+                videoScaffoldConfig.update(config.copy(enableExperimentalHlsSegmentFiltering = it))
+            },
+            title = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter)) },
+            description = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter_description)) },
         )
         HorizontalDividerItem()
         DropdownItem(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
@@ -508,15 +508,17 @@ fun SettingsScope.PlayerGroup(
             title = { Text(stringResource(Lang.settings_player_auto_switch_media_on_error)) },
         )
         HorizontalDividerItem()
-        SwitchItem(
-            checked = config.enableExperimentalHlsSegmentFiltering,
-            onCheckedChange = {
-                videoScaffoldConfig.update(config.copy(enableExperimentalHlsSegmentFiltering = it))
-            },
-            title = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter)) },
-            description = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter_description)) },
-        )
-        HorizontalDividerItem()
+        if (!LocalPlatform.current.isIos()) {
+            SwitchItem(
+                checked = config.enableExperimentalHlsSegmentFiltering,
+                onCheckedChange = {
+                    videoScaffoldConfig.update(config.copy(enableExperimentalHlsSegmentFiltering = it))
+                },
+                title = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter)) },
+                description = { Text(stringResource(Lang.settings_player_experimental_hls_segment_filter_description)) },
+            )
+            HorizontalDividerItem()
+        }
         DropdownItem(
             selected = { config.fastForwardSpeed },
             values = { listOf(1.5f, 2f, 2.5f, 3f) },

--- a/utils/http-downloader/src/commonMain/kotlin/m3u/M3u8Parser.kt
+++ b/utils/http-downloader/src/commonMain/kotlin/m3u/M3u8Parser.kt
@@ -139,6 +139,7 @@ data class MediaSegment(
     val byteRange: ByteRange? = null,
     val encryption: MediaSegmentEncryption? = null,
     val tags: Map<String, String> = emptyMap(),
+    val sourceRange: M3u8SourceRange? = null,
 )
 
 data class MediaSegmentEncryption(
@@ -147,6 +148,11 @@ data class MediaSegmentEncryption(
     val iv: String? = null,
     val keyFormat: String? = null,
     val keyFormatVersions: String? = null,
+)
+
+data class M3u8SourceRange(
+    val startLine: Int,
+    val endLine: Int,
 )
 
 /**
@@ -174,8 +180,10 @@ data class VariantStream(
  */
 object DefaultM3u8Parser : M3u8Parser {
     override fun parse(content: String, baseUrl: String): M3u8Playlist {
-        val lines = content.lines().filter { it.isNotBlank() }
-        if (lines.isEmpty() || !lines[0].trimStart().startsWith("#EXTM3U")) {
+        val lines = content.lines()
+            .mapIndexed { index, text -> M3u8SourceLine(index + 1, text) }
+            .filter { it.text.isNotBlank() }
+        if (lines.isEmpty() || !lines[0].text.trimStart().startsWith("#EXTM3U")) {
             throw M3uFormatException("Invalid M3U8 format, must start with #EXTM3U")
         }
 
@@ -196,12 +204,14 @@ object DefaultM3u8Parser : M3u8Parser {
         var currentSegmentByteRange: ByteRange? = null
         val currentSegmentTags = mutableMapOf<String, String>()
         var currentSegmentEncryption: MediaSegmentEncryption? = null
+        var currentSegmentSourceStartLine: Int? = null
 
         // For current variant being built
         var currentVariantAttributes = mutableMapOf<String, String>()
 
         while (i < lines.size) {
-            val line = lines[i++].trim()
+            val sourceLine = lines[i++]
+            val line = sourceLine.text.trim()
 
             if (line.startsWith("#")) {
                 // This is a tag
@@ -226,17 +236,20 @@ object DefaultM3u8Parser : M3u8Parser {
                         // Format: #EXTINF:duration[,title]
                         val valueStr = line.substringAfter(":")
                         currentSegmentDuration = valueStr.substringBefore(",").toFloat()
+                        currentSegmentSourceStartLine = currentSegmentSourceStartLine ?: sourceLine.number
                         if (valueStr.contains(",")) {
                             currentSegmentTitle = valueStr.substringAfter(",").trim()
                         }
                     }
 
-                    line.startsWith("#EXT-X-DISCONTINUITY") -> {
+                    line == "#EXT-X-DISCONTINUITY" -> {
                         currentSegmentDiscontinuity = true
+                        currentSegmentSourceStartLine = currentSegmentSourceStartLine ?: sourceLine.number
                     }
 
                     line.startsWith("#EXT-X-BYTERANGE:") -> {
                         currentSegmentByteRange = parseByteRange(line.substringAfter(":").trim())
+                        currentSegmentSourceStartLine = currentSegmentSourceStartLine ?: sourceLine.number
                     }
 
                     line.startsWith("#EXT-X-KEY:") -> {
@@ -272,6 +285,7 @@ object DefaultM3u8Parser : M3u8Parser {
                             if (currentSegmentDuration != null) {
                                 // Tag belongs to the current segment
                                 currentSegmentTags[tagName] = tagValue
+                                currentSegmentSourceStartLine = currentSegmentSourceStartLine ?: sourceLine.number
                             } else {
                                 // Tag belongs to the playlist
                                 tags[tagName] = tagValue
@@ -279,6 +293,7 @@ object DefaultM3u8Parser : M3u8Parser {
                         } else {
                             if (currentSegmentDuration != null) {
                                 currentSegmentTags[line] = ""
+                                currentSegmentSourceStartLine = currentSegmentSourceStartLine ?: sourceLine.number
                             } else {
                                 tags[line] = ""
                             }
@@ -321,6 +336,10 @@ object DefaultM3u8Parser : M3u8Parser {
                             byteRange = currentSegmentByteRange,
                             encryption = currentSegmentEncryption,
                             tags = currentSegmentTags.toMap(),
+                            sourceRange = M3u8SourceRange(
+                                startLine = currentSegmentSourceStartLine ?: sourceLine.number,
+                                endLine = sourceLine.number,
+                            ),
                         ),
                     )
 
@@ -330,6 +349,7 @@ object DefaultM3u8Parser : M3u8Parser {
                     currentSegmentDiscontinuity = false
                     currentSegmentByteRange = null
                     currentSegmentTags.clear()
+                    currentSegmentSourceStartLine = null
                 }
             }
         }
@@ -420,6 +440,11 @@ object DefaultM3u8Parser : M3u8Parser {
         return ByteRange(length, offset)
     }
 }
+
+private data class M3u8SourceLine(
+    val number: Int,
+    val text: String,
+)
 
 private fun rewriteKeyLine(
     line: String,

--- a/utils/http-downloader/src/commonTest/kotlin/m3u/DefaultM3u8ParserTest.kt
+++ b/utils/http-downloader/src/commonTest/kotlin/m3u/DefaultM3u8ParserTest.kt
@@ -160,6 +160,47 @@ class DefaultM3u8ParserTest {
     }
 
     @Test
+    fun `parse - discontinuity sequence is not segment discontinuity`() {
+        val content = """
+            #EXTM3U
+            #EXT-X-VERSION:4
+            #EXT-X-DISCONTINUITY-SEQUENCE:7
+            #EXT-X-TARGETDURATION:10
+            #EXTINF:10.0,
+            segment0.ts
+            #EXT-X-ENDLIST
+        """.trimIndent()
+
+        val playlist = parser.parse(content, "http://example.com")
+
+        assertTrue(playlist is M3u8Playlist.MediaPlaylist)
+        assertEquals(1, playlist.segments.size)
+        assertFalse(playlist.segments.single().isDiscontinuity)
+    }
+
+    @Test
+    fun `parse - media segment source range`() {
+        val content = """
+            #EXTM3U
+            #EXT-X-VERSION:4
+            #EXT-X-TARGETDURATION:10
+            #EXTINF:10.0,
+            segment0.ts
+            #EXT-X-DISCONTINUITY
+            #EXTINF:10.0,
+            #EXT-X-BYTERANGE:75232@0
+            segment1.ts
+            #EXT-X-ENDLIST
+        """.trimIndent()
+
+        val playlist = parser.parse(content, "http://example.com")
+
+        assertTrue(playlist is M3u8Playlist.MediaPlaylist)
+        assertEquals(M3u8SourceRange(startLine = 4, endLine = 5), playlist.segments[0].sourceRange)
+        assertEquals(M3u8SourceRange(startLine = 6, endLine = 9), playlist.segments[1].sourceRange)
+    }
+
+    @Test
     fun `parse - media playlist with encryption key`() {
         val content = """
             #EXTM3U


### PR DESCRIPTION
## 概要

实现 #3039 中提出的 HLS manifest 过滤方案。

本 PR 添加一个默认关闭的实验性设置，用于尝试过滤部分在线源插入的贴片广告。该功能只作用于播放链路：在 `MediaDataProvider.open(...)` 返回 `UriMediaData` 后、`PlayerSession` 调用 `player.setMediaData(...)` 前处理 HLS 播放地址。

播放器后端仍然接收普通 `UriMediaData`。media provider、下载、缓存、ExoPlayer、VLC、AVKit API 不变。

<img width="1236" height="361" alt="preview-transparent-trimmed" src="https://github.com/user-attachments/assets/d1e54e53-db8b-4133-924e-de2c997ffcce" />

## 用户界面

设置项位于「设置 → 播放器和弹幕过滤」，默认关闭。

<img width="1271" height="1362" alt="animeko-current" src="https://github.com/user-attachments/assets/a1a3d7ae-86a4-4081-a11e-4d2babe302d3" />

## 实现

新增 `HlsPlaybackPreparer`，由 `PlayerSession.loadMedia` 在设置开启时调用。

Android 和 Desktop 注册 JVM 实现。该实现会拉取原始 `.m3u8`，根据 playlist 类型处理：

- media playlist：执行 `HlsManifestFilter`，命中过滤规则后由本地 playlist proxy 提供给播放器；
- master playlist：由本地 playlist proxy 改写 variant playlist URL，variant playlist 按需拉取、过滤和改写。

proxy 只服务和改写 playlist，不转发媒体分片。playlist 中的相对 URI 会解析为原始源的绝对 URI，让播放器继续直接请求远端媒体资源。

## 过滤范围

当前规则偏保守，只处理带 `#EXT-X-ENDLIST` 的 media playlist，即不会继续追加 segment 的播放列表。以下情况会跳过过滤：

- live 或没有 `#EXT-X-ENDLIST` 的 playlist；
- 没有 `#EXT-X-DISCONTINUITY` 边界的 playlist；
- AES-128 key 未显式声明 IV；
- byte range 未显式声明 offset。

候选片段组由 playlist 结构判断，包括重复短片段组、夹在长片段之间的短片段组、密集 playlist 中的极短片段组、路径特征、序号孤岛等。规则不依赖源名称。

## 平台状态

Android 和 Desktop 已接入。

iOS 暂不显示该开关。当前实现依赖 JVM 侧本地 proxy；AVKit + localhost proxy 路径需要在 macOS/iOS 设备上验证后再启用。

## 测试

添加了以下测试：

- 纯 manifest 过滤测试；
- 本地 playlist proxy 测试，覆盖 media playlist、master playlist、URI 改写和重复过滤回归；
- `PlayerSession` 生命周期测试，覆盖 proxy session 的持有和释放。

本地验证：

```bash
./gradlew :app:shared:app-data:desktopTest --tests 'me.him188.ani.app.domain.media.hls.*' --tests 'me.him188.ani.app.domain.episode.PlayerSessionHlsPlaybackPreparerTest'
./gradlew :app:android:compileDefaultDebugKotlin
```

Refs #3039
