### PR TITLE
Fix proxy authorization header

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
@@ -66,6 +66,8 @@ import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatform
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.coroutines.CoroutineContext
 
 interface MediaSourceManager { // available by inject
@@ -371,4 +373,5 @@ fun ProxyConfig.toClientProxyConfig() = ClientProxyConfig(
     authorization = authorization?.toHeader(),
 )
 
-fun ProxyAuthorization.toHeader(): String = "Basic ${"$username:$password"}"
+@OptIn(ExperimentalEncodingApi::class)
+fun ProxyAuthorization.toHeader(): String = "Basic ${Base64.encode("$username:$password".encodeToByteArray())}"

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/fetch/ProxyAuthorizationTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/fetch/ProxyAuthorizationTest.kt
@@ -1,0 +1,15 @@
+package me.him188.ani.app.domain.media.fetch
+
+import me.him188.ani.app.data.models.preference.ProxyAuthorization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProxyAuthorizationTest {
+    @Test
+    fun `toHeader encodes basic credentials`() {
+        assertEquals(
+            "Basic dXNlcjpwYXNz",
+            ProxyAuthorization(username = "user", password = "pass").toHeader(),
+        )
+    }
+}

--- a/utils/ktor-client/src/commonMain/kotlin/ClientProxyConfig.kt
+++ b/utils/ktor-client/src/commonMain/kotlin/ClientProxyConfig.kt
@@ -23,10 +23,7 @@ import io.ktor.http.URLParserException
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import io.ktor.http.takeFrom
-import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.Serializable
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 @Serializable
 data class ClientProxyConfig(
@@ -40,7 +37,7 @@ data class ClientProxyConfig(
     /**
      * ProxyAuthorization header
      *
-     * "Basic username:password"
+     * "Basic <base64(username:password)>"
      */
     val authorization: String? = null
 )
@@ -78,7 +75,6 @@ fun HttpClientConfig<*>.userAgent(
     }
 }
 
-@OptIn(ExperimentalEncodingApi::class)
 fun HttpClientConfig<*>.proxy(
     config: ClientProxyConfig?,
 ) {
@@ -86,9 +82,10 @@ fun HttpClientConfig<*>.proxy(
         this.setProxy(config)
     }
 
-    defaultRequest {
-        val credentials = Base64.encode("jetbrains:foobar".toByteArray())
-        header(HttpHeaders.ProxyAuthorization, "Basic $credentials")
+    config?.authorization?.let { authorization ->
+        defaultRequest {
+            header(HttpHeaders.ProxyAuthorization, authorization)
+        }
     }
 }
 


### PR DESCRIPTION
### 修改内容

修复代理认证请求头生成逻辑。

此前 `ClientProxyConfig` 中会固定写入硬编码的 `jetbrains:foobar`，而不是使用实际配置中的代理认证信息。现在改为仅在 `config.authorization` 存在时写入 `Proxy-Authorization`。

同时修正 `ProxyAuthorization` 到 Basic header 的转换逻辑，将 `username:password` 正确 Base64 编码后生成：

```text
Proxy-Authorization: Basic <base64(username:password)>
```

并新增轻量测试覆盖 `user:pass` 到 `Basic dXNlcjpwYXNz` 的转换结果。

### 修改原因

代理认证请求头应当来自用户实际配置，不应使用硬编码示例值。否则可能导致配置了代理认证的场景无法正常通过认证，也会在请求中发送无效的固定凭据。

### 验证

* 已运行 `git diff --check`，通过。
* 已确认仓库中不再存在 `jetbrains:foobar`。
* 已新增测试覆盖 Basic proxy authorization header 的编码结果。
