### PR TITLE
fix(player): enable keyboard shortcuts in touch mode

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -45,6 +44,8 @@ import me.him188.ani.app.ui.foundation.text.ProvideContentColor
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.episode_send_danmaku
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
+import me.him188.ani.app.videoplayer.ui.PlayerFocusState
+import me.him188.ani.app.videoplayer.ui.playerTextInputFocus
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults
 import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.danmaku.api.DanmakuContent
@@ -62,6 +63,7 @@ fun PlayerDanmakuEditor(
     videoScaffoldConfig: VideoScaffoldConfig,
     playerControllerState: PlayerControllerState,
     modifier: Modifier = Modifier,
+    onEscape: (() -> Unit)? = null,
 ) {
     val sending by danmakuEditorState.isSending.collectAsStateWithLifecycle()
     PlayerDanmakuEditor(
@@ -71,7 +73,7 @@ fun PlayerDanmakuEditor(
         onSend = {
             danmakuEditorState.post(it)
         },
-        danmakuTextPlaceholder, playerState, videoScaffoldConfig, playerControllerState, modifier,
+        danmakuTextPlaceholder, playerState, videoScaffoldConfig, playerControllerState, modifier, onEscape,
     )
 }
 
@@ -87,10 +89,11 @@ fun PlayerDanmakuEditor(
     videoScaffoldConfig: VideoScaffoldConfig,
     playerControllerState: PlayerControllerState,
     modifier: Modifier = Modifier,
+    onEscape: (() -> Unit)? = null,
 ) {
     val danmakuEditorRequester = rememberAlwaysOnRequester(playerControllerState, "danmakuEditor")
 
-    val focusManager = LocalFocusManager.current
+    val playerFocusState = playerControllerState.focusState
 
     /**
      * 是否设置了暂停
@@ -114,7 +117,7 @@ fun PlayerDanmakuEditor(
                             location = DanmakuLocation.NORMAL,
                         ),
                     )
-                    focusManager.clearFocus()
+                    playerFocusState.preferPlayer()
                 }
             },
             modifier = Modifier.onFocusChanged {
@@ -132,6 +135,8 @@ fun PlayerDanmakuEditor(
                     danmakuEditorRequester.cancelRequest()
                 }
             }.weight(1f),
+            playerFocusState = playerFocusState,
+            onEscape = onEscape,
         )
     }
 }
@@ -143,14 +148,16 @@ fun PlayerDanmakuEditor(
     isSending: () -> Boolean,
     placeholderText: String,
     onSend: (text: String) -> Unit,
+    playerFocusState: PlayerFocusState,
     modifier: Modifier = Modifier,
+    onEscape: (() -> Unit)? = null,
     colors: TextFieldColors = PlayerControllerDefaults.inVideoDanmakuTextFieldColors(),
     style: TextStyle = MaterialTheme.typography.bodyMedium,
 ) {
     PlayerControllerDefaults.DanmakuTextField(
         text,
         onValueChange = onTextChange,
-        modifier = modifier,
+        modifier = modifier.playerTextInputFocus(playerFocusState, onEscape),
         onSend = {
             if (text.isEmpty()) return@DanmakuTextField
             onSend(text)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -149,6 +149,7 @@ import me.him188.ani.app.ui.subject.episode.video.sidesheet.MediaSelectorSheet
 import me.him188.ani.app.ui.subject.episode.video.topbar.EpisodePlayerTitle
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
+import me.him188.ani.app.videoplayer.ui.PlayerFocusState
 import me.him188.ani.app.videoplayer.ui.VideoAspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.gesture.LevelController
 import me.him188.ani.app.videoplayer.ui.gesture.NoOpLevelController
@@ -772,7 +773,9 @@ private fun EpisodeScreenContentPhone(
                     }
                 },
                 focusRequester,
-                Modifier.imePadding(),
+                vm.playerControllerState.focusState,
+                onDismiss = dismiss,
+                modifier = Modifier.imePadding(),
             )
             LaunchedEffect(true) {
                 focusRequester.requestFocus()
@@ -786,6 +789,8 @@ private fun DetachedDanmakuEditorLayout(
     danmakuEditorState: DanmakuEditorState,
     onSend: (text: String) -> Unit,
     focusRequester: FocusRequester,
+    playerFocusState: PlayerFocusState,
+    onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.padding(all = 16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -797,7 +802,9 @@ private fun DetachedDanmakuEditorLayout(
             isSending = { isSending.value },
             placeholderText = rememberRandomDanmakuPlaceholder(),
             onSend = onSend,
-            Modifier.fillMaxWidth().focusRequester(focusRequester),
+            playerFocusState = playerFocusState,
+            modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+            onEscape = onDismiss,
             colors = OutlinedTextFieldDefaults.colors(),
         )
     }

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -749,6 +749,33 @@ class EpisodeVideoControllerTest {
     }
 
     @Test
+    fun `mouse - keyboard shortcuts - enter does not activate click gesture`() = runAniComposeUiTest {
+        lateinit var playerState: TestMediampPlayer
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+                onPlayerStateCreated = { playerState = it },
+            )
+        }
+        waitForIdle()
+        runOnIdle {
+            playerState.playbackState.value = PlaybackState.PAUSED
+        }
+
+        videoGestureHost.assertIsFocused()
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Enter)
+            pressKey(Key.NumPadEnter)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(PlaybackState.PAUSED, playerState.playbackState.value)
+        }
+    }
+
+    @Test
     fun `touch - keyboard shortcuts - reclaim focus from editor on mouse move`() = runAniComposeUiTest {
         val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
         setContent {

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.ui.subject.episode
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -19,20 +20,28 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.swipe
+import androidx.compose.ui.window.WindowPlacement
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.him188.ani.app.data.models.preference.DarkMode
@@ -41,9 +50,12 @@ import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
 import me.him188.ani.app.domain.media.player.ChunkState
 import me.him188.ani.app.domain.media.player.staticMediaCacheProgressState
 import me.him188.ani.app.domain.player.VideoLoadingState
+import me.him188.ani.app.platform.PlatformWindow
 import me.him188.ani.app.ui.danmaku.PlayerDanmakuEditor
 import me.him188.ani.app.ui.episode.share.MediaShareData
+import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
 import me.him188.ani.app.ui.framework.AniComposeUiTest
 import me.him188.ani.app.ui.framework.doesNotExist
 import me.him188.ani.app.ui.framework.exists
@@ -69,6 +81,7 @@ import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.VideoAspectRatioControllerState
 import me.him188.ani.app.videoplayer.ui.gesture.GestureFamily
+import me.him188.ani.app.videoplayer.ui.gesture.LevelController
 import me.him188.ani.app.videoplayer.ui.gesture.NoOpLevelController
 import me.him188.ani.app.videoplayer.ui.gesture.VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION
 import me.him188.ani.app.videoplayer.ui.gesture.VIDEO_GESTURE_TOUCH_SHOW_CONTROLLER_DURATION
@@ -83,7 +96,12 @@ import me.him188.ani.app.videoplayer.ui.progress.TAG_SPEED_SWITCHER_DROPDOWN_MEN
 import me.him188.ani.app.videoplayer.ui.progress.TAG_SPEED_SWITCHER_TEXT_BUTTON
 import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
 import me.him188.ani.danmaku.ui.DanmakuConfig
+import me.him188.ani.utils.platform.Arch
+import me.him188.ani.utils.platform.Platform
 import org.junit.jupiter.api.Disabled
+import org.openani.mediamp.InternalForInheritanceMediampApi
+import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.test.TestMediampPlayer
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -161,15 +179,30 @@ class EpisodeVideoControllerTest {
         get() = onNodeWithTag(TAG_DANMAKU_ICON_BUTTON, useUnmergedTree = true)
     private val SemanticsNodeInteractionsProvider.player
         get() = onNodeWithTag("PLAYER", useUnmergedTree = true)
+    private val SemanticsNodeInteractionsProvider.videoGestureHost
+        get() = onNodeWithTag("VideoGestureHost", useUnmergedTree = true)
     private val SemanticsNodeInteractionsProvider.mediaProgressIndicatorText: SemanticsNodeInteraction
         get() = onNodeWithTag(TAG_MEDIA_PROGRESS_INDICATOR_TEXT, useUnmergedTree = true)
 
     @Composable
-    private fun Player(gestureFamily: GestureFamily, playerControllerState: PlayerControllerState = controllerState) {
+    private fun Player(
+        gestureFamily: GestureFamily,
+        playerControllerState: PlayerControllerState = controllerState,
+        onClickFullScreen: () -> Unit = {},
+        onExitFullscreen: () -> Unit = {},
+        onToggleDanmaku: () -> Unit = {},
+        audioController: LevelController = NoOpLevelController,
+        playbackSpeedControllerState: PlaybackSpeedControllerState? = null,
+        onPlayerStateCreated: (TestMediampPlayer) -> Unit = {},
+        onPlatformWindow: (PlatformWindow) -> Unit = {},
+        showDanmakuEditor: () -> Boolean = { true },
+        onEditorEscape: (() -> Unit)? = null,
+    ) {
         ProvideCompositionLocalsForPreview(darkMode = DarkMode.DARK) {
+            onPlatformWindow(LocalPlatformWindow.current)
             val scope = rememberCoroutineScope()
             val playerState = remember {
-                TestMediampPlayer(scope.coroutineContext)
+                TestMediampPlayer(scope.coroutineContext).also(onPlayerStateCreated)
             }
             val expanded = true
             val cacheProgressInfoFlow = staticMediaCacheProgressState(ChunkState.NONE).flow
@@ -182,22 +215,25 @@ class EpisodeVideoControllerTest {
                 title = { PlayerTopBar() },
                 danmakuHost = {},
                 danmakuEnabled = false,
-                onToggleDanmaku = {},
+                onToggleDanmaku = onToggleDanmaku,
                 videoLoadingStateFlow = remember { MutableStateFlow(VideoLoadingState.Succeed(isBt = true)) },
-                onClickFullScreen = {},
-                onExitFullscreen = {},
+                onClickFullScreen = onClickFullScreen,
+                onExitFullscreen = onExitFullscreen,
                 danmakuEditor = {
-                    PlayerDanmakuEditor(
-                        text = "",
-                        onTextChange = {},
-                        isSending = { false },
-                        onSend = {},
-                        danmakuTextPlaceholder = "",
-                        playerState = playerState,
-                        videoScaffoldConfig = VideoScaffoldConfig.Default,
-                        playerControllerState = playerControllerState,
-                        modifier = Modifier.testTag(TAG_DANMAKU_EDITOR),
-                    )
+                    if (showDanmakuEditor()) {
+                        PlayerDanmakuEditor(
+                            text = "",
+                            onTextChange = {},
+                            isSending = { false },
+                            onSend = {},
+                            danmakuTextPlaceholder = "",
+                            playerState = playerState,
+                            videoScaffoldConfig = VideoScaffoldConfig.Default,
+                            playerControllerState = playerControllerState,
+                            modifier = Modifier.testTag(TAG_DANMAKU_EDITOR),
+                            onEscape = onEditorEscape,
+                        )
+                    }
                 },
                 onClickScreenshot = {},
                 detachedProgressSlider = {
@@ -212,9 +248,9 @@ class EpisodeVideoControllerTest {
                 onToggleSidebar = {},
                 progressSliderState = progressSliderState,
                 cacheProgressInfoFlow = cacheProgressInfoFlow,
-                audioController = NoOpLevelController,
+                audioController = audioController,
                 brightnessController = NoOpLevelController,
-                playbackSpeedControllerState = remember {
+                playbackSpeedControllerState = playbackSpeedControllerState ?: remember {
                     PlaybackSpeedControllerState(NoOpPlaybackSpeedController, scope = scope)
                 },
                 videoAspectRatioControllerState = remember {
@@ -287,6 +323,33 @@ class EpisodeVideoControllerTest {
         }
     }
 
+    private class TestLevelController(
+        initialLevel: Float,
+        override val levelStep: Float = 0.01f,
+    ) : LevelController {
+        override var level: Float = initialLevel
+            private set
+
+        override val range: ClosedRange<Float> = 0f..1f
+
+        override fun setLevel(level: Float) {
+            this.level = level.coerceIn(range.start, range.endInclusive)
+        }
+    }
+
+    @OptIn(InternalForInheritanceMediampApi::class)
+    private class TestPlaybackSpeed(initialSpeed: Float) : PlaybackSpeed {
+        private val state = MutableStateFlow(initialSpeed)
+
+        override val valueFlow = state
+        override val value: Float
+            get() = state.value
+
+        override fun set(speed: Float) {
+            state.value = speed
+        }
+    }
+
 
     /**
      * @see GestureFamily.clickToToggleController
@@ -342,6 +405,414 @@ class EpisodeVideoControllerTest {
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.doesNotExist() }
             assertEquals(NORMAL_INVISIBLE, controllerState.visibility)
         }
+    }
+
+    @Test
+    fun `touch - keyboard shortcuts - playback fullscreen danmaku seek volume and speed`() = runAniComposeUiTest {
+        lateinit var playerState: TestMediampPlayer
+        lateinit var playbackSpeed: TestPlaybackSpeed
+        val audioController = TestLevelController(0.5f, levelStep = 0.04f)
+        var fullscreenCount = 0
+        var exitFullscreenCount = 0
+        var toggleDanmakuCount = 0
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                val scope = rememberCoroutineScope()
+                playbackSpeed = remember { TestPlaybackSpeed(1f) }
+                Player(
+                    GestureFamily.TOUCH,
+                    onClickFullScreen = { fullscreenCount++ },
+                    onExitFullscreen = { exitFullscreenCount++ },
+                    onToggleDanmaku = { toggleDanmakuCount++ },
+                    audioController = audioController,
+                    playbackSpeedControllerState = remember {
+                        PlaybackSpeedControllerState(playbackSpeed, scope = scope)
+                    },
+                    onPlayerStateCreated = { playerState = it },
+                )
+            }
+        }
+        waitForIdle()
+        runOnIdle {
+            playerState.playbackState.value = PlaybackState.PAUSED
+            playerState.currentPositionMillis.value = 20_000L
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.F)
+            pressKey(Key.Escape)
+            pressKey(Key.B)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1, fullscreenCount)
+            assertEquals(1, exitFullscreenCount)
+            assertEquals(1, toggleDanmakuCount)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Spacebar)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(PlaybackState.PLAYING, playerState.playbackState.value)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.DirectionRight)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(25_000L, playerState.currentPositionMillis.value)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.DirectionLeft)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(20_000L, playerState.currentPositionMillis.value)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.DirectionUp)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0.6f, audioController.level)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.DirectionDown)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0.5f, audioController.level)
+        }
+
+        videoGestureHost.performKeyInput {
+            keyDown(Key.ShiftLeft)
+            pressKey(Key.DirectionUp)
+            keyUp(Key.ShiftLeft)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0.54f, audioController.level)
+        }
+
+        videoGestureHost.performKeyInput {
+            keyDown(Key.ShiftLeft)
+            pressKey(Key.DirectionDown)
+            keyUp(Key.ShiftLeft)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0.5f, audioController.level)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.D)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1.25f, playbackSpeed.value)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.S)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1f, playbackSpeed.value)
+        }
+    }
+
+    @Test
+    fun `touch - keyboard shortcuts - yield focus to editor and reclaim it from video click`() = runAniComposeUiTest {
+        lateinit var playerState: TestMediampPlayer
+        var toggleDanmakuCount = 0
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                Player(
+                    GestureFamily.TOUCH,
+                    playerControllerState = visibleControllerState,
+                    onToggleDanmaku = { toggleDanmakuCount++ },
+                    onPlayerStateCreated = { playerState = it },
+                )
+            }
+        }
+        waitForIdle()
+        runOnIdle {
+            playerState.playbackState.value = PlaybackState.PAUSED
+        }
+
+        videoGestureHost.assertIsFocused()
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditor.performKeyInput {
+            pressKey(Key.B)
+            pressKey(Key.Spacebar)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0, toggleDanmakuCount)
+            assertEquals(PlaybackState.PAUSED, playerState.playbackState.value)
+        }
+
+        videoGestureHost.performClick()
+        videoGestureHost.assertIsFocused()
+        videoGestureHost.performKeyInput {
+            pressKey(Key.B)
+            pressKey(Key.Spacebar)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1, toggleDanmakuCount)
+            assertEquals(PlaybackState.PLAYING, playerState.playbackState.value)
+        }
+    }
+
+    @Test
+    fun `touch - keyboard shortcuts - do not reclaim focus when tab leaves editor`() = runAniComposeUiTest {
+        lateinit var playerState: TestMediampPlayer
+        var toggleDanmakuCount = 0
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                Player(
+                    GestureFamily.TOUCH,
+                    playerControllerState = visibleControllerState,
+                    onToggleDanmaku = { toggleDanmakuCount++ },
+                    onPlayerStateCreated = { playerState = it },
+                )
+            }
+        }
+        waitForIdle()
+        runOnIdle {
+            playerState.playbackState.value = PlaybackState.PAUSED
+        }
+
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditor.performKeyInput {
+            pressKey(Key.Tab)
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsNotFocused()
+        onRoot().performKeyInput {
+            pressKey(Key.B)
+            pressKey(Key.Spacebar)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(0, toggleDanmakuCount)
+            assertEquals(PlaybackState.PAUSED, playerState.playbackState.value)
+        }
+    }
+
+    @Test
+    fun `touch - keyboard shortcuts - escape dismisses detached editor before exiting fullscreen`() = runAniComposeUiTest {
+        var exitFullscreenCount = 0
+        var editorEscapeCount = 0
+        var showDanmakuEditor by mutableStateOf(true)
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                Player(
+                    GestureFamily.TOUCH,
+                    playerControllerState = visibleControllerState,
+                    onExitFullscreen = { exitFullscreenCount++ },
+                    showDanmakuEditor = { showDanmakuEditor },
+                    onEditorEscape = {
+                        editorEscapeCount++
+                        showDanmakuEditor = false
+                    },
+                )
+            }
+        }
+        waitForIdle()
+
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditor.performKeyInput {
+            pressKey(Key.Escape)
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        danmakuEditor.doesNotExist()
+        runOnIdle {
+            assertEquals(1, editorEscapeCount)
+            assertEquals(0, exitFullscreenCount)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Escape)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1, exitFullscreenCount)
+        }
+    }
+
+    @Test
+    fun `mouse - keyboard shortcuts - reclaim focus from editor on mouse move`() = runAniComposeUiTest {
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+            )
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+
+        videoGestureHost.slightlyMoveFromCenterToRight()
+        waitForIdle()
+        videoGestureHost.assertIsFocused()
+    }
+
+    @Test
+    fun `mouse - keyboard shortcuts - reclaim focus when editor closes`() = runAniComposeUiTest {
+        lateinit var playerState: TestMediampPlayer
+        var showDanmakuEditor by mutableStateOf(true)
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+                onPlayerStateCreated = { playerState = it },
+                showDanmakuEditor = { showDanmakuEditor },
+            )
+        }
+        waitForIdle()
+        runOnIdle {
+            playerState.playbackState.value = PlaybackState.PAUSED
+        }
+
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+        runOnIdle {
+            showDanmakuEditor = false
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Spacebar)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(PlaybackState.PLAYING, playerState.playbackState.value)
+        }
+    }
+
+    @Test
+    fun `mouse - keyboard shortcuts - reclaim focus after fullscreen button click on mouse move`() = runAniComposeUiTest {
+        var fullscreenCount = 0
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+                onClickFullScreen = { fullscreenCount++ },
+            )
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        onNodeWithContentDescription("Exit Fullscreen").performClick()
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1, fullscreenCount)
+        }
+
+        videoGestureHost.slightlyMoveFromCenterToRight()
+        waitForIdle()
+        videoGestureHost.assertIsFocused()
+    }
+
+    @Test
+    fun `touch - keyboard shortcuts - reclaim focus from editor on mouse move`() = runAniComposeUiTest {
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                Player(
+                    GestureFamily.TOUCH,
+                    playerControllerState = visibleControllerState,
+                )
+            }
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+
+        videoGestureHost.slightlyMoveFromCenterToRight()
+        waitForIdle()
+        videoGestureHost.assertIsFocused()
+    }
+
+    @Test
+    fun `mouse - keyboard shortcuts - reclaim focus when fullscreen changes`() = runAniComposeUiTest {
+        lateinit var platformWindow: PlatformWindow
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+                onPlatformWindow = { platformWindow = it },
+            )
+        }
+        waitForIdle()
+
+        onNodeWithContentDescription("Exit Fullscreen").performClick()
+        runOnIdle {
+            platformWindow.windowState.placement = WindowPlacement.Fullscreen
+        }
+        waitForIdle()
+        videoGestureHost.assertIsFocused()
+
+        onNodeWithContentDescription("Exit Fullscreen").performClick()
+        runOnIdle {
+            platformWindow.windowState.placement = WindowPlacement.Floating
+        }
+        waitForIdle()
+        videoGestureHost.assertIsFocused()
+    }
+
+    @Test
+    fun `mouse - keyboard shortcuts - preserve editor focus when fullscreen changes`() = runAniComposeUiTest {
+        lateinit var platformWindow: PlatformWindow
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+                onPlatformWindow = { platformWindow = it },
+            )
+        }
+        waitForIdle()
+
+        danmakuEditor.performClick()
+        danmakuEditor.onChild().assertIsFocused()
+        runOnIdle {
+            platformWindow.windowState.placement = WindowPlacement.Fullscreen
+        }
+        waitForIdle()
+        danmakuEditor.onChild().assertIsFocused()
+
+        runOnIdle {
+            platformWindow.windowState.placement = WindowPlacement.Floating
+        }
+        waitForIdle()
+        danmakuEditor.onChild().assertIsFocused()
     }
 
     private fun AniComposeUiTest.testClickAndWaitForHide() {

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowState
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.him188.ani.app.data.models.preference.DarkMode
@@ -195,18 +196,21 @@ class EpisodeVideoControllerTest {
         playbackSpeedControllerState: PlaybackSpeedControllerState? = null,
         onPlayerStateCreated: (TestMediampPlayer) -> Unit = {},
         onPlatformWindow: (PlatformWindow) -> Unit = {},
+        platformWindowOverride: PlatformWindow? = null,
         showDanmakuEditor: () -> Boolean = { true },
         onEditorEscape: (() -> Unit)? = null,
     ) {
         ProvideCompositionLocalsForPreview(darkMode = DarkMode.DARK) {
-            onPlatformWindow(LocalPlatformWindow.current)
-            val scope = rememberCoroutineScope()
-            val playerState = remember {
-                TestMediampPlayer(scope.coroutineContext).also(onPlayerStateCreated)
-            }
-            val expanded = true
-            val cacheProgressInfoFlow = staticMediaCacheProgressState(ChunkState.NONE).flow
-            EpisodeVideoImpl(
+            val platformWindow = platformWindowOverride ?: LocalPlatformWindow.current
+            CompositionLocalProvider(LocalPlatformWindow provides platformWindow) {
+                onPlatformWindow(platformWindow)
+                val scope = rememberCoroutineScope()
+                val playerState = remember {
+                    TestMediampPlayer(scope.coroutineContext).also(onPlayerStateCreated)
+                }
+                val expanded = true
+                val cacheProgressInfoFlow = staticMediaCacheProgressState(ChunkState.NONE).flow
+                EpisodeVideoImpl(
                 playerState = playerState,
                 expanded = expanded,
                 hasNextEpisode = true,
@@ -319,9 +323,16 @@ class EpisodeVideoControllerTest {
                 shareData = MediaShareData(null, null),
                 onClickCache = {},
                 modifier = Modifier.testTag("PLAYER"),
-            )
+                )
+            }
         }
     }
+
+    private fun placementBackedPlatformWindow(): PlatformWindow = PlatformWindow(
+        windowHandle = 0L,
+        windowState = WindowState(),
+        platform = Platform.Linux(Arch.X86_64),
+    )
 
     private class TestLevelController(
         initialLevel: Float,
@@ -761,13 +772,13 @@ class EpisodeVideoControllerTest {
 
     @Test
     fun `mouse - keyboard shortcuts - reclaim focus when fullscreen changes`() = runAniComposeUiTest {
-        lateinit var platformWindow: PlatformWindow
+        val platformWindow = placementBackedPlatformWindow()
         val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
         setContent {
             Player(
                 GestureFamily.MOUSE,
                 playerControllerState = visibleControllerState,
-                onPlatformWindow = { platformWindow = it },
+                platformWindowOverride = platformWindow,
             )
         }
         waitForIdle()
@@ -789,13 +800,13 @@ class EpisodeVideoControllerTest {
 
     @Test
     fun `mouse - keyboard shortcuts - preserve editor focus when fullscreen changes`() = runAniComposeUiTest {
-        lateinit var platformWindow: PlatformWindow
+        val platformWindow = placementBackedPlatformWindow()
         val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
         setContent {
             Player(
                 GestureFamily.MOUSE,
                 playerControllerState = visibleControllerState,
-                onPlatformWindow = { platformWindow = it },
+                platformWindowOverride = platformWindow,
             )
         }
         waitForIdle()

--- a/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.videoplayer.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -20,6 +21,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import me.him188.ani.app.ui.foundation.effects.ComposeKey
+import me.him188.ani.app.ui.foundation.effects.onKey
 import me.him188.ani.app.ui.foundation.interaction.hoverable
 import me.him188.ani.utils.platform.annotations.TestOnly
 
@@ -33,6 +40,86 @@ fun rememberVideoControllerState(
 ): PlayerControllerState {
     return remember {
         PlayerControllerState(initialVisibility)
+    }
+}
+
+enum class PlayerFocusTarget {
+    PLAYER,
+    TEXT_INPUT,
+}
+
+/** Coordinates focus policy; [preferredTarget] is intent, not the currently focused Compose node. */
+@Stable
+class PlayerFocusState {
+    var preferredTarget: PlayerFocusTarget by mutableStateOf(PlayerFocusTarget.PLAYER)
+        private set
+
+    internal val requester = FocusRequester()
+    private var textInputOwner: Any? = null
+
+    fun preferPlayer() {
+        textInputOwner = null
+        preferredTarget = PlayerFocusTarget.PLAYER
+    }
+
+    internal fun preferTextInput(owner: Any) {
+        textInputOwner = owner
+        preferredTarget = PlayerFocusTarget.TEXT_INPUT
+    }
+
+    internal fun releaseTextInput(owner: Any) {
+        if (textInputOwner === owner) {
+            preferPlayer()
+        }
+    }
+
+    internal fun requestPlayerFocus() {
+        preferPlayer()
+        requester.requestFocus()
+    }
+
+    internal fun restorePlayerFocusIfPreferred() {
+        if (preferredTarget == PlayerFocusTarget.PLAYER) {
+            requester.requestFocus()
+        }
+    }
+}
+
+/** Attaches the player requester and restores focus when its policy or [reapplyKey] changes. */
+@Composable
+internal fun Modifier.playerFocusHost(
+    state: PlayerFocusState,
+    reapplyKey: Any?,
+): Modifier {
+    val preferredTarget = state.preferredTarget
+
+    LaunchedEffect(state, preferredTarget, reapplyKey) {
+        state.restorePlayerFocusIfPreferred()
+    }
+    return focusRequester(state.requester)
+}
+
+fun Modifier.playerTextInputFocus(
+    state: PlayerFocusState,
+    onEscape: (() -> Unit)? = null,
+): Modifier = composed {
+    val owner = remember { Any() }
+    DisposableEffect(state, owner) {
+        onDispose {
+            state.releaseTextInput(owner)
+        }
+    }
+
+    onFocusChanged {
+        if (it.hasFocus) {
+            state.preferTextInput(owner)
+        }
+    }.onKey(ComposeKey.Escape) {
+        if (onEscape == null) {
+            state.requestPlayerFocus()
+        } else {
+            onEscape()
+        }
     }
 }
 
@@ -85,6 +172,8 @@ class PlayerControllerState(
     companion object {
         val DEFAULT_INITIAL_VISIBILITY = ControllerVisibility.Invisible
     }
+
+    val focusState = PlayerFocusState()
 
     private var fullVisible by mutableStateOf(initialVisibility == ControllerVisibility.Visible)
     private val hasProgressBarRequester by derivedStateOf { progressBarRequesters.isNotEmpty() }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -17,7 +17,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -618,7 +617,6 @@ fun PlayerGestureHost(
                         }
                     }
                 }
-                .focusable()
                 .fillMaxSize(),
         ) {
             Row(

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -52,7 +53,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -65,17 +65,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.coerceAtLeast
@@ -85,8 +77,6 @@ import kotlinx.coroutines.flow.collectLatest
 import me.him188.ani.app.tools.rememberUiMonoTasker
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
-import me.him188.ani.app.ui.foundation.effects.ComposeKey
-import me.him188.ani.app.ui.foundation.effects.onKey
 import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.isSystemInFullscreen
@@ -94,6 +84,7 @@ import me.him188.ani.app.utils.fixToString
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
+import me.him188.ani.app.videoplayer.ui.playerFocusHost
 import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.BRIGHTNESS
 import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.FAST_BACKWARD
 import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.FAST_FORWARD
@@ -104,7 +95,6 @@ import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.VOLU
 import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
 import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
-import me.him188.ani.app.videoplayer.ui.top.needWorkaroundForFocusManager
 import me.him188.ani.utils.platform.Platform
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.features.AudioLevelController
@@ -376,7 +366,6 @@ val Platform.mouseFamily: GestureFamily
 
 @Immutable
 enum class GestureFamily(
-    val useDesktopGestureLayoutWorkaround: Boolean,
     val clickToPauseResume: Boolean,
     val clickToToggleController: Boolean,
     val doubleClickToFullscreen: Boolean,
@@ -388,16 +377,9 @@ enum class GestureFamily(
     val scrollForVolume: Boolean,
     val autoHideController: Boolean,
     val volumeControllerOnBottomBar: Boolean,
-    val keyboardSpaceForPauseResume: Boolean = true,
-    val keyboardUpDownForVolume: Boolean = true,
-    val keyboardLeftRightToSeek: Boolean = true,
     val mouseHoverForController: Boolean = true, // not supported on mobile
-    val keyboardControlFullscreen: Boolean = true,
-    val keyboardControlSpeed: Boolean = true,
-    val keyboardToggleDanmaku: Boolean = true,
 ) {
     TOUCH(
-        useDesktopGestureLayoutWorkaround = false,
         clickToPauseResume = false,
         clickToToggleController = true,
         doubleClickToFullscreen = false,
@@ -412,7 +394,6 @@ enum class GestureFamily(
         mouseHoverForController = false,
     ),
     MOUSE(
-        useDesktopGestureLayoutWorkaround = true,
         clickToPauseResume = true,
         clickToToggleController = false,
         doubleClickToFullscreen = true,
@@ -470,394 +451,238 @@ fun PlayerGestureHost(
         val adjustingForwardOrBackward =
             indicatorState.visible && (indicatorState.state == FAST_FORWARD || indicatorState.state == FAST_BACKWARD)
 
-        // TODO: 临时解决方案, 安卓和 PC 需要不同的组件层级关系才能实现各种快捷手势
-        val needWorkaroundForFocusManager = needWorkaroundForFocusManager
-        if (family.useDesktopGestureLayoutWorkaround) {
-            val indicatorTasker = rememberUiMonoTasker()
-            val focusRequester = remember { FocusRequester() }
-            val manager = LocalFocusManager.current
-            val keyboardFocus = remember { FocusRequester() } // focus 了才能用键盘快捷键
+        val indicatorTasker = rememberUiMonoTasker()
+        val audioLevelController = playerState.features[AudioLevelController]
+        val useMediaAudioController = family == GestureFamily.MOUSE
+        val systemFullscreen = isSystemInFullscreen()
+        val playerFocusState = controllerState.focusState
 
-            val audioLevelController = playerState.features[AudioLevelController]
-            Box(
-                modifier
-                    .focusRequester(keyboardFocus)
-                    .ifThen(family.swipeToSeek) {
-                        swipeToSeek(
-                            seekerState,
-                            Orientation.Horizontal,
-                            //调节音量/亮度时禁用水平seek
-                            enabled = !adjustingVolumeOrBrightness,
-                        )
-                    }
-                    .ifThen(family.keyboardLeftRightToSeek) {
-                        keyboardSeekAndFastForward(
-                            onSeekBackward = {
-                                seekerState.onSeek(-5)
-                            },
-                            onSeekForward = {
-                                seekerState.onSeek(5)
-                            },
-                            fastSkipState = fastSkipState,
-                        )
-                    }
-                    .ifThen(family.keyboardUpDownForVolume && audioLevelController != null) {
-                        if (audioLevelController == null) return@ifThen this
-                        onKeyEvent {
-                            if (it.type == KeyEventType.KeyUp) return@onKeyEvent false
-                            val consumed = when {
-                                it.isShiftPressed && it.key == ComposeKey.DirectionUp -> {
-                                    audioLevelController.volumeUp(0.01f)
-                                    true
-                                }
-
-                                it.isShiftPressed && it.key == ComposeKey.DirectionDown -> {
-                                    audioLevelController.volumeDown(0.01f)
-                                    true
-                                }
-
-                                it.key == ComposeKey.DirectionUp -> {
-                                    audioLevelController.volumeUp()
-                                    true
-                                }
-
-                                it.key == ComposeKey.DirectionDown -> {
-                                    audioLevelController.volumeDown()
-                                    true
-                                }
-
-                                else -> false
-                            }
-                            if (consumed) {
-                                audioLevelController.setMute(false)
-                                indicatorTasker.launch {
-                                    indicatorState.showVolumeRange(audioLevelController.volume.value / audioLevelController.maxVolume)
-                                }
-                            }
-                            consumed
+        val keyboardModifier = modifier
+            .testTag("VideoGestureHost")
+            .playerKeyboardShortcuts(
+                seekerState = seekerState,
+                fastSkipState = fastSkipState,
+                playbackSpeedControllerState = playbackSpeedControllerState,
+                volumeEnabled = !useMediaAudioController || audioLevelController != null,
+                onVolumeUp = { fineAdjustment ->
+                    if (useMediaAudioController) {
+                        checkNotNull(audioLevelController)
+                        if (fineAdjustment) audioLevelController.volumeUp(0.01f) else audioLevelController.volumeUp()
+                        audioLevelController.setMute(false)
+                        indicatorTasker.launch {
+                            indicatorState.showVolumeRange(audioLevelController.volume.value / audioLevelController.maxVolume)
+                        }
+                    } else {
+                        audioController.increaseLevel(if (fineAdjustment) audioController.levelStep else 0.10f)
+                        indicatorTasker.launch {
+                            indicatorState.showVolumeRange(audioController.level)
                         }
                     }
-                    .ifThen(family.keyboardSpaceForPauseResume) {
-                        onKey(ComposeKey.Spacebar) {
-                            onTogglePauseResumeState()
+                },
+                onVolumeDown = { fineAdjustment ->
+                    if (useMediaAudioController) {
+                        checkNotNull(audioLevelController)
+                        if (fineAdjustment) audioLevelController.volumeDown(0.01f) else audioLevelController.volumeDown()
+                        audioLevelController.setMute(false)
+                        indicatorTasker.launch {
+                            indicatorState.showVolumeRange(audioLevelController.volume.value / audioLevelController.maxVolume)
+                        }
+                    } else {
+                        audioController.decreaseLevel(if (fineAdjustment) audioController.levelStep else 0.10f)
+                        indicatorTasker.launch {
+                            indicatorState.showVolumeRange(audioController.level)
                         }
                     }
-                    .ifThen(family.mouseHoverForController) {
-                        val scope = rememberUiMonoTasker()
-                        // 没有人请求 alwaysOn 时自动隐藏控制器
-                        LaunchedEffect(true) {
-                            snapshotFlow { controllerState.alwaysOn }.collectLatest { alwaysOn ->
-                                if (alwaysOn) return@collectLatest
-                                snapshotFlow { controllerState.visibility != ControllerVisibility.Invisible }.collectLatest {
-                                    if (!it) {
-                                        delay(VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION)
-                                        controllerState.toggleFullVisible(false)
-                                    }
-                                }
-                            }
-                        }
-                        // 这里不能用 hover, 因为在当控制器隐藏后, hover 状态仍然有, 于是下次移动鼠标时不会重复触发 hover 事件, 也就无法显示
-                        // See test case: `mouse - mouseHoverForController - center screen twice`
-                        onPointerEventMultiplatform(PointerEventType.Move) { _ ->
-                            controllerState.toggleFullVisible(true)
-                            keyboardFocus.requestFocus()
-                            scope.launch {
-                                delay(VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION)
-                                controllerState.toggleFullVisible(false)
-                            }
-                        }
-                    }
-                    .ifThen(family.keyboardControlFullscreen) {
-                        onKey(ComposeKey.Escape) {
-                            if (needWorkaroundForFocusManager) {
-                                manager.clearFocus()
-                            }
-                            onExitFullscreen()
-                        }.onKey(ComposeKey.F) {
-                            if (needWorkaroundForFocusManager) {
-                                manager.clearFocus()
-                            }
-                            onToggleFullscreen()
-                        }
-                    }
-                    .ifThen(family.keyboardControlSpeed && playbackSpeedControllerState != null) {
-                        if (playbackSpeedControllerState == null) return@ifThen this
-                        onKey(ComposeKey.A) { playbackSpeedControllerState.speedDown() }
-                            .onKey(ComposeKey.D) { playbackSpeedControllerState.speedUp() }
-                            .onKey(ComposeKey.S) { playbackSpeedControllerState.reset() }
-                    }
-                    .ifThen(family.keyboardToggleDanmaku) {
-                        onKey(ComposeKey.B, onToggleDanmaku)
-                    }
-                    .ifThen(family.scrollForVolume && audioLevelController != null) {
-                        if (audioLevelController == null) return@ifThen this
-                        onPointerEventMultiplatform(PointerEventType.Scroll) { event ->
-                            event.changes.firstOrNull()?.scrollDelta?.y?.run {
-                                audioLevelController.setMute(false)
-                                if (this < 0) audioLevelController.volumeUp()
-                                else if (this > 0) audioLevelController.volumeDown()
+                },
+                onTogglePauseResume = onTogglePauseResumeState,
+                onToggleFullscreen = onToggleFullscreen,
+                onExitFullscreen = onExitFullscreen,
+                onToggleDanmaku = onToggleDanmaku,
+            )
+            .playerFocusHost(playerFocusState, systemFullscreen)
 
-                                indicatorTasker.launch {
-                                    indicatorState.showVolumeRange(audioLevelController.volume.value / audioLevelController.maxVolume)
-                                }
+        if (family.autoHideController) {
+            LaunchedEffect(controllerState.visibility, controllerState.alwaysOn) {
+                if (controllerState.alwaysOn) return@LaunchedEffect
+                if (controllerState.visibility.bottomBar) {
+                    delay(VIDEO_GESTURE_TOUCH_SHOW_CONTROLLER_DURATION)
+                    controllerState.toggleFullVisible(false)
+                }
+            }
+        }
+
+        if (family.mouseHoverForController) {
+            // 没有人请求 alwaysOn 时自动隐藏控制器
+            LaunchedEffect(controllerState) {
+                snapshotFlow { controllerState.alwaysOn }.collectLatest { alwaysOn ->
+                    if (alwaysOn) return@collectLatest
+                    snapshotFlow { controllerState.visibility != ControllerVisibility.Invisible }.collectLatest {
+                        if (!it) {
+                            delay(VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION)
+                            controllerState.toggleFullVisible(false)
+                        }
+                    }
+                }
+            }
+        }
+
+        @Composable
+        fun Modifier.combineClickableWithFamilyGesture() = this then
+                combinedClickable(
+                    remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = remember(family, playerFocusState) {
+                        {
+                            if (family.clickToPauseResume) {
+                                onTogglePauseResumeState()
+                            }
+                            if (family.clickToToggleController) {
+                                controllerState.toggleFullVisible()
+                            }
+                            playerFocusState.requestPlayerFocus()
+                        }
+                    },
+                    onDoubleClick = remember(family, onToggleFullscreen, playerFocusState) {
+                        {
+                            if (family.doubleClickToFullscreen) {
+                                onToggleFullscreen()
+                            }
+                            if (family.doubleClickToPauseResume) {
+                                onTogglePauseResumeState()
+                            }
+                            playerFocusState.requestPlayerFocus()
+                        }
+                    },
+                )
+
+        val mouseMoveTasker = rememberUiMonoTasker()
+        Box(
+            keyboardModifier
+                .combineClickableWithFamilyGesture()
+                .ifThen(family.swipeToSeek && enableSwipeToSeek) {
+                    val swipeToSeekRequester = rememberAlwaysOnRequester(controllerState, "swipeToSeek")
+                    swipeToSeek(
+                        seekerState,
+                        Orientation.Horizontal,
+                        //调节音量/亮度时禁用水平seek
+                        enabled = !adjustingVolumeOrBrightness,
+                        onDragStarted = {
+                            if (controllerState.visibility.bottomBar) {
+                                swipeToSeekRequester.request()
+                            }
+                            controllerState.setRequestProgressBar(swipeToSeekRequester)
+                        },
+                        onDragStopped = {
+                            if (controllerState.visibility.bottomBar) {
+                                swipeToSeekRequester.cancelRequest()
+                            }
+                            controllerState.cancelRequestProgressBarVisible(swipeToSeekRequester)
+                            progressSliderState.finishPreview()
+                        },
+                    ) {
+                        progressSliderState.run {
+                            if (totalDurationMillis == 0L) return@run
+                            val offsetRatio =
+                                (currentPositionMillis + seekerState.deltaSeconds.times(1000)).toFloat() / totalDurationMillis
+                            previewPositionRatio(offsetRatio.coerceIn(0f, 1f))
+                        }
+                    }
+                }
+                .onPointerEventMultiplatform(PointerEventType.Move) { event ->
+                    if (event.changes.firstOrNull()?.type == PointerType.Mouse) {
+                        playerFocusState.requestPlayerFocus()
+                    }
+                }
+                .ifThen(family.mouseHoverForController) {
+                    // 这里不能用 hover, 因为在当控制器隐藏后, hover 状态仍然有, 于是下次移动鼠标时不会重复触发 hover 事件, 也就无法显示
+                    // See test case: `mouse - mouseHoverForController - center screen twice`
+                    onPointerEventMultiplatform(PointerEventType.Move) { _ ->
+                        controllerState.toggleFullVisible(true)
+                        mouseMoveTasker.launch {
+                            delay(VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION)
+                            controllerState.toggleFullVisible(false)
+                        }
+                    }
+                }
+                .ifThen(family.scrollForVolume && audioLevelController != null) {
+                    if (audioLevelController == null) return@ifThen this
+                    onPointerEventMultiplatform(PointerEventType.Scroll) { event ->
+                        event.changes.firstOrNull()?.scrollDelta?.y?.run {
+                            audioLevelController.setMute(false)
+                            if (this < 0) audioLevelController.volumeUp()
+                            else if (this > 0) audioLevelController.volumeDown()
+
+                            indicatorTasker.launch {
+                                indicatorState.showVolumeRange(audioLevelController.volume.value / audioLevelController.maxVolume)
                             }
                         }
                     }
-                    .fillMaxSize(),
+                }
+                .focusable()
+                .fillMaxSize(),
+        ) {
+            Row(
+                Modifier.matchParentSize()
+                    .ifThen(
+                        family.swipeLhsForBrightness ||
+                                family.swipeRhsForVolume ||
+                                family.longPressForFastSkip,
+                    ) {
+                        systemGesturesPadding()
+                    }
+                    .ifThen(family.longPressForFastSkip) {
+                        fastSkipState?.let {
+                            longPressFastSkip(it, SkipDirection.FORWARD)
+                        }
+                    },
             ) {
                 Box(
                     Modifier
-                        .ifThen(needWorkaroundForFocusManager) {
-                            onFocusEvent {
-                                if (it.hasFocus) {
-                                    focusRequester.requestFocus()
-                                }
-                            }
+                        .ifThen(family.swipeLhsForBrightness) {
+                            swipeLevelControlWithIndicator(
+                                brightnessController,
+                                ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
+                                Orientation.Vertical,
+                                indicatorState,
+                                enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
+                                step = 0.01f,
+                                setup = {
+                                    indicatorState.state = BRIGHTNESS
+                                },
+                            )
                         }
-                        .matchParentSize()
-                        .combinedClickable(
-                            remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = remember(family) {
-                                {
-                                    if (family.clickToPauseResume) {
-                                        onTogglePauseResumeState()
-                                    }
-                                    if (family.clickToToggleController) {
-                                        controllerState.toggleFullVisible()
-                                    }
-                                }
-                            },
-                            onDoubleClick = remember(family, onToggleFullscreen) {
-                                {
-                                    if (needWorkaroundForFocusManager) {
-                                        manager.clearFocus()
-                                    }
-                                    if (family.doubleClickToFullscreen) {
-                                        onToggleFullscreen()
-                                    }
-                                    if (family.doubleClickToPauseResume) {
-                                        onTogglePauseResumeState()
-                                    }
-                                }
-                            },
-                        ),
+                        .weight(1f)
+                        .fillMaxHeight(),
+                )
 
-                    )
+                Box(Modifier.weight(1f).fillMaxHeight())
 
-                Row(Modifier.focusRequester(focusRequester).matchParentSize()) {
-                    Box(
-                        Modifier
-                            .ifThen(family.swipeLhsForBrightness) {
-                                swipeLevelControlWithIndicator(
-                                    brightnessController,
-                                    ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
-                                    Orientation.Vertical,
-                                    indicatorState,
-                                    enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
-                                    step = 0.01f,
-                                    setup = {
-                                        indicatorState.state = BRIGHTNESS
-                                    },
-                                )
-                            }
-                            .weight(1f)
-                            .fillMaxHeight(),
-                    )
-
-                    Box(Modifier.weight(1f).fillMaxHeight())
-
-                    Box(
-                        Modifier
-                            .ifThen(family.swipeRhsForVolume) {
-                                swipeLevelControlWithIndicator(
-                                    audioController,
-                                    ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
-                                    Orientation.Vertical,
-                                    indicatorState,
-                                    enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
-                                    step = 0.05f,
-                                    setup = {
-                                        indicatorState.state = VOLUME
-                                    },
-                                )
-                            }
-                            .weight(1f)
-                            .fillMaxHeight(),
-                    )
-                }
-
-                SideEffect {
-                    focusRequester.requestFocus()
-                }
+                Box(
+                    Modifier
+                        .ifThen(family.swipeRhsForVolume) {
+                            swipeLevelControlWithIndicator(
+                                audioController,
+                                ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
+                                Orientation.Vertical,
+                                indicatorState,
+                                enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
+                                step = 0.05f,
+                                setup = {
+                                    indicatorState.state = VOLUME
+                                },
+                            )
+                        }
+                        .weight(1f)
+                        .fillMaxHeight(),
+                )
             }
-        } else {
+        }
 
-            val indicatorTasker = rememberUiMonoTasker()
-            val focusManager by rememberUpdatedState(LocalFocusManager.current) // workaround for #288
-
-            if (family.autoHideController) {
-                LaunchedEffect(controllerState.visibility, controllerState.alwaysOn) {
-                    if (controllerState.alwaysOn) return@LaunchedEffect
-                    if (controllerState.visibility.bottomBar) {
-                        delay(VIDEO_GESTURE_TOUCH_SHOW_CONTROLLER_DURATION)
-                        controllerState.toggleFullVisible(false)
-                    }
-                }
-            }
-
-            @Composable
-            fun Modifier.combineClickableWithFamilyGesture() = this then
-                    combinedClickable(
-                        remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = remember(family) {
-                            {
-                                if (family.clickToPauseResume) {
-                                    onTogglePauseResumeState()
-                                }
-                                if (family.clickToToggleController) {
-                                    focusManager.clearFocus()
-                                    controllerState.toggleFullVisible()
-                                }
-                            }
-                        },
-                        onDoubleClick = remember(family, onToggleFullscreen) {
-                            {
-                                if (family.doubleClickToFullscreen) {
-                                    onToggleFullscreen()
-                                }
-                                if (family.doubleClickToPauseResume) {
-                                    onTogglePauseResumeState()
-                                }
-                            }
-                        },
-                    )
-            Box(
-                modifier
-                    .testTag("VideoGestureHost")
-                    .ifThen(needWorkaroundForFocusManager) {
-                        onFocusEvent {
-                            if (it.hasFocus) {
-                                focusManager.clearFocus()
-                            }
-                        }
-                    }
-                    .combineClickableWithFamilyGesture()
-                    .ifThen(family.swipeToSeek && enableSwipeToSeek) {
-                        val swipeToSeekRequester = rememberAlwaysOnRequester(controllerState, "swipeToSeek")
-                        swipeToSeek(
-                            seekerState,
-                            Orientation.Horizontal,
-                            //调节音量/亮度时禁用水平seek
-                            enabled = !adjustingVolumeOrBrightness,
-                            onDragStarted = {
-                                if (controllerState.visibility.bottomBar) {
-                                    swipeToSeekRequester.request()
-                                }
-                                controllerState.setRequestProgressBar(swipeToSeekRequester)
-                            },
-                            onDragStopped = {
-                                if (controllerState.visibility.bottomBar) {
-                                    swipeToSeekRequester.cancelRequest()
-                                }
-                                controllerState.cancelRequestProgressBarVisible(swipeToSeekRequester)
-                                progressSliderState.finishPreview()
-                            },
-                        ) {
-                            progressSliderState.run {
-                                if (totalDurationMillis == 0L) return@run
-                                val offsetRatio =
-                                    (currentPositionMillis + seekerState.deltaSeconds.times(1000)).toFloat() / totalDurationMillis
-                                previewPositionRatio(offsetRatio.coerceIn(0f, 1f))
-                            }
-                        }
-                    }
-                    .ifThen(family.keyboardLeftRightToSeek) {
-                        keyboardSeekAndFastForward(
-                            onSeekBackward = {
-                                seekerState.onSeek(-5)
-                            },
-                            onSeekForward = {
-                                seekerState.onSeek(5)
-                            },
-                            fastSkipState = fastSkipState,
-                        )
-                    }
-                    .ifThen(family.keyboardUpDownForVolume) {
-                        audioController.let { controller ->
-                            onKey(ComposeKey.DirectionUp) {
-                                controller.increaseLevel(0.10f)
-                            }
-                            onKey(ComposeKey.DirectionDown) {
-                                controller.decreaseLevel(0.10f)
-                            }
-                        }
-                    }
-                    .ifThen(family.keyboardSpaceForPauseResume) {
-                        onKey(ComposeKey.Spacebar) {
-                            onTogglePauseResumeState()
-                        }
-                    }
-                    .fillMaxSize(),
-            ) {
-                Row(
-                    Modifier.matchParentSize()
-                        .systemGesturesPadding()
-                        .ifThen(family.longPressForFastSkip) {
-                            fastSkipState?.let {
-                                longPressFastSkip(it, SkipDirection.FORWARD)
-                            }
-                        },
-                ) {
-                    Box(
-                        Modifier
-                            .ifThen(family.swipeLhsForBrightness) {
-                                swipeLevelControlWithIndicator(
-                                    brightnessController,
-                                    ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
-                                    Orientation.Vertical,
-                                    indicatorState,
-                                    enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
-                                    step = 0.01f,
-                                    setup = {
-                                        indicatorState.state = BRIGHTNESS
-                                    },
-                                )
-                            }
-                            .weight(1f)
-                            .fillMaxHeight(),
-                    )
-
-                    Box(Modifier.weight(1f).fillMaxHeight())
-
-                    Box(
-                        Modifier
-                            .ifThen(family.swipeRhsForVolume) {
-                                swipeLevelControlWithIndicator(
-                                    audioController,
-                                    ((maxHeight - 100.dp) / 40).coerceAtLeast(2.dp),
-                                    Orientation.Vertical,
-                                    indicatorState,
-                                    enabled = !seekerState.isSeeking && !adjustingForwardOrBackward,
-                                    step = 0.05f,
-                                    setup = {
-                                        indicatorState.state = VOLUME
-                                    },
-                                )
-                            }
-                            .weight(1f)
-                            .fillMaxHeight(),
-                    )
-                }
-            }
-
+        if (family.clickToToggleController && systemFullscreen) {
             // 状态栏区域响应点击手势
             Box(
                 Modifier.fillMaxWidth()
-                    .ifThen(isSystemInFullscreen()) {
-                        windowInsetsTopHeight(WindowInsets.systemGestures)
-                    }
+                    .windowInsetsTopHeight(WindowInsets.systemGestures)
                     .combineClickableWithFamilyGesture(),
             )
         }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import me.him188.ani.app.ui.foundation.effects.ComposeKey
 import me.him188.ani.app.ui.foundation.effects.onKey
@@ -70,5 +71,12 @@ internal fun Modifier.playerKeyboardShortcuts(
             .onKey(ComposeKey.D, playbackSpeedControllerState::speedUp)
             .onKey(ComposeKey.S, playbackSpeedControllerState::reset)
     }
-    return result.onKey(ComposeKey.B, onToggleDanmaku)
+    return result
+        .onKey(ComposeKey.B, onToggleDanmaku)
+        // The same node carries combinedClickable, which treats Enter as a click when focused.
+        // Enter is not a player shortcut, so swallow it; DPad center is left for clickable so that
+        // remote/DPad activation still works like a tap.
+        .onPreviewKeyEvent { event ->
+            event.key == ComposeKey.Enter || event.key == ComposeKey.NumPadEnter
+        }
 }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import me.him188.ani.app.ui.foundation.effects.ComposeKey
+import me.him188.ani.app.ui.foundation.effects.onKey
+import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
+
+/**
+ * Installs the player keyboard commands on a single focus target.
+ *
+ * The caller owns focus policy. Commands are active only while the modified node owns focus, so a text field or
+ * another player control can temporarily take keyboard input without triggering playback commands.
+ */
+internal fun Modifier.playerKeyboardShortcuts(
+    seekerState: SwipeSeekerState,
+    fastSkipState: FastSkipState?,
+    playbackSpeedControllerState: PlaybackSpeedControllerState?,
+    volumeEnabled: Boolean,
+    onVolumeUp: (fineAdjustment: Boolean) -> Unit,
+    onVolumeDown: (fineAdjustment: Boolean) -> Unit,
+    onTogglePauseResume: () -> Unit,
+    onToggleFullscreen: () -> Unit,
+    onExitFullscreen: () -> Unit,
+    onToggleDanmaku: () -> Unit,
+): Modifier {
+    var result = keyboardSeekAndFastForward(
+        onSeekBackward = { seekerState.onSeek(-5) },
+        onSeekForward = { seekerState.onSeek(5) },
+        fastSkipState = fastSkipState,
+    )
+    if (volumeEnabled) {
+        result = result.onKeyEvent { event ->
+            if (event.type == KeyEventType.KeyUp) return@onKeyEvent false
+            when (event.key) {
+                ComposeKey.DirectionUp -> {
+                    onVolumeUp(event.isShiftPressed)
+                    true
+                }
+
+                ComposeKey.DirectionDown -> {
+                    onVolumeDown(event.isShiftPressed)
+                    true
+                }
+
+                else -> false
+            }
+        }
+    }
+    result = result
+        .onKey(ComposeKey.Spacebar, onTogglePauseResume)
+        .onKey(ComposeKey.Escape, onExitFullscreen)
+        .onKey(ComposeKey.F, onToggleFullscreen)
+    if (playbackSpeedControllerState != null) {
+        result = result
+            .onKey(ComposeKey.A, playbackSpeedControllerState::speedDown)
+            .onKey(ComposeKey.D, playbackSpeedControllerState::speedUp)
+            .onKey(ComposeKey.S, playbackSpeedControllerState::reset)
+    }
+    return result.onKey(ComposeKey.B, onToggleDanmaku)
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
@@ -15,6 +15,22 @@ import kotlin.test.assertEquals
 
 class PlayerControllerStateTest {
     @Test
+    fun `text input preference returns to player when its owner is released`() {
+        val state = PlayerFocusState()
+        val owner = Any()
+        assertEquals(PlayerFocusTarget.PLAYER, state.preferredTarget)
+
+        state.preferTextInput(owner)
+        assertEquals(PlayerFocusTarget.TEXT_INPUT, state.preferredTarget)
+
+        state.releaseTextInput(Any())
+        assertEquals(PlayerFocusTarget.TEXT_INPUT, state.preferredTarget)
+
+        state.releaseTextInput(owner)
+        assertEquals(PlayerFocusTarget.PLAYER, state.preferredTarget)
+    }
+
+    @Test
     fun `test toggle visibility`() = runTest {
         val state = PlayerControllerState(ControllerVisibility.Visible)
         state.toggleFullVisible()


### PR DESCRIPTION
## 背景

`GestureFamily.TOUCH` 表示移动端采用触屏手势约定，实体键盘和鼠标仍可同时存在。`PlayerGestureHost` 原先按手势类型维护两套组件层级，键盘焦点与鼠标手势分支绑定；触屏分支还会因既有焦点 workaround 清除焦点，缺少稳定、可恢复的键盘焦点目标。

Android 设备连接实体键盘后，播放器无法稳定获得焦点，快捷键不生效。弹幕输入框、全屏切换和播放器之间也缺少统一的焦点流转规则。

## 修改内容

### 统一输入模型

合并 `PlayerGestureHost` 的鼠标和触屏组件层级，让两种手势模式共用同一个手势节点、键盘处理器和焦点管理逻辑。手势类型只决定点击、双击、滑动、滚轮等交互方式，不再决定设备能否使用键盘。

统一后的手势节点显式添加 `Modifier.focusable()`，成为可由 `FocusRequester` 请求和恢复的 Compose 焦点目标。`playerKeyboardShortcuts` 统一安装在该节点上，触屏模式因此可以使用完整的播放器快捷键：

- `Space`：播放或暂停
- `Left` / `Right`：后退或前进
- 长按 `Right`：快进播放
- `Up` / `Down`：调节音量
- `Shift + Up` / `Shift + Down`：微调音量
- `F`：切换全屏
- `Escape`：退出全屏
- `A` / `S` / `D`：降低、重置或提高播放速度
- `B`：开关弹幕

### 引入播放器焦点状态机

新增 `PlayerFocusState`，用两个状态记录键盘输入的优先目标：

- `PLAYER`：播放器应持有焦点，快捷键生效；
- `TEXT_INPUT`：文本输入优先，播放器不处理快捷键。

`preferredTarget` 记录当前焦点策略。Compose 焦点系统仍负责具体节点之间的焦点移动，例如用户按 `Tab` 从输入框移动到其他控件。此时状态保持 `TEXT_INPUT`，播放器不会立即抢回焦点。

`playerFocusHost` 将状态机连接到播放器的 `FocusRequester`。当状态切换为 `PLAYER` 时，它会请求播放器焦点；全屏状态变化后，如果焦点策略仍指向播放器，也会重新应用该请求。

`playerTextInputFocus` 负责登记文本输入框的焦点所有权。每个输入框使用独立 owner，销毁时只释放自己的请求；如果另一个输入框已经接管焦点，旧 owner 的释放操作不会改变当前状态。

播放器会在以下场景切换或恢复到 `PLAYER`：

- 弹幕发送完成；
- 弹幕输入框或分离式编辑器销毁；
- 点击视频区域；
- 鼠标移入视频区域；
- 全屏状态变化，且当前焦点策略指向播放器。

弹幕输入框获得焦点后，状态切换为 `TEXT_INPUT`，播放器快捷键暂停响应。分离式弹幕编辑器中的 `Escape` 会先关闭编辑器，随后恢复播放器焦点，不会直接退出全屏。

### 修正 Android 音量微调

Android 系统音量由离散档位表示。固定调节 1% 时，数值经过系统取整会落回原档位，按键触发后音量保持不变。

本 PR 为 `AudioManager` 增加最小音量步长，并让 Android 返回一个原生音量档位对应的比例。`Shift + Up/Down` 现在稳定调整一个系统可表示的音量档位。