### PR TITLE
fix: 修复集合列表海报不显示

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -571,7 +571,7 @@ private fun SubjectCollectionEntity.toSubjectInfo(): SubjectInfo {
         nameCn = nameCn,
         summary = summary,
         nsfw = nsfw,
-        imageLarge = imageLarge,
+        imageLarge = staticSubjectImageLargeUrl(subjectId),
         totalEpisodes = totalEpisodes,
         airDate = airDate,
         tags = tags,
@@ -676,7 +676,7 @@ fun AniSubjectCollection.toEntity(
         nameCn = nameCn,
         summary = summary,
         nsfw = nsfw,
-        imageLarge = "https://api.bgm.tv/v0/subjects/${id}/image?type=large",
+        imageLarge = staticSubjectImageLargeUrl(id.toInt()),
         totalEpisodes = episodes.size,
         airDate = PackedDate.parseFromDate(airDate),
         aliases = aliases,
@@ -710,6 +710,9 @@ fun AniSubjectCollection.toEntity(
         cachedCharactersUpdated = 0,
     )
 }
+
+private fun staticSubjectImageLargeUrl(subjectId: Int): String =
+    "https://static.myani.org/bangumi/subjects/$subjectId/large"
 
 fun AniSubjectRelations.toSubjectRelationsEntity(): SubjectRelations {
     return SubjectRelations(

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -571,7 +571,7 @@ private fun SubjectCollectionEntity.toSubjectInfo(): SubjectInfo {
         nameCn = nameCn,
         summary = summary,
         nsfw = nsfw,
-        imageLarge = staticSubjectImageLargeUrl(subjectId),
+        imageLarge = imageLarge,
         totalEpisodes = totalEpisodes,
         airDate = airDate,
         tags = tags,

--- a/datasource/bangumi/src/commonMain/kotlin/BangumiClient.kt
+++ b/datasource/bangumi/src/commonMain/kotlin/BangumiClient.kt
@@ -322,7 +322,7 @@ class BangumiClientImpl(
 
     companion object {
         fun getSubjectImageUrl(id: Int, size: BangumiSubjectImageSize): String {
-            return "$BANGUMI_API_HOST/v0/subjects/${id}/image?type=${size.id.lowercase()}"
+            return "https://static.myani.org/bangumi/subjects/$id/${size.id.lowercase()}"
         }
     }
 }


### PR DESCRIPTION
Fixes #3107，我真等不及了每次看番个人列表都没封面显示，就动手修了一下。

在追 / 看过 / 想看等 subject collection 列表中，条目封面此前使用 Bangumi API 的图片重定向链接：

`api.bgm.tv/v0/subjects/{id}/image`

该链接在 Android 设备上可能出现超时，导致集合列表海报不显示；但 Ani 静态资源本身可以正常加载。

本 PR 将集合条目的封面地址改为 Ani 静态 subject cover URL，并在缓存的 collection entity 映射为 `SubjectInfo` 时进行规范化，避免已有本地缓存继续请求旧的 Bangumi 图片接口。

## 测试

-  `./gradlew.bat :app:shared:compileAndroidMain`
-  Android debug install，确认新的 collection cover 请求使用 `static.myani.org/bangumi/subjects/{id}/large`