### PR TITLE
desktop: use locally-built mpv natives in mediamp composite builds

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -45,28 +45,22 @@ dependencies {
     }
     // mpv 后端只分发给 Windows x64 与 macOS arm64; Linux x64 与 macOS x64 仍用 VLC.
     // 与 me.him188.ani.app.desktop.usesMpv() 保持一致.
-    when (val triple = getOsTriple()) {
-        "windows-x64", "macos-arm64" -> {
-            if (getLocalProperty("ani.build.mediamp.path") != null) {
-                // Composite 模式: natives 按 capability 从 :mediamp-mpv 的 composite runtime variant 取
-                // (mpvCompositeRuntimeElements-*, 产物来自本地 mpv-output 构建). 不能直接依赖
-                // mediamp-mpv-runtime-* 模块: 它不在 settings 的替换名单里, 会从 mavenLocal 解析 —
-                // 版本恰好已发布时静默用上发布版 natives (本地 native 改动不生效), 未发布时解析失败.
-                // 也不能在 settings 里替换: composite 的 dependencySubstitution 不保留 capability 选择.
-                runtimeOnly(libs.mediamp.mpv) {
-                    capabilities {
-                        requireCapability("org.openani.mediamp:mediamp-mpv-runtime-$triple")
-                    }
-                }
-            } else {
-                when (triple) {
-                    "windows-x64" -> runtimeOnly(libs.mediamp.mpv.runtime.windows.x64)
-                    "macos-arm64" -> runtimeOnly(libs.mediamp.mpv.runtime.macos.arm64)
+    val mpvTriple = getOsTriple().takeIf { it in listOf("windows-x64", "macos-arm64") }
+    if (mpvTriple != null) {
+        if (getLocalProperty("ani.build.mediamp.path") != null) {
+            // Composite 模式: natives 按 capability 从 :mediamp-mpv 的 composite runtime variant 取
+            // (mpvCompositeRuntimeElements-*, 产物来自本地 mpv-output 构建). 不能直接依赖
+            // mediamp-mpv-runtime-* 模块: 它不在 settings 的替换名单里, 会从 mavenLocal 解析 —
+            // 版本恰好已发布时静默用上发布版 natives (本地 native 改动不生效), 未发布时解析失败.
+            // 也不能在 settings 里替换: composite 的 dependencySubstitution 不保留 capability 选择.
+            runtimeOnly(libs.mediamp.mpv) {
+                capabilities {
+                    requireCapability("org.openani.mediamp:mediamp-mpv-runtime-$mpvTriple")
                 }
             }
+        } else {
+            runtimeOnly("org.openani.mediamp:mediamp-mpv-runtime-$mpvTriple:${libs.versions.mediampMpv.get()}")
         }
-
-        else -> {}
     }
     // vlcj 依赖里没有 native libraries，依赖是手动放的
     implementation(libs.vlcj)

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -46,8 +46,26 @@ dependencies {
     // mpv 后端只分发给 Windows x64 与 macOS arm64; Linux x64 与 macOS x64 仍用 VLC.
     // 与 me.him188.ani.app.desktop.usesMpv() 保持一致.
     when (val triple = getOsTriple()) {
-        "windows-x64" -> runtimeOnly(libs.mediamp.mpv.runtime.windows.x64)
-        "macos-arm64" -> runtimeOnly(libs.mediamp.mpv.runtime.macos.arm64)
+        "windows-x64", "macos-arm64" -> {
+            if (getLocalProperty("ani.build.mediamp.path") != null) {
+                // Composite 模式: natives 按 capability 从 :mediamp-mpv 的 composite runtime variant 取
+                // (mpvCompositeRuntimeElements-*, 产物来自本地 mpv-output 构建). 不能直接依赖
+                // mediamp-mpv-runtime-* 模块: 它不在 settings 的替换名单里, 会从 mavenLocal 解析 —
+                // 版本恰好已发布时静默用上发布版 natives (本地 native 改动不生效), 未发布时解析失败.
+                // 也不能在 settings 里替换: composite 的 dependencySubstitution 不保留 capability 选择.
+                runtimeOnly(libs.mediamp.mpv) {
+                    capabilities {
+                        requireCapability("org.openani.mediamp:mediamp-mpv-runtime-$triple")
+                    }
+                }
+            } else {
+                when (triple) {
+                    "windows-x64" -> runtimeOnly(libs.mediamp.mpv.runtime.windows.x64)
+                    "macos-arm64" -> runtimeOnly(libs.mediamp.mpv.runtime.macos.arm64)
+                }
+            }
+        }
+
         else -> {}
     }
     // vlcj 依赖里没有 native libraries，依赖是手动放的

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -283,10 +283,6 @@ mediamp-ffmpeg-runtime-macos-arm64 = { module = "org.openani.mediamp:mediamp-ffm
 mediamp-ffmpeg-runtime-ios-xcframework = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-ios-xcframework", version.ref = "mediamp" }
 # Apple runtime is published as a @zip XCFramework and is resolved explicitly where needed.
 mediamp-mpv = { module = "org.openani.mediamp:mediamp-mpv", version.ref = "mediampMpv" }
-mediamp-mpv-runtime-windows-x64 = { module = "org.openani.mediamp:mediamp-mpv-runtime-windows-x64", version.ref = "mediampMpv" }
-mediamp-mpv-runtime-linux-x64 = { module = "org.openani.mediamp:mediamp-mpv-runtime-linux-x64", version.ref = "mediampMpv" }
-mediamp-mpv-runtime-macos-x64 = { module = "org.openani.mediamp:mediamp-mpv-runtime-macos-x64", version.ref = "mediampMpv" }
-mediamp-mpv-runtime-macos-arm64 = { module = "org.openani.mediamp:mediamp-mpv-runtime-macos-arm64", version.ref = "mediampMpv" }
 mediamp-source-ktxio = { module = "org.openani.mediamp:mediamp-source-ktxio", version.ref = "mediamp" }
 mediamp-test = { module = "org.openani.mediamp:mediamp-test", version.ref = "mediamp" }
 mediamp-vlc = { module = "org.openani.mediamp:mediamp-vlc", version.ref = "mediamp" }


### PR DESCRIPTION
## 问题

Composite 模式(`ani.build.mediamp.path`)下,`mediamp-mpv-runtime-<triple>` 模块不在 settings 的替换名单里,走仓库解析:

- mediamp 的 version 恰好已发布到 mavenLocal 时,**静默使用发布版 natives**,本地 `mpv-output` 的改动完全不生效(排查 `Protocol not found` 时确认:本地构建树曾残留网络协议 flags 启用前编译的旧 ffmpeg);
- 未发布时直接解析失败。

## 修复

Composite 模式下改为按 capability 从 `:mediamp-mpv` 取 runtime natives(命中 mediamp 侧的 `mpvCompositeRuntimeElements-<triple>` variant,产物始终从本地 mediamp 工作树现打)。非 composite 模式行为不变。

注:不能在 settings.gradle.kts 里替换 runtime 模块——composite 的 dependencySubstitution 会丢弃 capability 选择,选中普通库 variant,natives 直接从 classpath 消失(已实测)。

## 验证

- `dependencyInsight` + runtime classpath dump:runtime jar 从 `~/.m2/...` 变为 `mediamp-mpv/build/libs/mediamp-mpv-runtime-*-macos-arm64.jar`(现场由 `mpvAssembleMacosArm64` 构建);
- composite 模式跑 `MpvVerify` 播放 https URL:`Opening done`,`Loading hwdec driver 'videotoolbox'`;
- natives 新鲜度联动:composite 构建自动触发 ffmpeg/libmpv 重编(首次较慢,之后增量)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)