### PR TITLE
feat(pikpak): support explicit BT caching over HTTPS

### DIFF
--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -158,6 +158,8 @@ fun getAndroidModules(
 
     single<HttpMediaCacheEngine> {
         val logger = logger<TorrentManager>()
+        val pikpakConfig = get<SettingsRepository>().pikpakConfig.flow
+            .stateIn(coroutineScope, SharingStarted.Eagerly, PikPakConfig.Default)
 
         val saveDir = get<MediaSaveDirProvider>().saveDir
             .let { Path(it).resolve(HttpMediaCacheEngine.MEDIA_CACHE_DIR) }
@@ -169,6 +171,7 @@ fun getAndroidModules(
             downloader = get<HttpDownloader>(),
             saveDir = saveDir,
             mediaResolver = get<MediaResolver>(),
+            pikpakConfig = { pikpakConfig.value },
         )
     }
 

--- a/app/desktop/src/main/kotlin/DesktopModules.kt
+++ b/app/desktop/src/main/kotlin/DesktopModules.kt
@@ -120,6 +120,8 @@ fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) =
     }
     single<HttpMediaCacheEngine> {
         val saveDir = Path(get<MediaSaveDirProvider>().saveDir).resolve(HttpMediaCacheEngine.MEDIA_CACHE_DIR)
+        val pikpakConfig = get<SettingsRepository>().pikpakConfig.flow
+            .stateIn(scope, SharingStarted.Eagerly, PikPakConfig.Default)
         logger<TorrentManager>().info { "HttpMediaCacheEngine base save dir: $saveDir" }
 
         HttpMediaCacheEngine(
@@ -128,6 +130,7 @@ fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) =
             downloader = get<HttpDownloader>(),
             saveDir = saveDir.toKtPath(),
             mediaResolver = get<MediaResolver>(),
+            pikpakConfig = { pikpakConfig.value },
         )
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/PikPakConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/PikPakConfig.kt
@@ -60,11 +60,13 @@ data class PikPakConfig(
      * [SLOT_QUEUE_UNLIMITED]) that disables eviction entirely.
      */
     val slotQueueLength: Int = 1,
+    /** Number of parallel HTTP range requests used by explicit PikPak caches. */
+    val downloadConcurrency: Int = DEFAULT_DOWNLOAD_CONCURRENCY,
 ) {
     override fun toString(): String {
         return "PikPakConfig(enabled=$enabled, username=$username, password.hash=${password.hashCode()}, " +
                 "refreshToken.hash=${refreshToken.let { if (it.isNotEmpty()) it.hashCode() else "" }}, " +
-                "slotQueueLength=$slotQueueLength)"
+                "slotQueueLength=$slotQueueLength, downloadConcurrency=$downloadConcurrency)"
     }
 
     companion object {
@@ -78,6 +80,10 @@ data class PikPakConfig(
          * stop. Any value ≥ this is treated as unlimited by the engine.
          */
         const val SLOT_QUEUE_UNLIMITED: Int = SLOT_QUEUE_MAX_NUMERIC + 1
+
+        const val MIN_DOWNLOAD_CONCURRENCY: Int = 1
+        const val MAX_DOWNLOAD_CONCURRENCY: Int = 8
+        const val DEFAULT_DOWNLOAD_CONCURRENCY: Int = 4
     }
 }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/engine/HttpMediaCacheEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/engine/HttpMediaCacheEngine.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import me.him188.ani.app.data.persistent.database.dao.HttpCacheDownloadStateDao
+import me.him188.ani.app.data.models.preference.PikPakConfig
 import me.him188.ani.app.domain.media.cache.MediaCache
 import me.him188.ani.app.domain.media.cache.MediaCacheState
 import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
@@ -34,6 +35,7 @@ import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.MediaCacheMetadata
 import me.him188.ani.datasources.api.MediaCacheProperties
+import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
 import me.him188.ani.datasources.api.topic.ResourceLocation
@@ -65,6 +67,7 @@ class HttpMediaCacheEngine(
     private val mediaResolver: MediaResolver,
     private val mediaSourceId: String,
     private val dao: HttpCacheDownloadStateDao,
+    private val pikpakConfig: () -> PikPakConfig = { PikPakConfig.Default },
 ) : MediaCacheEngine {
     override val engineKey: MediaCacheEngineKey = MediaCacheEngineKey.WebM3u
 
@@ -96,8 +99,10 @@ class HttpMediaCacheEngine(
         return when (media.download) {
             is ResourceLocation.HttpStreamingFile -> mediaResolver.supports(media)
             is ResourceLocation.HttpTorrentFile,
-            is ResourceLocation.LocalFile,
             is ResourceLocation.MagnetLink,
+                -> pikpakConfig().enabled && mediaResolver.supports(media)
+
+            is ResourceLocation.LocalFile,
                 -> {
                 false
             }
@@ -160,10 +165,22 @@ class HttpMediaCacheEngine(
             is UriMediaData -> {
                 // TODO: 用 [Media.mediaId] 当作 DownloadId 好吗?
                 val downloadId = origin.toSafeDownloadId()
+                var options = DownloadOptions(headers = mediaData.headers)
+                if (origin.kind == MediaSourceKind.BitTorrent) {
+                    val config = pikpakConfig()
+                    options = options.copy(
+                        maxConcurrentSegments = config.downloadConcurrency.coerceIn(
+                            PikPakConfig.MIN_DOWNLOAD_CONCURRENCY,
+                            PikPakConfig.MAX_DOWNLOAD_CONCURRENCY,
+                        ),
+                        // PikPak CDN rejects Ktor's default JSON Accept header with 406.
+                        headers = options.headers + ("Accept" to "application/octet-stream"),
+                    )
+                }
                 val state = downloader.downloadWithId(
                     downloadId = downloadId,
                     mediaData.uri,
-                    options = DownloadOptions(headers = mediaData.headers),
+                    options = options,
                 ) ?: throw UnsupportedOperationException("Failed to create download job of $downloadId, state is null.")
 
                 return HttpMediaCache(

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/requester/EpisodeCacheRequester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/requester/EpisodeCacheRequester.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.sync.withLock
 import me.him188.ani.app.data.models.episode.EpisodeInfo
 import me.him188.ani.app.data.models.subject.SubjectInfo
 import me.him188.ani.app.domain.media.cache.MediaCache
+import me.him188.ani.app.domain.media.cache.engine.MediaCacheEngineKey
 import me.him188.ani.app.domain.media.cache.requester.CacheRequestStage.MediaSelected
 import me.him188.ani.app.domain.media.cache.storage.MediaCacheStorage
 import me.him188.ani.app.domain.media.cache.storage.contains
@@ -32,6 +33,7 @@ import me.him188.ani.app.domain.media.selector.autoSelect
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.MediaCacheMetadata
 import me.him188.ani.datasources.api.source.MediaFetchRequest
+import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.topic.contains
 import me.him188.ani.datasources.api.topic.isSingleEpisode
 import me.him188.ani.datasources.api.unwrapCached
@@ -226,6 +228,10 @@ class EpisodeCacheRequesterImpl(
 
         override val storages: List<MediaCacheStorage> = storages.filter {
             it.engine.supports(selectedMedia)
+        }.let { supported ->
+            preferredCacheEngineKey(selectedMedia, supported.map { it.engine.engineKey })
+                ?.let { preferred -> supported.filter { it.engine.engineKey == preferred } }
+                ?: supported
         }
 
         override val fetchSession: MediaFetchSession get() = previous.fetchSession
@@ -323,4 +329,14 @@ class EpisodeCacheRequesterImpl(
             stage.value = it
         }
     }
+}
+
+private fun preferredCacheEngineKey(
+    media: Media,
+    supported: List<MediaCacheEngineKey>,
+): MediaCacheEngineKey? {
+    if (media.kind != MediaSourceKind.BitTorrent) return null
+
+    // 启用 PikPak 后，自动接管 BT 源缓存并通过 HTTP 下载。
+    return MediaCacheEngineKey.WebM3u.takeIf { it in supported }
 }

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -60,6 +60,8 @@
     <string name="settings_pikpak_queue_title">缓存槽位数</string>
     <string name="settings_pikpak_queue_description">PikPak 云盘保留多少个最近源的缓存；更多则重播更快但占更多云盘。拉到 13 右侧的"不限"档则完全不清理。</string>
     <string name="settings_pikpak_queue_unlimited">不限</string>
+    <string name="settings_pikpak_download_concurrency_title">下载并发数</string>
+    <string name="settings_pikpak_download_concurrency_description">缓存 PikPak 文件时使用的并行连接数。提高并发可能加快下载，但也更容易触发服务器临时错误。</string>
     <string name="settings_pikpak_test_connection">测试连接</string>
     <string name="settings_pikpak_recommend_title">同步调整数据源选择器？</string>
     <string name="settings_pikpak_recommend_message">PikPak 只处理 BT 资源。建议把"优先数据源类型"设为 BT，这样默认选择器才会实际走到 PikPak。</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="settings_pikpak_queue_title">Cache slots</string>
     <string name="settings_pikpak_queue_description">How many recent sources to keep in PikPak\'s working folder before evicting the oldest. Higher makes re-plays instant at the cost of drive space. Drag past 13 for no eviction at all.</string>
     <string name="settings_pikpak_queue_unlimited">Unlimited</string>
+    <string name="settings_pikpak_download_concurrency_title">Download concurrency</string>
+    <string name="settings_pikpak_download_concurrency_description">Number of parallel connections used when caching files from PikPak. Higher values may improve download speed but increase the chance of temporary server errors.</string>
     <string name="settings_pikpak_test_connection">Test connection</string>
     <string name="settings_pikpak_recommend_title">Align media selector?</string>
     <string name="settings_pikpak_recommend_message">PikPak only handles BitTorrent sources. Set "Preferred source type" to BT so the default selector routes through PikPak.</string>

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/PikPakAcceleratorGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/PikPakAcceleratorGroup.kt
@@ -26,6 +26,8 @@ import me.him188.ani.app.data.models.preference.PikPakConfig
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.settings_pikpak_description
+import me.him188.ani.app.ui.lang.settings_pikpak_download_concurrency_description
+import me.him188.ani.app.ui.lang.settings_pikpak_download_concurrency_title
 import me.him188.ani.app.ui.lang.settings_pikpak_enabled
 import me.him188.ani.app.ui.lang.settings_pikpak_password
 import me.him188.ani.app.ui.lang.settings_pikpak_password_description
@@ -162,6 +164,29 @@ internal fun SettingsScope.PikPakAcceleratorGroup(
                             else queueLength.toString(),
                         )
                     },
+                )
+
+                val downloadConcurrency = config.downloadConcurrency.coerceIn(
+                    PikPakConfig.MIN_DOWNLOAD_CONCURRENCY,
+                    PikPakConfig.MAX_DOWNLOAD_CONCURRENCY,
+                )
+                SliderItem(
+                    value = downloadConcurrency.toFloat(),
+                    onValueChange = { raw ->
+                        val rounded = raw.toInt().coerceIn(
+                            PikPakConfig.MIN_DOWNLOAD_CONCURRENCY,
+                            PikPakConfig.MAX_DOWNLOAD_CONCURRENCY,
+                        )
+                        if (rounded != config.downloadConcurrency) {
+                            state.update(config.copy(downloadConcurrency = rounded))
+                        }
+                    },
+                    title = { Text(stringResource(Lang.settings_pikpak_download_concurrency_title)) },
+                    description = { Text(stringResource(Lang.settings_pikpak_download_concurrency_description)) },
+                    valueRange = PikPakConfig.MIN_DOWNLOAD_CONCURRENCY.toFloat()..
+                            PikPakConfig.MAX_DOWNLOAD_CONCURRENCY.toFloat(),
+                    steps = PikPakConfig.MAX_DOWNLOAD_CONCURRENCY - PikPakConfig.MIN_DOWNLOAD_CONCURRENCY - 1,
+                    valueLabel = { Text(downloadConcurrency.toString()) },
                 )
 
                 TextItem(


### PR DESCRIPTION
此前 PikPak 只参与播放解析，缓存 BT 源时仍然通过 BT 下载。本 PR 将 PikPak 加速接入缓存流程：启用 PikPak 后，缓存 BT 源会先获取 HTTPS 下载地址，再通过 HTTP 缓存引擎下载；未启用时保持原有行为。

同时增加 PikPak 下载并发数设置，可选范围为 1～8，默认值为 4。下载时显式发送 `Accept: application/octet-stream`，避免 PikPak CDN 返回 `406 Not Acceptable`。

<img width="1192" height="1135" alt="PikPak 下载并发数设置" src="https://github.com/user-attachments/assets/2a9c77f7-9d68-41a3-863f-b1394ded4fec" />

使用真实 PikPak 账号和 BT 源完成本机测试。8 并发下下载速度约为 16～17.6 MiB/s；16 并发提升有限，且出现过 `503`，因此设置上限取 8。

未添加依赖 PikPak 账号的端到端测试，因为测试需要有效凭据和临时下载 Key，不适合放入 CI。
