### PR TITLE
fix(desktop): stabilize Linux AppImage runtime

### DIFF
--- a/app/desktop/appResources/linux-x64/AppRun
+++ b/app/desktop/appResources/linux-x64/AppRun
@@ -11,7 +11,7 @@
 
 export APPDIR="$(dirname "$(readlink -f "$0")")"
 export PATH="$APPDIR/usr/bin/:$PATH"
-export LD_LIBRARY_PATH="$APPDIR/usr/lib:$PATH"
+export LD_LIBRARY_PATH="$APPDIR/usr/lib:$APPDIR/usr/lib/app${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export XDG_DATA_DIRS="$APPDIR/usr/share/:/usr/share/:$XDG_DATA_DIRS"
 
 "$APPDIR"/usr/bin/Ani $@

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -12,6 +12,7 @@ import org.jetbrains.compose.desktop.application.tasks.AbstractJLinkTask
 import org.jetbrains.compose.desktop.application.tasks.AbstractJPackageTask
 import org.jetbrains.compose.reload.gradle.ComposeHotRun
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import java.nio.file.Files
 import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -367,6 +368,7 @@ tasks.withType(AbstractJPackageTask::class) {
         destinationDir.get().asFile
             .walk()
             .filter(::isRuntimePayloadJar)
+            .toList()
             .forEach { jar ->
                 unpackJar(jar, jar.parentFile) {
                     !(it.name.contains("MANIFEST") || it.name.contains("META-INF"))
@@ -377,6 +379,33 @@ tasks.withType(AbstractJPackageTask::class) {
                     "Extracted ${jar.name} into ${jar.parentFile} and deleted the jars",
                 )
             }
+
+        if (triple == "linux-x64") {
+            destinationDir.get().asFile
+                .walk()
+                .filter { it.isDirectory && it.name == "app" && it.parentFile.name == "lib" }
+                .flatMap { it.walk() }
+                .filter { it.isFile && it.name.startsWith("lib") && it.extension == "so" }
+                .forEach { library ->
+                    val process = ProcessBuilder("readelf", "-d", library.absolutePath)
+                        .redirectErrorStream(true)
+                        .start()
+                    val readElf = process.inputStream.bufferedReader().use { it.readText() }
+                    if (process.waitFor() != 0) return@forEach
+                    val soname = Regex("Library soname: \\[(.+)]")
+                        .find(readElf)
+                        ?.groupValues
+                        ?.get(1)
+                        ?: return@forEach
+                    if (soname == library.name) return@forEach
+
+                    val alias = library.toPath().resolveSibling(soname)
+                    if (Files.notExists(alias)) {
+                        Files.createSymbolicLink(alias, library.toPath().fileName)
+                        logger.lifecycle("Created SONAME alias $alias -> ${library.name}")
+                    }
+                }
+        }
     }
 }
 

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -141,6 +141,9 @@ object AniCefApp {
         }
         if (platform.isLinux()) {
             jcefConfig.appArgsAsList.apply {
+                // Embedded browsers do not save passwords; avoid depending on desktop keyrings such as KWallet.
+                add("--password-store=basic")
+
                 // will cause 139 (segfault)
                 // add("--disable-gpu")
                 // add("--disable-software-rasterizer")


### PR DESCRIPTION
## Summary

Fix three Linux runtime issues in the AppImage package:

- preserve the existing `LD_LIBRARY_PATH` and include the packaged `usr/lib/app` directory;
- generate versioned SONAME aliases for bundled native libraries during Linux packaging;
- prevent JCEF from contacting desktop keyrings when Animeko does not store browser passwords.

The FFmpeg runtime JAR contains unversioned files such as `libavdevice.so`, while `libffmpegkitjni.so` depends on versioned SONAMEs such as `libavdevice.so.62`. The release packaging task now reads each bundled ELF SONAME and creates the corresponding symlink, so dependency updates do not require hard-coded FFmpeg version numbers.

JCEF now uses Chromium's basic password store on Linux. This avoids KWallet startup and shutdown failures without changing Animeko's credential handling.

This resolves problem 1 in #3060. It may also be related to the startup crash reported in #3121, but that report does not contain enough diagnostic information to confirm the same root cause.

## Validation

- Built the release distributable with `./gradlew createReleaseDistributable --parallel`, including configuration-cache storage.
- Confirmed all `libffmpegkitjni.so` dependencies resolve to the packaged FFmpeg libraries with no missing entries on the host and in an Ubuntu 22.04 container.
- Ran the release AppDir through `AppRun` and confirmed the process loaded `libffmpegkitjni.so`, `libav*`, and `libsw*` from `usr/lib/app`.
- Verified startup and playback under KDE Plasma/Wayland without KWallet calls.
