### PR TITLE
fix(desktop): fix app freeze when installing auto-update on macOS

### DIFF
--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -41,6 +41,8 @@ import java.text.SimpleDateFormat
 import java.util.Collections
 import java.util.Date
 import java.util.IdentityHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.swing.SwingUtilities
@@ -343,8 +345,23 @@ object AniCefApp {
         if (!shouldDispose) return
 
         runCatching {
-            blockOnCefContext {
+            if (SwingUtilities.isEventDispatchThread()) {
                 target.dispose()
+            } else {
+                // 此方法会在 JVM shutdown hook 中调用. 若这次 shutdown 是 EDT 调用 System.exit 触发的,
+                // EDT 正阻塞等待 hook 结束, invokeAndWait 无限等待会互相死锁, 进程永远无法退出,
+                // 因此只能有界等待.
+                val latch = CountDownLatch(1)
+                SwingUtilities.invokeLater {
+                    try {
+                        target.dispose()
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+                if (!latch.await(5, TimeUnit.SECONDS)) {
+                    logger.warn { "Timed out waiting for JCEF disposal on EDT, proceeding without it." }
+                }
             }
         }.onFailure {
             logger.warn(it) { "Failed to dispose JCEF." }

--- a/app/shared/src/desktopMain/kotlin/tools/update/DesktopUpdateInstaller.kt
+++ b/app/shared/src/desktopMain/kotlin/tools/update/DesktopUpdateInstaller.kt
@@ -21,6 +21,7 @@ import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.platform.Platform
 import java.io.File
+import kotlin.concurrent.thread
 import kotlin.io.path.createTempDirectory
 import kotlin.system.exitProcess
 
@@ -120,8 +121,7 @@ object MacOSUpdateInstaller : DesktopUpdateInstaller {
             .start()
 
         logger.info { "Exiting old instance." }
-        Thread.sleep(1000)
-        exitProcess(0)
+        return exitProcessForUpdate(delayMillis = 1000)
     }
 
     /**
@@ -276,6 +276,21 @@ object MacOSUpdateInstaller : DesktopUpdateInstaller {
     }
 }
 
+/**
+ * 在后台线程退出进程, 让外部更新程序接管.
+ *
+ * [UpdateInstaller.install] 在 AWT 事件线程 (EDT) 上被调用, 而 System.exit 会阻塞当前线程等待
+ * 所有 JVM shutdown hook 完成, 其中 JCEF 的清理 hook 又需要 EDT 处理事件 —
+ * 在 EDT 上直接 exitProcess 会互相等待, 进程永远无法退出 (#3067 后表现为点击更新后 app 冻结).
+ */
+private fun exitProcessForUpdate(delayMillis: Long): InstallationResult {
+    thread(name = "ani-update-exit") {
+        if (delayMillis > 0) Thread.sleep(delayMillis)
+        exitProcess(0)
+    }
+    return InstallationResult.Succeed
+}
+
 object LinuxUpdateInstaller : DesktopUpdateInstaller {
     override fun deleteOldUpdater() {
         // no-op
@@ -323,7 +338,7 @@ object WindowsUpdateInstaller : DesktopUpdateInstaller {
             .start()
 
         logger.info { "Installer started" }
-        exitProcess(0)
+        return exitProcessForUpdate(delayMillis = 0)
     }
 
     override fun deleteOldUpdater() {


### PR DESCRIPTION
## 问题

macOS 上点击自动更新的"安装"按钮后,app 不再自动关闭,而是直接冻结,更新无法完成。Windows 理论上也受影响。

## 根因

`install()` 由 Compose 点击回调调用,运行在 **AWT EDT** 上,并直接调用了 `exitProcess(0)`:

1. `System.exit` 会阻塞调用线程(EDT),等待所有 JVM shutdown hook 完成;
2. #3067 把 JCEF 清理的 shutdown hook 从非阻塞的 `runOnCefContext`(`invokeLater`)改成了 `disposeAppBlocking` → `blockOnCefContext` → `SwingUtilities.invokeAndWait`,即**阻塞等待 EDT** 来执行 CefApp dispose;
3. EDT 等 hook,hook 等 EDT → 死锁,进程永远退不出去;
4. 外部更新脚本 `while kill -0 $OLD_PID` 一直等旧进程退出,更新永远不会安装。

正常关窗/托盘退出不受影响,因为那条路径先在 EDT 内联执行了 `AniCefApp.disposeBlocking()`,hook 里 `disposedApps` 去重后变 no-op;只有更新安装路径绕过了它直接 `exitProcess`。JCEF 在启动时必然初始化,hook 必然注册,所以所有 macOS 用户点更新 100% 冻结。

## 修复(双保险)

1. **DesktopUpdateInstaller**(mac + Windows):`exitProcess(0)` 挪到后台线程 `exitProcessForUpdate`,`install()` 返回 `Succeed`。EDT 保持空闲,shutdown 期间 CEF 能正常在 EDT 上 dispose。顺带消除了原来 `Thread.sleep(1000)` 卡 UI 一秒的问题。
2. **AniCefApp.disposeAppBlocking**:非 EDT 调用时不再 `invokeAndWait` 无限等待,改为 `invokeLater` + `CountDownLatch` **5 秒有界等待**,超时打 warning 后继续退出。以后即使再有代码从 EDT 直接 `System.exit`,最坏 5 秒后退出,不可能再永久冻结。EDT 上调用行为不变(内联执行),正常退出路径不受影响。

## 验证

- `:app:shared:app-platform:compileKotlinDesktop` + `:app:shared:compileKotlinDesktop` BUILD SUCCESSFUL。
- 用最小 AWT 复现程序实测(Swing 窗口 + shutdown hook):
  - 旧代码(`invokeAndWait` hook + EDT 上 exit)→ **永久冻结**,复现线上问题;
  - 修复后更新流程(后台线程 exit + 有界 hook)→ CEF 在 EDT 干净 dispose,~1.7s 正常退出;
  - 最坏情况(仍在 EDT 上 exit)→ 5 秒超时后正常退出。
- 未做:真实打包 .app 的端到端自动更新验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)