### PR TITLE
Improve episode long press feedback

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeListSection.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeListSection.kt
@@ -12,7 +12,10 @@ package me.him188.ani.app.ui.subject.episode.details
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -74,6 +77,7 @@ import kotlinx.coroutines.launch
 import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
 import me.him188.ani.app.data.models.episode.displayName
 import me.him188.ani.app.domain.media.cache.EpisodeCacheStatus
+import me.him188.ani.app.ui.foundation.LongClickProgressFill
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.icons.PlayingIcon
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
@@ -422,6 +426,7 @@ private fun EpisodeCard(
     modifier: Modifier = Modifier,
 ) {
     val isWatched = episode.collectionType.isDoneOrDropped()
+    val interactionSource = remember { MutableInteractionSource() }
 
     Card(
         colors = CardDefaults.cardColors(
@@ -437,47 +442,56 @@ private fun EpisodeCard(
             .height(64.dp)
             .aspectRatio(16f / 10)
             .combinedClickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
                 onClick = onClick,
                 onLongClick = onLongClick,
             ),
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp, vertical = 8.dp),
-        ) {
-            Column(
-                modifier = Modifier.align(Alignment.CenterStart),
+        Box(Modifier.fillMaxSize()) {
+            LongClickProgressFill(
+                interactionSource = interactionSource,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                modifier = Modifier.matchParentSize(),
+            )
+            Box(
+                modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp, vertical = 8.dp),
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                Column(
+                    modifier = Modifier.align(Alignment.CenterStart),
                 ) {
-                    if (isPlaying) {
-                        PlayingIcon(width = 20.dp, height = 12.dp)
-                        Spacer(Modifier.width(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (isPlaying) {
+                            PlayingIcon(width = 20.dp, height = 12.dp)
+                            Spacer(Modifier.width(4.dp))
+                        }
+                        Text(
+                            episode.episodeInfo.sort.toString(),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = if (isPlaying) {
+                                MaterialTheme.colorScheme.primary
+                            } else if (isWatched) {
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                            } else {
+                                LocalContentColor.current
+                            },
+                        )
                     }
+                    Spacer(Modifier.height(4.dp))
                     Text(
-                        episode.episodeInfo.sort.toString(),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = if (isPlaying) {
-                            MaterialTheme.colorScheme.primary
-                        } else if (isWatched) {
+                        episode.episodeInfo.displayName,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = if (isWatched) {
                             MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                         } else {
-                            LocalContentColor.current
+                            MaterialTheme.colorScheme.onSurfaceVariant
                         },
                     )
                 }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    episode.episodeInfo.displayName,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = if (isWatched) {
-                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                )
             }
         }
     }
@@ -495,39 +509,53 @@ private fun EpisodeListSectionItem(
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ListItem(
-        colors = ListItemDefaults.colors(
-            containerColor = when {
-                isPlaying -> MaterialTheme.colorScheme.primaryContainer
-                isWatched -> MaterialTheme.colorScheme.surfaceContainer
-                else -> MaterialTheme.colorScheme.surfaceContainer
-            },
-        ),
-        headlineContent = {
-            Text(
-                text = "${episode.episodeInfo.sort}  ${episode.episodeInfo.displayName}",
-                color = when {
-                    isPlaying -> MaterialTheme.colorScheme.primary
-                    isWatched -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-                    else -> LocalContentColor.current
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        trailingContent = {
-            if (isPlaying) {
-                PlayingIcon()
-            }
-        },
+    val interactionSource = remember { MutableInteractionSource() }
+    val shape = MaterialTheme.shapes.small
+    val containerColor = when {
+        isPlaying -> MaterialTheme.colorScheme.primaryContainer
+        isWatched -> MaterialTheme.colorScheme.surfaceContainer
+        else -> MaterialTheme.colorScheme.surfaceContainer
+    }
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .clip(MaterialTheme.shapes.small)
+            .clip(shape)
+            .background(containerColor)
             .combinedClickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
                 onClick = onClick,
                 onLongClick = onLongClick,
             ),
-    )
+    ) {
+        LongClickProgressFill(
+            interactionSource = interactionSource,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+            modifier = Modifier.matchParentSize(),
+        )
+        ListItem(
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            headlineContent = {
+                Text(
+                    text = "${episode.episodeInfo.sort}  ${episode.episodeInfo.displayName}",
+                    color = when {
+                        isPlaying -> MaterialTheme.colorScheme.primary
+                        isWatched -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        else -> LocalContentColor.current
+                    },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            trailingContent = {
+                if (isPlaying) {
+                    PlayingIcon()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }
 
 /**

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/EpisodeGrid.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/EpisodeGrid.kt
@@ -9,14 +9,18 @@
 
 package me.him188.ani.app.ui.subject.episode.details.components
 
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -40,13 +44,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
 import me.him188.ani.app.data.models.episode.displayName
 import me.him188.ani.app.domain.media.cache.EpisodeCacheStatus
+import me.him188.ani.app.ui.foundation.LongClickProgressFill
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.icons.PlayingIcon
 import me.him188.ani.app.ui.foundation.layout.plus
@@ -164,6 +168,7 @@ private fun EpisodeGridItem(
     modifier: Modifier = Modifier,
 ) {
     val isWatched = episode.collectionType.isDoneOrDropped()
+    val interactionSource = remember { MutableInteractionSource() }
     
     Card(
         colors = CardDefaults.cardColors(
@@ -179,46 +184,55 @@ private fun EpisodeGridItem(
             .fillMaxWidth()
             .height(72.dp)
             .combinedClickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
                 onClick = onClick,
-                onLongClick = onLongClick
+                onLongClick = onLongClick,
             ),
     ) {
-        Column(
-            modifier = Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
+        Box(Modifier.fillMaxSize()) {
+            LongClickProgressFill(
+                interactionSource = interactionSource,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+                modifier = Modifier.matchParentSize(),
+            )
+            Column(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                if (isPlaying) {
-                    PlayingIcon()
-                    Spacer(Modifier.width(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (isPlaying) {
+                        PlayingIcon()
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    Text(
+                        "${episode.episodeInfo.sort}",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = if (isPlaying) {
+                            MaterialTheme.colorScheme.primary
+                        } else if (isWatched) {
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        } else {
+                            LocalContentColor.current
+                        },
+                    )
                 }
                 Text(
-                    "${episode.episodeInfo.sort}",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = if (isPlaying) {
-                        MaterialTheme.colorScheme.primary
-                    } else if (isWatched) {
+                    episode.episodeInfo.displayName,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = if (isWatched) {
                         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                     } else {
-                        LocalContentColor.current
-                    }
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                 )
             }
-            Text(
-                episode.episodeInfo.displayName,
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                color = if (isWatched) {
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                }
-            )
         }
     }
 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/PaginatedEpisodeList.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/PaginatedEpisodeList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,7 +9,11 @@
 
 package me.him188.ani.app.ui.subject.episode.details.components
 
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
@@ -26,10 +30,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
 import me.him188.ani.app.data.models.episode.displayName
+import me.him188.ani.app.ui.foundation.LongClickProgressFill
 import me.him188.ani.app.ui.foundation.icons.PlayingIcon
 import me.him188.ani.app.ui.foundation.lists.PaginatedGroup
 import me.him188.ani.app.ui.foundation.lists.PaginatedList
@@ -118,42 +124,53 @@ private fun EpisodeDetailsListItem(
     modifier: Modifier = Modifier,
 ) {
     val isWatched = episode.collectionType.isDoneOrDropped()
+    val interactionSource = remember { MutableInteractionSource() }
+    val shape = MaterialTheme.shapes.small
+    val containerColor = if (isPlaying) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceContainer
+    }
 
-    ListItem(
-        colors = ListItemDefaults.colors(
-            containerColor = if (isPlaying) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else if (isWatched) {
-                MaterialTheme.colorScheme.surfaceContainer
-            } else {
-                MaterialTheme.colorScheme.surfaceContainer
-            },
-        ),
-        headlineContent = {
-            Text(
-                "${episode.episodeInfo.sort}  ${episode.episodeInfo.displayName}",
-                color = if (isPlaying) {
-                    MaterialTheme.colorScheme.primary
-                } else if (isWatched) {
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-                } else {
-                    LocalContentColor.current
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        trailingContent = {
-            if (isPlaying) {
-                PlayingIcon()
-            }
-        },
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .clip(MaterialTheme.shapes.small)
+            .clip(shape)
+            .background(containerColor)
             .combinedClickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
                 onClick = onClick,
                 onLongClick = onLongClick,
             ),
-    )
+    ) {
+        LongClickProgressFill(
+            interactionSource = interactionSource,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f),
+            modifier = Modifier.matchParentSize(),
+        )
+        ListItem(
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            headlineContent = {
+                Text(
+                    "${episode.episodeInfo.sort}  ${episode.episodeInfo.displayName}",
+                    color = if (isPlaying) {
+                        MaterialTheme.colorScheme.primary
+                    } else if (isWatched) {
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                    } else {
+                        LocalContentColor.current
+                    },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            trailingContent = {
+                if (isPlaying) {
+                    PlayingIcon()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/LongClickButtons.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/LongClickButtons.kt
@@ -1,14 +1,28 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 @file:Suppress("ERROR_SUPPRESSION")
 
 package me.him188.ani.app.ui.foundation
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -28,14 +42,23 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collectLatest
 import me.him188.ani.app.ui.foundation.text.ProvideTextStyleContentColor
 
 /**
@@ -86,7 +109,7 @@ import me.him188.ani.app.ui.foundation.text.ProvideTextStyleContentColor
 fun FilledTonalCombinedClickButton(
     onClick: () -> Unit,
     onClickLabel: String? = null,
-    onLongClick: (() -> Unit)? = {},
+    onLongClick: (() -> Unit)? = null,
     onLongClickLabel: String? = null,
     onDoubleClick: (() -> Unit)? = null,
     indication: Indication = LocalIndication.current,
@@ -169,7 +192,7 @@ fun FilledTonalCombinedClickButton(
 fun CombinedClickButton(
     onClick: () -> Unit,
     onClickLabel: String? = null,
-    onLongClick: (() -> Unit)? = {},
+    onLongClick: (() -> Unit)? = null,
     onLongClickLabel: String? = null,
     onDoubleClick: (() -> Unit)? = null,
     indication: Indication = LocalIndication.current,
@@ -210,16 +233,89 @@ fun CombinedClickButton(
             MaterialTheme.typography.labelLarge,
             contentColor,
         ) {
-            Row(
-                Modifier.defaultMinSize(
-                    minWidth = ButtonDefaults.MinWidth,
-                    minHeight = ButtonDefaults.MinHeight,
+            Box {
+                LongClickProgressFill(
+                    interactionSource = interactionSource,
+                    enabled = enabled && onLongClick != null,
+                    color = contentColor.copy(alpha = 0.12f),
+                    modifier = Modifier.matchParentSize(),
                 )
-                    .padding(contentPadding),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-                content = content,
-            )
+                Row(
+                    Modifier.defaultMinSize(
+                        minWidth = ButtonDefaults.MinWidth,
+                        minHeight = ButtonDefaults.MinHeight,
+                    )
+                        .padding(contentPadding),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = content,
+                )
+            }
         }
     }
+}
+
+@Composable
+fun LongClickProgressFill(
+    interactionSource: MutableInteractionSource,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    color: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.16f),
+) {
+    val progress by animateLongClickProgressAsState(interactionSource, enabled)
+    Box(
+        modifier.drawBehind {
+            if (progress > 0f) {
+                drawRect(
+                    color = color,
+                    size = Size(width = size.width * progress, height = size.height),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun animateLongClickProgressAsState(
+    interactionSource: MutableInteractionSource,
+    enabled: Boolean,
+): State<Float> {
+    val longPressTimeoutMillis = LocalViewConfiguration.current.longPressTimeoutMillis.toInt()
+    val progress = remember { Animatable(0f) }
+    val progressState = remember { mutableStateOf(0f) }
+
+    suspend fun animatePressProgress() {
+        progress.snapTo(0f)
+        progressState.value = 0f
+
+        progress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = longPressTimeoutMillis, easing = LinearEasing),
+        ) {
+            progressState.value = value
+        }
+        progressState.value = progress.value
+    }
+
+    suspend fun resetProgress() {
+        progress.snapTo(0f)
+        progressState.value = 0f
+    }
+
+    LaunchedEffect(interactionSource, enabled, longPressTimeoutMillis) {
+        if (!enabled) {
+            resetProgress()
+            return@LaunchedEffect
+        }
+
+        interactionSource.interactions.collectLatest { interaction ->
+            when (interaction) {
+                is PressInteraction.Press -> animatePressProgress()
+                is PressInteraction.Release -> resetProgress()
+                is PressInteraction.Cancel -> resetProgress()
+            }
+        }
+    }
+
+    return progressState
 }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/episode/list/EpisodeSortSquareButton.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/episode/list/EpisodeSortSquareButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,7 +9,6 @@
 
 package me.him188.ani.app.ui.subject.episode.list
 
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.widthIn
@@ -39,7 +38,6 @@ internal fun EpisodeSortSquareButton(
         onClick = onClick,
         onLongClick = onLongClick,
         modifier = modifier
-            .combinedClickable(onLongClick = onLongClick, onClick = onClick)
             .heightIn(min = 48.dp)
             .widthIn(min = 48.dp),
         shape = MaterialTheme.shapes.small,


### PR DESCRIPTION
  ## 变更内容

  优化剧集列表的长按交互反馈，让用户在长按标记观看状态时能看到明确的进度提示。

  - 新增通用的 `LongClickProgressFill`，在按住过程中显示线性进度填充
  - 为剧集卡片、宽屏列表项、分页剧集列表、底部弹窗网格项接入长按进度反馈
  - 统一复用同一个 `MutableInteractionSource`，保证点击、长按和视觉反馈状态一致
  - 长按释放或取消后立即清除进度，不保留额外回退动画
  - 移除 `EpisodeSortSquareButton` 上重复的点击修饰符，避免交互处理重复叠加

  ## 验证

  - 已通过相关 shared UI 模块的 Kotlin metadata 编译
  - 已完成 App 启动后的剧集列表长按交互测试
  
<img width="1250" height="742" alt="Kapture 2026-07-05 at 17 55 16" src="https://github.com/user-attachments/assets/762197b2-f8dc-49f0-8256-91bae72a45f2" />
