### PR TITLE
Add configurable Bangumi OAuth domain

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/BangumiSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/BangumiSettings.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.models.preference
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+const val DEFAULT_BANGUMI_WEB_BASE_URL = "https://bgm.tv"
+
+@Serializable
+@Immutable
+data class BangumiSettings(
+    val webBaseUrl: String = DEFAULT_BANGUMI_WEB_BASE_URL,
+    @Suppress("PropertyName") @Transient val _placeholder: Int = 0,
+) {
+    companion object {
+        @Stable
+        val Default = BangumiSettings()
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/user/SettingsRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/user/SettingsRepository.kt
@@ -24,6 +24,7 @@ import me.him188.ani.app.data.models.danmaku.DanmakuConfigSerializer
 import me.him188.ani.app.data.models.danmaku.DanmakuFilterConfig
 import me.him188.ani.app.data.models.preference.AnalyticsSettings
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
+import me.him188.ani.app.data.models.preference.BangumiSettings
 import me.him188.ani.app.data.models.preference.DanmakuSettings
 import me.him188.ani.app.data.models.preference.DebugSettings
 import me.him188.ani.app.data.models.preference.MediaCacheSettings
@@ -80,6 +81,8 @@ interface SettingsRepository {
     val torrentPeerConfig: Settings<TorrentPeerConfig>
 
     val oneshotActionConfig: Settings<OneshotActionConfig>
+
+    val bangumiSettings: Settings<BangumiSettings>
 
     val analyticsSettings: Settings<AnalyticsSettings>
     val debugSettings: Settings<DebugSettings>
@@ -242,6 +245,12 @@ class PreferencesRepositoryImpl(
         "oneshotActionConfig",
         OneshotActionConfig.serializer(),
         default = { OneshotActionConfig.Default },
+    )
+
+    override val bangumiSettings: Settings<BangumiSettings> = SerializablePreference(
+        "bangumiSettings",
+        BangumiSettings.serializer(),
+        default = { BangumiSettings.Default },
     )
 
     override val analyticsSettings: Settings<AnalyticsSettings> = SerializablePreference(

--- a/app/shared/app-data/src/commonMain/kotlin/domain/session/auth/BangumiOAuthUrl.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/session/auth/BangumiOAuthUrl.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.session.auth
+
+import io.ktor.http.URLBuilder
+import io.ktor.http.URLProtocol
+import io.ktor.http.Url
+import me.him188.ani.app.data.models.preference.DEFAULT_BANGUMI_WEB_BASE_URL
+
+private val bangumiWebHosts = setOf("bgm.tv", "bangumi.tv")
+
+fun normalizeBangumiWebBaseUrl(value: String): String? {
+    val trimmed = value.trim().trimEnd('/')
+    val withScheme = if (trimmed.isBlank()) {
+        DEFAULT_BANGUMI_WEB_BASE_URL
+    } else if ("://" in trimmed) {
+        trimmed
+    } else {
+        "https://$trimmed"
+    }
+    val parsed = runCatching { Url(withScheme) }.getOrNull() ?: return null
+    if (parsed.protocol != URLProtocol.HTTPS && parsed.protocol != URLProtocol.HTTP) return null
+    if (parsed.host.isBlank()) return null
+
+    return URLBuilder().apply {
+        protocol = parsed.protocol
+        host = parsed.host
+        port = parsed.port
+    }.buildString().trimEnd('/')
+}
+
+fun rewriteBangumiOAuthUrl(url: String, bangumiWebBaseUrl: String): String {
+    val target = normalizeBangumiWebBaseUrl(bangumiWebBaseUrl) ?: return url
+    val original = runCatching { Url(url) }.getOrNull() ?: return url
+    if (original.host.lowercase() !in bangumiWebHosts) return url
+
+    val targetUrl = Url(target)
+    return URLBuilder(original).apply {
+        protocol = targetUrl.protocol
+        host = targetUrl.host
+        port = targetUrl.port
+        encodedUser = null
+        encodedPassword = null
+    }.buildString()
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/danmaku/DanmakuCacheTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/danmaku/DanmakuCacheTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.runTest
 import me.him188.ani.app.data.models.danmaku.DanmakuFilterConfig
 import me.him188.ani.app.data.models.preference.AnalyticsSettings
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
+import me.him188.ani.app.data.models.preference.BangumiSettings
 import me.him188.ani.app.data.models.preference.DanmakuCacheStrategy
 import me.him188.ani.app.data.models.preference.DanmakuSettings
 import me.him188.ani.app.data.models.preference.DebugSettings
@@ -263,6 +264,7 @@ class DanmakuCacheTest {
         override val pikpakConfig: Settings<PikPakConfig> by lazy { error("no implemented") }
         override val torrentPeerConfig: Settings<TorrentPeerConfig> by lazy { error("no implemented") }
         override val oneshotActionConfig: Settings<OneshotActionConfig> by lazy { error("no implemented") }
+        override val bangumiSettings: Settings<BangumiSettings> by lazy { error("no implemented") }
         override val analyticsSettings: Settings<AnalyticsSettings> by lazy { error("no implemented") }
         override val debugSettings: Settings<DebugSettings> by lazy { error("no implemented") }
     }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/session/auth/BangumiOAuthUrlTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/session/auth/BangumiOAuthUrlTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.session.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BangumiOAuthUrlTest {
+    @Test
+    fun `normalizes host-only value as https url`() {
+        assertEquals("https://bangumi.rdd.moe", normalizeBangumiWebBaseUrl("bangumi.rdd.moe"))
+    }
+
+    @Test
+    fun `normalizes blank value to default Bangumi host`() {
+        assertEquals("https://bgm.tv", normalizeBangumiWebBaseUrl("  "))
+    }
+
+    @Test
+    fun `rejects unsupported scheme`() {
+        assertNull(normalizeBangumiWebBaseUrl("javascript:alert(1)"))
+    }
+
+    @Test
+    fun `rewrites Bangumi OAuth host and preserves query`() {
+        val original = "https://bgm.tv/oauth/authorize?client_id=ani&redirect_uri=https%3A%2F%2Fapi.myani.org%2Fcb&state=req"
+
+        assertEquals(
+            "https://bangumi.rdd.moe/oauth/authorize?client_id=ani&redirect_uri=https%3A%2F%2Fapi.myani.org%2Fcb&state=req",
+            rewriteBangumiOAuthUrl(original, "bangumi.rdd.moe"),
+        )
+    }
+
+    @Test
+    fun `rewrites bangumi tv OAuth host`() {
+        assertEquals(
+            "https://bangumi.rdd.moe/oauth/authorize",
+            rewriteBangumiOAuthUrl("https://bangumi.tv/oauth/authorize", "https://bangumi.rdd.moe"),
+        )
+    }
+
+    @Test
+    fun `does not rewrite non-Bangumi urls`() {
+        assertEquals(
+            "https://api.myani.org/v1/login/bangumi/oauth/callback?code=abc",
+            rewriteBangumiOAuthUrl(
+                "https://api.myani.org/v1/login/bangumi/oauth/callback?code=abc",
+                "https://bangumi.rdd.moe",
+            ),
+        )
+    }
+}

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -678,6 +678,8 @@
     <string name="oauth_bangumi_waiting_result">正在等待结果</string>
     <string name="oauth_bangumi_authorized">已授权</string>
     <string name="oauth_bangumi_cancel">取消</string>
+    <string name="oauth_bangumi_web_base_url">Bangumi 网页域名</string>
+    <string name="oauth_bangumi_web_base_url_description">仅用于打开 Bangumi 授权页面。除非信任替代域名，否则请使用官方域名。</string>
     <string name="oauth_bangumi_help_title">帮助</string>
     <string name="oauth_bangumi_help_bangumi_desc">Bangumi 是什么</string>
     <string name="oauth_bangumi_help_website_blocked">浏览器提示网站被屏蔽或禁止访问</string>
@@ -687,7 +689,7 @@
     <string name="oauth_bangumi_help_activation_failed">注册时一直激活失败</string>
     <string name="oauth_bangumi_help_others">其他问题</string>
     <string name="oauth_bangumi_help_bangumi_desc_content">Bangumi 番组计划是一个中文互联网的 ACGN 内容分享与交流网站，致力于提供一个轻松便捷独特的交流与沟通环境。\nBangumi 提供了番剧索引、番剧收藏、追番进度等功能，Ani 可以将你的观看记录同步至 Bangumi。</string>
-    <string name="oauth_bangumi_help_website_blocked_content">请在系统设置中更换默认浏览器，推荐使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。</string>
+    <string name="oauth_bangumi_help_website_blocked_content">请在系统设置中更换默认浏览器，推荐使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。如果需要使用其他可信域名，也可以编辑上方的 Bangumi 网页域名。</string>
     <string name="oauth_bangumi_help_register_choose_content">选择“管理 ACG 收藏与收视进度，分享交流”这一项。</string>
     <string name="oauth_bangumi_help_wrong_captcha_content">如果没有验证码输入框，可以尝试多点几次密码输入框；如果输错了验证码，需要刷新页面后再重新登录。</string>
     <string name="oauth_bangumi_help_cant_receive_email_content">请检查垃圾箱，并尽可能使用常见邮箱注册，例如 QQ 邮箱、网易邮箱或 Outlook。</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -653,6 +653,8 @@
     <string name="oauth_bangumi_waiting_result">正在等待結果</string>
     <string name="oauth_bangumi_authorized">已授權</string>
     <string name="oauth_bangumi_cancel">取消</string>
+    <string name="oauth_bangumi_web_base_url">Bangumi 網頁域名</string>
+    <string name="oauth_bangumi_web_base_url_description">僅用於開啟 Bangumi 授權頁面。除非信任替代域名，否則請使用官方域名。</string>
     <string name="oauth_bangumi_help_title">幫助</string>
     <string name="oauth_bangumi_help_bangumi_desc">Bangumi 是甚麼</string>
     <string name="oauth_bangumi_help_website_blocked">瀏覽器提示網站被屏蔽或禁止訪問</string>
@@ -662,7 +664,7 @@
     <string name="oauth_bangumi_help_activation_failed">註冊時一直激活失敗</string>
     <string name="oauth_bangumi_help_others">其他問題</string>
     <string name="oauth_bangumi_help_bangumi_desc_content">Bangumi 番組計劃是一個中文互聯網的 ACGN 內容分享與交流網站，致力於提供一個輕鬆便捷而獨特的交流環境。\nBangumi 提供番劇索引、番劇收藏和追番進度等功能，Ani 可以將你的觀看記錄同步至 Bangumi。</string>
-    <string name="oauth_bangumi_help_website_blocked_content">請在系統設置中更換預設瀏覽器，建議使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。</string>
+    <string name="oauth_bangumi_help_website_blocked_content">請在系統設置中更換預設瀏覽器，建議使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。如需使用其他可信域名，也可以編輯上方的 Bangumi 網頁域名。</string>
     <string name="oauth_bangumi_help_register_choose_content">選擇「管理 ACG 收藏與收視進度，分享交流」這一項。</string>
     <string name="oauth_bangumi_help_wrong_captcha_content">如果沒有驗證碼輸入框，可以多點幾次密碼輸入框；如果輸錯了驗證碼，需要重新整理頁面後再登入。</string>
     <string name="oauth_bangumi_help_cant_receive_email_content">請檢查垃圾郵件箱，並盡量使用常見郵箱註冊，例如 QQ 郵箱、網易郵箱或 Outlook。</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -642,6 +642,8 @@
     <string name="oauth_bangumi_waiting_result">正在等待結果</string>
     <string name="oauth_bangumi_authorized">已授權</string>
     <string name="oauth_bangumi_cancel">取消</string>
+    <string name="oauth_bangumi_web_base_url">Bangumi 網頁網域</string>
+    <string name="oauth_bangumi_web_base_url_description">僅用於開啟 Bangumi 授權頁面。除非信任替代網域，否則請使用官方網域。</string>
     <string name="oauth_bangumi_help_title">幫助</string>
     <string name="oauth_bangumi_help_bangumi_desc">Bangumi 是什麼</string>
     <string name="oauth_bangumi_help_website_blocked">瀏覽器提示網站被封鎖或禁止存取</string>
@@ -651,7 +653,7 @@
     <string name="oauth_bangumi_help_activation_failed">註冊時一直啟用失敗</string>
     <string name="oauth_bangumi_help_others">其他問題</string>
     <string name="oauth_bangumi_help_bangumi_desc_content">Bangumi 番組計劃是一個中文網際網路的 ACGN 內容分享與交流網站，致力於提供一個輕鬆便捷又獨特的交流環境。\nBangumi 提供番劇索引、番劇收藏和追番進度等功能，Ani 可以將你的觀看紀錄同步到 Bangumi。</string>
-    <string name="oauth_bangumi_help_website_blocked_content">請在系統設定中更換預設瀏覽器，建議使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。</string>
+    <string name="oauth_bangumi_help_website_blocked_content">請在系統設定中更換預設瀏覽器，建議使用 Google Chrome、Microsoft Edge 或 Mozilla Firefox。如果需要使用其他可信任網域，也可以編輯上方的 Bangumi 網頁網域。</string>
     <string name="oauth_bangumi_help_register_choose_content">選擇「管理 ACG 收藏與收視進度，分享交流」這一項。</string>
     <string name="oauth_bangumi_help_wrong_captcha_content">如果沒有驗證碼輸入框，可以多點幾次密碼輸入框；如果輸錯了驗證碼，需要重新整理頁面後再登入。</string>
     <string name="oauth_bangumi_help_cant_receive_email_content">請檢查垃圾郵件匣，並盡量使用常見信箱註冊，例如 QQ 郵箱、網易郵箱或 Outlook。</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -638,6 +638,8 @@
     <string name="oauth_bangumi_waiting_result">Waiting for result</string>
     <string name="oauth_bangumi_authorized">Authorized</string>
     <string name="oauth_bangumi_cancel">Cancel</string>
+    <string name="oauth_bangumi_web_base_url">Bangumi Website</string>
+    <string name="oauth_bangumi_web_base_url_description">Used only when opening the Bangumi authorization page. Use the official domain unless you trust the replacement.</string>
     <string name="oauth_bangumi_help_title">Help</string>
     <string name="oauth_bangumi_help_bangumi_desc">What is Bangumi?</string>
     <string name="oauth_bangumi_help_website_blocked">The browser says the website is blocked or inaccessible</string>
@@ -647,7 +649,7 @@
     <string name="oauth_bangumi_help_activation_failed">Account activation keeps failing during registration</string>
     <string name="oauth_bangumi_help_others">Other issues</string>
     <string name="oauth_bangumi_help_bangumi_desc_content">Bangumi is a Chinese ACGN community website for sharing and discussion.\nBangumi provides anime indexes, collections, and watch progress tracking. Ani can sync your watch history to Bangumi.</string>
-    <string name="oauth_bangumi_help_website_blocked_content">Change your default browser in system settings. Google Chrome, Microsoft Edge, and Mozilla Firefox are recommended.</string>
+    <string name="oauth_bangumi_help_website_blocked_content">Change your default browser in system settings. Google Chrome, Microsoft Edge, and Mozilla Firefox are recommended. You can also edit the Bangumi Website field above if you need to use another trusted domain.</string>
     <string name="oauth_bangumi_help_register_choose_content">Choose the option for managing ACG collections and watch progress, then sharing and discussing them.</string>
     <string name="oauth_bangumi_help_wrong_captcha_content">If there is no captcha input box, try clicking the password box a few more times. If you entered the captcha incorrectly, refresh the page before signing in again.</string>
     <string name="oauth_bangumi_help_cant_receive_email_content">Check your spam folder and try registering with a common email provider such as QQ Mail, NetEase Mail, or Outlook.</string>

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeLayout.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeLayout.kt
@@ -50,10 +50,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import me.him188.ani.app.data.models.preference.BangumiSettings
+import me.him188.ani.app.data.models.preference.DEFAULT_BANGUMI_WEB_BASE_URL
 import me.him188.ani.app.domain.foundation.LoadError
+import me.him188.ani.app.domain.session.auth.normalizeBangumiWebBaseUrl
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.animation.AniMotionScheme
 import me.him188.ani.app.ui.foundation.animation.AnimatedVisibilityMotionScheme
@@ -65,6 +69,7 @@ import me.him188.ani.app.ui.foundation.widgets.HeroIcon
 import me.him188.ani.app.ui.search.renderLoadErrorMessage
 import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
+import me.him188.ani.app.ui.settings.framework.components.TextFieldItem
 import me.him188.ani.app.ui.settings.framework.components.TextItem
 import org.jetbrains.compose.resources.*
 
@@ -87,6 +92,8 @@ fun BangumiAuthorizeLayout(
     contactActions: @Composable () -> Unit,
     onClickAuthorize: () -> Unit,
     onCancelAuthorize: () -> Unit,
+    bangumiSettings: BangumiSettings,
+    onBangumiWebBaseUrlChange: (String) -> Unit,
     scrollState: ScrollState,
     modifier: Modifier = Modifier,
 ) {
@@ -132,6 +139,10 @@ fun BangumiAuthorizeLayout(
                         modifier = Modifier.padding(vertical = 8.dp),
                         animatedVisibilityMotionScheme = motionScheme.animatedVisibility,
                     )
+                    BangumiWebBaseUrlItem(
+                        webBaseUrl = bangumiSettings.webBaseUrl,
+                        onWebBaseUrlChange = onBangumiWebBaseUrlChange,
+                    )
                 }
             }
             AuthorizeHelpQA(
@@ -141,6 +152,35 @@ fun BangumiAuthorizeLayout(
             )
         }
     }
+}
+
+@Composable
+private fun SettingsScope.BangumiWebBaseUrlItem(
+    webBaseUrl: String,
+    onWebBaseUrlChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextFieldItem(
+        value = webBaseUrl,
+        title = { Text(stringResource(Lang.oauth_bangumi_web_base_url)) },
+        description = { Text(stringResource(Lang.oauth_bangumi_web_base_url_description)) },
+        placeholder = { Text(DEFAULT_BANGUMI_WEB_BASE_URL) },
+        exposedItem = {
+            Text(
+                it.ifBlank { DEFAULT_BANGUMI_WEB_BASE_URL },
+                maxLines = 1,
+                overflow = TextOverflow.MiddleEllipsis,
+            )
+        },
+        onValueChangeCompleted = {
+            normalizeBangumiWebBaseUrl(it)?.let(onWebBaseUrlChange)
+        },
+        isErrorProvider = {
+            normalizeBangumiWebBaseUrl(it) == null
+        },
+        sanitizeValue = { it.trim() },
+        modifier = modifier.fillMaxWidth(),
+    )
 }
 
 

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeScreen.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import me.him188.ani.app.data.models.preference.BangumiSettings
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.platform.navigation.rememberAsyncBrowserNavigator
+import me.him188.ani.app.domain.session.auth.rewriteBangumiOAuthUrl
 import me.him188.ani.app.ui.login.EmailLoginScreenLayout
 import me.him188.ani.app.ui.lang.*
 import org.jetbrains.compose.resources.*
@@ -31,6 +33,7 @@ fun BangumiAuthorizeScreen(
     contactActions: @Composable () -> Unit,
 ) {
     val state by vm.state.collectAsStateWithLifecycle(AuthState.NoAniAccount)
+    val bangumiSettings by vm.bangumiSettings.collectAsStateWithLifecycle(BangumiSettings.Default)
     val scope = rememberCoroutineScope()
     val browserNavigator = rememberAsyncBrowserNavigator()
     val context = LocalContext.current
@@ -51,11 +54,16 @@ fun BangumiAuthorizeScreen(
                 vm.doOAuth(
                     state is AuthState.NoAniAccount || (currentState is AuthState.Failed && !currentState.loggedIn),
                 ) {
-                    browserNavigator.openBrowser(context, it)
+                    browserNavigator.openBrowser(
+                        context,
+                        rewriteBangumiOAuthUrl(it, bangumiSettings.webBaseUrl),
+                    )
                 }
             }
         },
         onCancelAuthorize = { vm.cancelCurrentOAuth() },
+        bangumiSettings = bangumiSettings,
+        onBangumiWebBaseUrlChange = vm::updateBangumiWebBaseUrl,
         onNavigateSettings = onNavigateSettings,
         onNavigateBack = onNavigateBack,
         contactActions = contactActions,
@@ -67,6 +75,8 @@ internal fun BangumiAuthorizeScreen(
     state: AuthState,
     onClickAuthorize: () -> Unit,
     onCancelAuthorize: () -> Unit,
+    bangumiSettings: BangumiSettings,
+    onBangumiWebBaseUrlChange: (String) -> Unit,
     onNavigateSettings: () -> Unit,
     onNavigateBack: () -> Unit,
     contactActions: @Composable () -> Unit,
@@ -83,6 +93,8 @@ internal fun BangumiAuthorizeScreen(
             contactActions = contactActions,
             onClickAuthorize = onClickAuthorize,
             onCancelAuthorize = onCancelAuthorize,
+            bangumiSettings = bangumiSettings,
+            onBangumiWebBaseUrlChange = onBangumiWebBaseUrlChange,
             scrollState = scrollState,
         )
     }

--- a/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeViewModel.kt
+++ b/app/shared/ui-onboarding/src/commonMain/kotlin/ui/oauth/BangumiAuthorizeViewModel.kt
@@ -9,16 +9,22 @@
 
 package me.him188.ani.app.ui.oauth
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import me.him188.ani.app.data.models.preference.BangumiSettings
 import me.him188.ani.app.data.network.AniApiProvider
+import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.session.SessionEvent
 import me.him188.ani.app.domain.session.SessionManager
 import me.him188.ani.app.domain.session.SessionState
 import me.him188.ani.app.domain.session.SessionStateProvider
 import me.him188.ani.app.domain.session.auth.BangumiOAuthClient
 import me.him188.ani.app.domain.session.auth.OAuthConfigurator
+import me.him188.ani.app.domain.session.auth.normalizeBangumiWebBaseUrl
 import me.him188.ani.app.domain.session.canAccessAniApiNow
 import me.him188.ani.app.ui.foundation.AbstractViewModel
 import me.him188.ani.utils.coroutines.SingleTaskExecutor
@@ -29,8 +35,10 @@ class BangumiAuthorizeViewModel : AbstractViewModel(), KoinComponent {
     private val aniApiProvider: AniApiProvider by inject()
     private val sessionManager: SessionManager by inject()
     private val sessionStateProvider: SessionStateProvider by inject()
+    private val settingsRepository: SettingsRepository by inject()
 
     private val tasker = SingleTaskExecutor(backgroundScope.coroutineContext)
+    private val localBangumiSettings = MutableStateFlow<BangumiSettings?>(null)
 
     private val configurator = OAuthConfigurator(
         client = BangumiOAuthClient(aniApiProvider.bangumiApi, sessionStateProvider),
@@ -64,6 +72,26 @@ class BangumiAuthorizeViewModel : AbstractViewModel(), KoinComponent {
                 }
             }
         }
+
+    val bangumiSettings = combine(
+        settingsRepository.bangumiSettings.flow,
+        localBangumiSettings,
+    ) { persisted, local ->
+        local ?: persisted
+    }.stateInBackground(BangumiSettings.Default)
+
+    fun updateBangumiWebBaseUrl(value: String) {
+        val normalized = normalizeBangumiWebBaseUrl(value) ?: return
+        localBangumiSettings.value = bangumiSettings.value.copy(webBaseUrl = normalized)
+        backgroundScope.launch {
+            val current = settingsRepository.bangumiSettings.flow.first()
+            if (current.webBaseUrl != normalized) {
+                settingsRepository.bangumiSettings.set(current.copy(webBaseUrl = normalized))
+                settingsRepository.bangumiSettings.flow.first { it.webBaseUrl == normalized }
+            }
+            localBangumiSettings.value = null
+        }
+    }
 
     suspend fun doOAuth(isRegister: Boolean, onOpenUrl: suspend (String) -> Unit): Boolean {
         val res = tasker.invoke {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
@@ -26,6 +26,7 @@ import me.him188.ani.app.data.models.danmaku.DanmakuFilterConfig
 import me.him188.ani.app.data.models.danmaku.DanmakuRegexFilter
 import me.him188.ani.app.data.models.preference.AnalyticsSettings
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
+import me.him188.ani.app.data.models.preference.BangumiSettings
 import me.him188.ani.app.data.models.preference.PikPakConfig
 import me.him188.ani.app.data.models.preference.DanmakuSettings
 import me.him188.ani.app.data.models.preference.DebugSettings
@@ -382,6 +383,7 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
             anitorrentConfig = settingsRepository.anitorrentConfig.flow.first(),
             torrentPeerConfig = settingsRepository.torrentPeerConfig.flow.first(),
             oneshotActionConfig = settingsRepository.oneshotActionConfig.flow.first(),
+            bangumiSettings = settingsRepository.bangumiSettings.flow.first(),
             analyticsSettings = settingsRepository.analyticsSettings.flow.first(),
             debugSettings = settingsRepository.debugSettings.flow.first(),
             // Account credentials must not leak into exported settings; keep
@@ -417,6 +419,7 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
         backup.anitorrentConfig?.let { settingsRepository.anitorrentConfig.set(it) }
         backup.torrentPeerConfig?.let { settingsRepository.torrentPeerConfig.set(it) }
         backup.oneshotActionConfig?.let { settingsRepository.oneshotActionConfig.set(it) }
+        backup.bangumiSettings?.let { settingsRepository.bangumiSettings.set(it) }
         backup.analyticsSettings?.let { settingsRepository.analyticsSettings.set(it) }
         backup.debugSettings?.let { settingsRepository.debugSettings.set(it) }
         // pikpakConfig deliberately not restored: see serializeSettingsBackup.
@@ -470,6 +473,7 @@ private data class SettingsBackup(
     val anitorrentConfig: AnitorrentConfig?,
     val torrentPeerConfig: TorrentPeerConfig?,
     val oneshotActionConfig: OneshotActionConfig?,
+    val bangumiSettings: BangumiSettings? = null,
     val analyticsSettings: AnalyticsSettings?,
     val debugSettings: DebugSettings?,
     val pikpakConfig: PikPakConfig? = null,


### PR DESCRIPTION
Closes #3087.

Implemented by the Codex agent (self-hosted run). Makes the Bangumi web/OAuth domain configurable so the login link resolves when the default domain is unreachable — adds `BangumiSettings` + `SettingsRepository` wiring, `BangumiOAuthUrl` (with test), settings UI, OAuth authorize screen/VM, and localized strings.

**Runtime verification** (from the run logs): built and installed the debug APK on the Android emulator and drove the real UI to the Bangumi settings/OAuth screen (screenshot confirmed the new domain row + editable at runtime); also ran the Compose Desktop app and confirmed the `Bangumi 网页域名` row.

_Note: this run predates #3133, so the captured screenshots were not preserved (they lived only in the runner temp dir). Future runs attach them to the PR + upload them as artifacts._

🤖 Generated by Codex on the self-hosted runner.