### PR TITLE
Avoid logging Bangumi access token

### DIFF
--- a/datasource/bangumi/src/commonMain/kotlin/BangumiClient.kt
+++ b/datasource/bangumi/src/commonMain/kotlin/BangumiClient.kt
@@ -130,7 +130,7 @@ class BangumiClientImpl(
             return null
         }
         if (!HttpTokenChecker.isValidToken(accessToken)) {
-            logger.error { "Invalid access token: $accessToken" }
+            logger.error { "Invalid access token" }
             return null
         }
         try {


### PR DESCRIPTION
### 修改内容

修复 Bangumi token 校验失败时将原始 access token 写入日志的问题。

原逻辑在 access token 无效时会记录原始 token。access token 属于敏感凭据，不应出现在日志中。修改后仅保留错误上下文，不再输出 token 原文。

### 修改原因

日志可能被本地诊断、错误上报或其他调试流程收集。如果其中包含 access token，可能造成凭据泄露风险。

本次修改不改变 token 校验逻辑，只移除日志中的敏感信息。

### 验证

* 已确认 `Invalid access token` 日志不再包含原始 access token。
