### PR TITLE
feat(desktop): support Linux dynamic color

### DIFF
--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/PlatformWindow.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/PlatformWindow.desktop.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.platform.window.BasicWindowProc
 import me.him188.ani.app.platform.window.LayoutHitTestOwner
+import me.him188.ani.app.platform.window.LinuxAccentColorMonitor
 import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.isWindows
 
@@ -40,8 +41,11 @@ actual open class PlatformWindow(
 
     // Common desktop accent color for window.
     val accentColor: Flow<Color>
-        get() = windowsWindowProc.flatMapLatest {
-            it?.accentColor ?: flowOf(Color.Unspecified)
+        get() = when (platform) {
+            is Platform.Linux -> LinuxAccentColorMonitor.accentColor
+            else -> windowsWindowProc.flatMapLatest {
+                it?.accentColor ?: flowOf(Color.Unspecified)
+            }
         }
 
     private var isWindowsUndecoratedFullscreen by mutableStateOf(false)

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/LinuxAccentColorMonitor.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/LinuxAccentColorMonitor.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform.window
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import me.him188.ani.utils.logging.logger
+import org.freedesktop.dbus.Struct
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.annotations.Position
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.messages.DBusSignal
+import org.freedesktop.dbus.types.Variant
+
+/**
+ * Monitors the session-wide accent color exposed by XDG Desktop Portal.
+ *
+ * Unlike Windows accent color notifications, portal settings are not tied to a window, so all Animeko windows share
+ * this single D-Bus listener and [accentColor] state.
+ */
+internal object LinuxAccentColorMonitor {
+    private const val PortalBusName = "org.freedesktop.portal.Desktop"
+    private const val PortalObjectPath = "/org/freedesktop/portal/desktop"
+    private const val AppearanceNamespace = "org.freedesktop.appearance"
+    private const val AccentColorKey = "accent-color"
+
+    private val logger = logger<LinuxAccentColorMonitor>()
+    private val mutableAccentColor = MutableStateFlow(Color.Unspecified)
+
+    val accentColor: StateFlow<Color> = mutableAccentColor.asStateFlow()
+
+    init {
+        Thread(::listenForAccentColor, "Linux-accent-color").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private fun listenForAccentColor() {
+        runCatching {
+            withDbusClassLoader {
+                val connection = DBusConnectionBuilder.forSessionBus().build()
+                val settings = connection.getRemoteObject(
+                    PortalBusName,
+                    PortalObjectPath,
+                    PortalSettings::class.java,
+                )
+                connection.addSigHandler(PortalSettings.SettingChanged::class.java, settings) { signal ->
+                    if (signal.namespace == AppearanceNamespace && signal.key == AccentColorKey) {
+                        updateAccentColor(signal.value)
+                    }
+                }
+                updateAccentColor(settings.readAccentColor())
+            }
+        }.onFailure {
+            logger.debug("Failed to read Linux accent color from XDG Desktop Portal", it)
+        }
+    }
+
+    private fun PortalSettings.readAccentColor(): Variant<*> {
+        return runCatching { ReadOne(AppearanceNamespace, AccentColorKey) }
+            .getOrElse { Read(AppearanceNamespace, AccentColorKey) }
+    }
+
+    private fun updateAccentColor(value: Variant<*>) {
+        mutableAccentColor.value = value.toComposeColor() ?: Color.Unspecified
+    }
+
+    private inline fun <T> withDbusClassLoader(block: () -> T): T {
+        val currentThread = Thread.currentThread()
+        val originalClassLoader = currentThread.contextClassLoader
+        currentThread.contextClassLoader = DBusConnectionBuilder::class.java.classLoader
+        return try {
+            block()
+        } finally {
+            currentThread.contextClassLoader = originalClassLoader
+        }
+    }
+}
+
+internal fun Variant<*>.toComposeColor(): Color? {
+    val channels = when (val value = unwrapVariant()) {
+        is PortalAccentColor -> listOf(value.red, value.green, value.blue)
+        is Array<*> -> value.mapNotNull { (it as? Number)?.toDouble() }
+        is List<*> -> value.mapNotNull { (it as? Number)?.toDouble() }
+        else -> return null
+    }
+    if (channels.size != 3 || channels.any { it !in 0.0..1.0 }) {
+        return null
+    }
+    return Color(channels[0].toFloat(), channels[1].toFloat(), channels[2].toFloat())
+}
+
+private tailrec fun Variant<*>.unwrapVariant(): Any = when (val unwrapped = value) {
+    is Variant<*> -> unwrapped.unwrapVariant()
+    else -> unwrapped
+}
+
+internal class PortalAccentColor(
+    @field:Position(0) val red: Double,
+    @field:Position(1) val green: Double,
+    @field:Position(2) val blue: Double,
+) : Struct()
+
+@DBusInterfaceName("org.freedesktop.portal.Settings")
+private interface PortalSettings : DBusInterface {
+    @Suppress("FunctionName")
+    fun Read(namespace: String, key: String): Variant<Variant<PortalAccentColor>>
+
+    @Suppress("FunctionName")
+    fun ReadOne(namespace: String, key: String): Variant<PortalAccentColor>
+
+    class SettingChanged(
+        path: String,
+        val namespace: String,
+        val key: String,
+        val value: Variant<*>,
+    ) : DBusSignal(path, namespace, key, value)
+}

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/theme/AppTheme.desktop.kt
@@ -19,6 +19,7 @@ import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
+import me.him188.ani.utils.platform.isLinux
 import me.him188.ani.utils.platform.isWindows
 
 @Composable
@@ -48,5 +49,5 @@ actual fun appColorScheme(
 
 @Composable
 actual fun isPlatformSupportDynamicTheme(): Boolean {
-    return LocalPlatform.current.isWindows()
+    return LocalPlatform.current.run { isWindows() || isLinux() }
 }

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/LinuxAccentColorMonitorTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/LinuxAccentColorMonitorTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform.window
+
+import androidx.compose.ui.graphics.Color
+import org.freedesktop.dbus.types.Variant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LinuxAccentColorMonitorTest {
+    @Test
+    fun `converts portal RGB tuple to Compose color`() {
+        assertEquals(
+            Color(0.25f, 0.5f, 0.75f),
+            Variant(PortalAccentColor(0.25, 0.5, 0.75)).toComposeColor(),
+        )
+    }
+
+    @Test
+    fun `unwraps deprecated Read nested variant`() {
+        assertEquals(
+            Color(0.25f, 0.5f, 0.75f),
+            Variant(Variant(PortalAccentColor(0.25, 0.5, 0.75))).toComposeColor(),
+        )
+    }
+
+    @Test
+    fun `converts dynamically decoded portal tuple`() {
+        assertEquals(
+            Color(0.25f, 0.5f, 0.75f),
+            Variant(arrayOf(0.25, 0.5, 0.75), "(ddd)").toComposeColor(),
+        )
+    }
+
+    @Test
+    fun `rejects out of range portal color`() {
+        assertNull(Variant(PortalAccentColor(1.1, 0.5, 0.75)).toComposeColor())
+    }
+}


### PR DESCRIPTION
## 概要

在 Linux 桌面端支持动态主题色。

启用动态主题后，Animeko 会从 XDG Desktop Portal 读取 `org.freedesktop.appearance/accent-color`，并在系统强调色变化时更新 Material 3 配色。Portal 不支持该设置或返回无效颜色时，继续使用用户设置的主题色。

兼容 Portal v2 的 `ReadOne` 与旧版 `Read`。

## 验证

- 在 Niri + GNOME/GTK portal 环境验证强调色读取
- 验证 Portal RGB tuple 与嵌套 Variant 的转换
- 验证越界颜色回退
- `./gradlew :app:shared:ui-foundation:desktopTest --tests '*LinuxAccentColorMonitorTest'`

Closes #3116