### PR TITLE
fix(desktop): use SwiftShader for JCEF on Linux

### DIFF
--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -141,6 +141,11 @@ object AniCefApp {
         }
         if (platform.isLinux()) {
             jcefConfig.appArgsAsList.apply {
+                // Chromium 137's hardware ANGLE path crashes the JCEF GPU process on Linux.
+                // TODO: Remove after upgrading to Chromium 141+ and verifying Intel, AMD, and NVIDIA.
+                add("--use-gl=angle")
+                add("--use-angle=swiftshader-webgl")
+
                 // will cause 139 (segfault)
                 // add("--disable-gpu")
                 // add("--disable-software-rasterizer")


### PR DESCRIPTION
## Summary

Use SwiftShader for JCEF on Linux while Animeko ships the Chromium 137 runtime.

The bundled JCEF GPU process crashes in ANGLE's `EGL_CreateWindowSurface` path on both Intel/Mesa and NVIDIA, then restarts three times before Chromium selects the same SwiftShader fallback. Selecting SwiftShader at startup avoids repeated native crashes, large coredumps, and JCEF shutdown-state errors.

This setting only affects the embedded browser used for web source discovery and challenges. MediaMP playback and its hardware decoding backend are unchanged. Windows and macOS keep their existing JCEF configuration.

The workaround includes a TODO to remove it after upgrading to a Chromium 141+ JCEF runtime and verifying Intel, AMD, and NVIDIA. A Chrome 147 JCEF smoke test already initializes native Wayland rendering successfully on Intel, but moving Animeko to JBR 25 requires separate JVM and native dependency compatibility work.

Related to problem 2 in #3060.

## Validation

- Reproduced three JCEF GPU process crashes followed by SwiftShader fallback on Intel/Mesa and NVIDIA.
- Started 14 web renderer processes with SwiftShader and resolved an m3u8 source successfully.
- Confirmed the player entered `resuming` after web source resolution.
- Observed no GPU process restart, EGL error, JCEF `SHUTTING_DOWN` state, or new coredump beyond the previous failure window.
