### PR TITLE
feat(appimage): support incremental updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -664,9 +664,17 @@ jobs:
         wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
         chmod +x appimagetool-x86_64.AppImage
 
+        # Bundle the external updater. It is copied out of the read-only AppImage mount before use.
+        appImageUpdateVersion="2.0.0-alpha-1-20251018"
+        appImageUpdateTool="appimageupdatetool-x86_64.AppImage"
+        wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/$appImageUpdateVersion/$appImageUpdateTool"
+        echo "d976cdac667b03dee8cb23fb95ef74b042c406c5cbab3ff294d2b16efeaff84f  $appImageUpdateTool" | sha256sum -c -
+        chmod +x "$appImageUpdateTool"
+
         # Prepare AppDir
         mkdir -p AppDir/usr
         cp -r app/desktop/build/compose/binaries/main-release/app/Ani/* AppDir/usr
+        cp "$appImageUpdateTool" AppDir/usr/lib/app/resources/
 
         cp app/desktop/appResources/linux-x64/AppRun AppDir/AppRun
         cp app/desktop/appResources/linux-x64/animeko.desktop AppDir/animeko.desktop
@@ -677,15 +685,32 @@ jobs:
         chmod a+x AppDir/usr/bin/Ani
         chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
 
-        # Build AppImage
-        ARCH=x86_64 ./appimagetool-x86_64.AppImage AppDir
+        # Build an AppImage whose zsync metadata points at this repository's release asset.
+        # Build with the final release filename so the generated zsync metadata keeps that name,
+        # then normalize the local filenames expected by the upload tasks below.
+        releaseTag="$GITHUB_REF_NAME"
+        releaseVersion="$(printf '%s' "$releaseTag" | sed 's/^v//')"
+        # Pull request merge refs contain '/', which must not become a path separator here.
+        releaseVersion="${releaseVersion//\//-}"
+        releaseAsset="ani-$releaseVersion-linux-x86_64.appimage"
+        updateInformation="zsync|https://github.com/$GITHUB_REPOSITORY/releases/download/$releaseTag/$releaseAsset.zsync"
+        ARCH=x86_64 ./appimagetool-x86_64.AppImage \
+          -u "$updateInformation" \
+          AppDir \
+          "$releaseAsset"
+        # Keep the zsync reusable on GitHub, d.myani.org and compatible mirrors.
+        sed -i "s|^URL:.*|URL: $releaseAsset|" "$releaseAsset.zsync"
+        mv "$releaseAsset" Animeko-x86_64.AppImage
+        mv "$releaseAsset.zsync" Animeko-x86_64.AppImage.zsync
     - id: 'step-53'
       name: 'Upload Linux packages (Attempt #1)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
     - id: 'step-54'
@@ -694,7 +719,9 @@ jobs:
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
       if: '${{ steps.step-53.outcome == ''failure'' }}'
@@ -704,7 +731,9 @@ jobs:
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
       if: '${{ steps.step-54.outcome == ''failure'' }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1973,9 +1973,17 @@ jobs:
         wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
         chmod +x appimagetool-x86_64.AppImage
 
+        # Bundle the external updater. It is copied out of the read-only AppImage mount before use.
+        appImageUpdateVersion="2.0.0-alpha-1-20251018"
+        appImageUpdateTool="appimageupdatetool-x86_64.AppImage"
+        wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/$appImageUpdateVersion/$appImageUpdateTool"
+        echo "d976cdac667b03dee8cb23fb95ef74b042c406c5cbab3ff294d2b16efeaff84f  $appImageUpdateTool" | sha256sum -c -
+        chmod +x "$appImageUpdateTool"
+
         # Prepare AppDir
         mkdir -p AppDir/usr
         cp -r app/desktop/build/compose/binaries/main-release/app/Ani/* AppDir/usr
+        cp "$appImageUpdateTool" AppDir/usr/lib/app/resources/
 
         cp app/desktop/appResources/linux-x64/AppRun AppDir/AppRun
         cp app/desktop/appResources/linux-x64/animeko.desktop AppDir/animeko.desktop
@@ -1986,15 +1994,32 @@ jobs:
         chmod a+x AppDir/usr/bin/Ani
         chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
 
-        # Build AppImage
-        ARCH=x86_64 ./appimagetool-x86_64.AppImage AppDir
+        # Build an AppImage whose zsync metadata points at this repository's release asset.
+        # Build with the final release filename so the generated zsync metadata keeps that name,
+        # then normalize the local filenames expected by the upload tasks below.
+        releaseTag="$GITHUB_REF_NAME"
+        releaseVersion="$(printf '%s' "$releaseTag" | sed 's/^v//')"
+        # Pull request merge refs contain '/', which must not become a path separator here.
+        releaseVersion="${releaseVersion//\//-}"
+        releaseAsset="ani-$releaseVersion-linux-x86_64.appimage"
+        updateInformation="zsync|https://github.com/$GITHUB_REPOSITORY/releases/download/$releaseTag/$releaseAsset.zsync"
+        ARCH=x86_64 ./appimagetool-x86_64.AppImage \
+          -u "$updateInformation" \
+          AppDir \
+          "$releaseAsset"
+        # Keep the zsync reusable on GitHub, d.myani.org and compatible mirrors.
+        sed -i "s|^URL:.*|URL: $releaseAsset|" "$releaseAsset.zsync"
+        mv "$releaseAsset" Animeko-x86_64.AppImage
+        mv "$releaseAsset.zsync" Animeko-x86_64.AppImage.zsync
     - id: 'step-65'
       name: 'Upload Linux packages (Attempt #1)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
     - id: 'step-66'
@@ -2003,7 +2028,9 @@ jobs:
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
       if: '${{ steps.step-65.outcome == ''failure'' }}'
@@ -2013,7 +2040,9 @@ jobs:
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'ani-linux-appimage-x64'
-        path: 'Animeko-x86_64.AppImage'
+        path: |-
+          Animeko-x86_64.AppImage
+          Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
       if: '${{ steps.step-66.outcome == ''failure'' }}'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -1795,10 +1795,18 @@ class WithMatrix(
                         # Download appimagetool
                         wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
                         chmod +x appimagetool-x86_64.AppImage
+
+                        # Bundle the external updater. It is copied out of the read-only AppImage mount before use.
+                        appImageUpdateVersion="2.0.0-alpha-1-20251018"
+                        appImageUpdateTool="appimageupdatetool-x86_64.AppImage"
+                        wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/$appImageUpdateVersion/$appImageUpdateTool"
+                        echo "d976cdac667b03dee8cb23fb95ef74b042c406c5cbab3ff294d2b16efeaff84f  $appImageUpdateTool" | sha256sum -c -
+                        chmod +x "$appImageUpdateTool"
                         
                         # Prepare AppDir
                         mkdir -p AppDir/usr
                         cp -r app/desktop/build/compose/binaries/main-release/app/Ani/* AppDir/usr
+                        cp "$appImageUpdateTool" AppDir/usr/lib/app/resources/
                         
                         cp app/desktop/appResources/linux-x64/AppRun AppDir/AppRun
                         cp app/desktop/appResources/linux-x64/animeko.desktop AppDir/animeko.desktop
@@ -1809,18 +1817,36 @@ class WithMatrix(
                         chmod a+x AppDir/usr/bin/Ani
                         chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
                         
-                        # Build AppImage
-                        ARCH=x86_64 ./appimagetool-x86_64.AppImage AppDir
+                        # Build an AppImage whose zsync metadata points at this repository's release asset.
+                        # Build with the final release filename so the generated zsync metadata keeps that name,
+                        # then normalize the local filenames expected by the upload tasks below.
+                        releaseTag="$GITHUB_REF_NAME"
+                        releaseVersion="$(printf '%s' "$releaseTag" | sed 's/^v//')"
+                        # Pull request merge refs contain '/', which must not become a path separator here.
+                        releaseVersion="${releaseVersion//\//-}"
+                        releaseAsset="ani-$releaseVersion-linux-x86_64.appimage"
+                        updateInformation="zsync|https://github.com/$GITHUB_REPOSITORY/releases/download/$releaseTag/$releaseAsset.zsync"
+                        ARCH=x86_64 ./appimagetool-x86_64.AppImage \
+                          -u "$updateInformation" \
+                          AppDir \
+                          "$releaseAsset"
+                        # Keep the zsync reusable on GitHub, d.myani.org and compatible mirrors.
+                        sed -i "s|^URL:.*|URL: $releaseAsset|" "$releaseAsset.zsync"
+                        mv "$releaseAsset" Animeko-x86_64.AppImage
+                        mv "$releaseAsset.zsync" Animeko-x86_64.AppImage.zsync
                         """.trimIndent(),
                 )
-                // Expected output path: Animeko-x86_64.AppImage.
+                // Expected output paths: Animeko-x86_64.AppImage and Animeko-x86_64.AppImage.zsync.
                 // If changed, change also uploadDesktopDistributions in :ci-helper
 
                 usesWithAttempts(
                     name = "Upload Linux packages",
                     action = UploadArtifact(
                         name = ArtifactNames.linuxAppImage(matrix.arch),
-                        path_Untyped = "Animeko-x86_64.AppImage",
+                        path_Untyped = $$"""
+                            Animeko-x86_64.AppImage
+                            Animeko-x86_64.AppImage.zsync
+                            """.trimIndent(),
                         overwrite = true,
                         ifNoFilesFound = UploadArtifact.BehaviorIfNoFilesFound.Error,
                     ),

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -475,9 +475,12 @@
     <string name="settings_update_popup_auto_update">自动更新</string>
     <string name="settings_update_popup_close">关闭</string>
     <string name="settings_update_popup_downloading">正在下载更新</string>
+    <string name="settings_update_popup_installing">正在安装更新</string>
     <string name="settings_update_popup_cancel_download">要取消下载吗?</string>
+    <string name="settings_update_popup_cancel_install">要取消更新吗?</string>
     <string name="settings_update_popup_cancel">取消</string>
     <string name="settings_update_popup_continue_download">继续下载</string>
+    <string name="settings_update_popup_continue_update">继续更新</string>
     <string name="settings_update_popup_restart_update">重启更新</string>
     <string name="settings_update_popup_download_complete">下载完成</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -442,9 +442,12 @@
     <string name="settings_update_popup_auto_update">自動更新</string>
     <string name="settings_update_popup_close">關閉</string>
     <string name="settings_update_popup_downloading">正在下載更新</string>
+    <string name="settings_update_popup_installing">正在安裝更新</string>
     <string name="settings_update_popup_cancel_download">要取消下載嗎?</string>
+    <string name="settings_update_popup_cancel_install">要取消更新嗎?</string>
     <string name="settings_update_popup_cancel">取消</string>
     <string name="settings_update_popup_continue_download">繼續下載</string>
+    <string name="settings_update_popup_continue_update">繼續更新</string>
     <string name="settings_update_popup_restart_update">重啟更新</string>
     <string name="settings_update_popup_download_complete">下載完成</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -442,9 +442,12 @@
     <string name="settings_update_popup_auto_update">自動更新</string>
     <string name="settings_update_popup_close">關閉</string>
     <string name="settings_update_popup_downloading">正在下載更新</string>
+    <string name="settings_update_popup_installing">正在安裝更新</string>
     <string name="settings_update_popup_cancel_download">要取消下載嗎?</string>
+    <string name="settings_update_popup_cancel_install">要取消更新嗎?</string>
     <string name="settings_update_popup_cancel">取消</string>
     <string name="settings_update_popup_continue_download">繼續下載</string>
+    <string name="settings_update_popup_continue_update">繼續更新</string>
     <string name="settings_update_popup_restart_update">重啟更新</string>
     <string name="settings_update_popup_download_complete">下載完成</string>
 

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -427,9 +427,12 @@
     <string name="settings_update_popup_auto_update">Auto-update</string>
     <string name="settings_update_popup_close">Close</string>
     <string name="settings_update_popup_downloading">Downloading Update</string>
+    <string name="settings_update_popup_installing">Installing Update</string>
     <string name="settings_update_popup_cancel_download">Cancel Download?</string>
+    <string name="settings_update_popup_cancel_install">Cancel Update?</string>
     <string name="settings_update_popup_cancel">Cancel</string>
     <string name="settings_update_popup_continue_download">Continue Download</string>
+    <string name="settings_update_popup_continue_update">Continue Update</string>
     <string name="settings_update_popup_restart_update">Restart to Update</string>
     <string name="settings_update_popup_download_complete">Download Complete</string>
 

--- a/app/shared/src/desktopMain/kotlin/tools/update/DesktopUpdateInstaller.kt
+++ b/app/shared/src/desktopMain/kotlin/tools/update/DesktopUpdateInstaller.kt
@@ -9,7 +9,10 @@
 
 package me.him188.ani.app.tools.update
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import me.him188.ani.app.platform.ContextMP
 import me.him188.ani.app.platform.ExecutableDirectoryDetector
 import me.him188.ani.app.platform.features.DesktopFileRevealer
@@ -21,7 +24,9 @@ import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.platform.Platform
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.path.createTempDirectory
 import kotlin.system.exitProcess
 
@@ -292,6 +297,11 @@ private fun exitProcessForUpdate(delayMillis: Long): InstallationResult {
 }
 
 object LinuxUpdateInstaller : DesktopUpdateInstaller {
+    private val logger = logger<LinuxUpdateInstaller>()
+
+    override fun getUpdatePreparationUrls(packageUrls: List<String>): List<String> =
+        packageUrls.toAppImageZsyncUrls()
+
     override fun deleteOldUpdater() {
         // no-op
     }
@@ -302,7 +312,154 @@ object LinuxUpdateInstaller : DesktopUpdateInstaller {
         }
         return InstallationResult.Succeed
     }
+
+    override suspend fun install(
+        file: SystemPath,
+        packageUrls: List<String>,
+        context: ContextMP,
+    ): InstallationResult = withContext(Dispatchers.IO) {
+        val appImage = System.getenv("APPIMAGE")
+            ?.takeIf(String::isNotBlank)
+            ?.let(::File)
+            ?: return@withContext failed("APPIMAGE is not set; the app was not started from an AppImage")
+
+        if (!appImage.isFile) {
+            return@withContext failed("APPIMAGE does not point to a file: ${appImage.absolutePath}")
+        }
+        if (!appImage.canWrite() || appImage.parentFile?.canWrite() != true) {
+            return@withContext failed("The current AppImage is not writable: ${appImage.absolutePath}")
+        }
+
+        val updateInformation = packageUrls.toAppImageZsyncUrls().map { "zsync|$it" }
+        if (updateInformation.isEmpty()) {
+            return@withContext failed("No AppImage update URLs were provided")
+        }
+
+        val resourcesDir = System.getProperty("compose.application.resources.dir")
+            ?.takeIf(String::isNotBlank)
+            ?.let(::File)
+            ?: return@withContext failed("Cannot find Compose application resources directory")
+        val bundledUpdater = resourcesDir.resolve(LINUX_APPIMAGE_UPDATE_TOOL)
+        if (!bundledUpdater.isFile) {
+            return@withContext failed("Bundled AppImage update tool was not found: ${bundledUpdater.absolutePath}")
+        }
+
+        try {
+            val tempDir = createTempDirectory(prefix = "animeko-appimage-update-").toFile()
+            val updater = tempDir.resolve(LINUX_APPIMAGE_UPDATE_TOOL)
+            bundledUpdater.copyTo(updater)
+            check(updater.setExecutable(true)) { "Failed to make updater executable: ${updater.absolutePath}" }
+
+            val script = tempDir.resolve("update.sh")
+            script.writeText(LINUX_APPIMAGE_UPDATE_SCRIPT)
+            check(script.setExecutable(true)) { "Failed to make update script executable: ${script.absolutePath}" }
+
+            val command = buildList {
+                add(script.absolutePath)
+                add(appImage.absolutePath)
+                add(updater.absolutePath)
+                addAll(updateInformation)
+            }
+            logger.info { "Launching AppImage updater for ${appImage.absolutePath}" }
+            val logFile = tempDir.resolve("update.log")
+            val process = ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .redirectOutput(logFile)
+                .start()
+            val exitCode = waitForUpdateProcess(process)
+            if (exitCode == 0) {
+                logger.info { "AppImage update completed successfully" }
+                exitProcessForUpdate(delayMillis = 0)
+            } else {
+                failed("AppImage updater exited with code $exitCode. Log: ${logFile.absolutePath}")
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (throwable: Throwable) {
+            logger.error(throwable) { "Failed to launch AppImage updater" }
+            InstallationResult.Failed(
+                InstallationFailureReason.FAILED_TO_COPY,
+                throwable.message,
+            )
+        }
+    }
+
+    private suspend fun waitForUpdateProcess(process: Process): Int {
+        try {
+            return runInterruptible { process.waitFor() }
+        } catch (e: CancellationException) {
+            process.descendants().use { descendants ->
+                descendants.forEach { it.destroy() }
+            }
+            process.destroy()
+            runInterruptible {
+                if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                    process.descendants().use { descendants ->
+                        descendants.forEach { it.destroyForcibly() }
+                    }
+                    process.destroyForcibly().waitFor()
+                }
+            }
+            throw e
+        }
+    }
+
+    private fun failed(message: String): InstallationResult.Failed {
+        logger.error { message }
+        return InstallationResult.Failed(
+            InstallationFailureReason.UNSUPPORTED_FILE_STRUCTURE,
+            message,
+        )
+    }
 }
+
+internal const val LINUX_APPIMAGE_UPDATE_TOOL = "appimageupdatetool-x86_64.AppImage"
+
+/**
+ * 版本 API 返回的是各平台通用的完整安装包地址. Linux Release 将 zsync 元数据作为同名 AppImage 的
+ * `.zsync` 伴随资源发布, 因此只在 Linux 安装准备阶段派生该地址, 而不向版本 API 引入平台专用字段.
+ */
+internal fun List<String>.toAppImageZsyncUrls(): List<String> = map { url ->
+    if (url.endsWith(".zsync", ignoreCase = true)) url else "$url.zsync"
+}
+
+internal val LINUX_APPIMAGE_UPDATE_SCRIPT = $$"""
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    APPIMAGE_PATH="$1"
+    UPDATER_PATH="$2"
+    shift 2
+
+    APPIMAGE_DIR="$(dirname "$APPIMAGE_PATH")"
+    APPIMAGE_NAME="$(basename "$APPIMAGE_PATH")"
+    WORK_DIR="$(mktemp -d --tmpdir="$APPIMAGE_DIR" ".${APPIMAGE_NAME}.update.XXXXXX")"
+    WORKING_APPIMAGE="$WORK_DIR/$APPIMAGE_NAME"
+
+    cleanup() {
+      rm -rf -- "$WORK_DIR"
+    }
+    trap cleanup EXIT
+    trap 'exit 130' INT TERM
+
+    # Keep the original path untouched while zsync downloads and rebuilds the new image.
+    # A hard link avoids copying the full AppImage; copy-on-write is used as a fallback.
+    if ! ln -- "$APPIMAGE_PATH" "$WORKING_APPIMAGE"; then
+      cp --reflink=auto --preserve=mode -- "$APPIMAGE_PATH" "$WORKING_APPIMAGE"
+    fi
+
+    for UPDATE_INFORMATION in "$@"; do
+      if "$UPDATER_PATH" --overwrite --update-info "$UPDATE_INFORMATION" "$WORKING_APPIMAGE"; then
+        chmod a+x "$WORKING_APPIMAGE"
+        # WORKING_APPIMAGE and APPIMAGE_PATH are on the same filesystem, so this is an atomic commit.
+        mv -f -- "$WORKING_APPIMAGE" "$APPIMAGE_PATH"
+        exit 0
+      fi
+    done
+
+    echo "All AppImage update sources failed." >&2
+    exit 1
+""".trimIndent()
 
 object WindowsUpdateInstaller : DesktopUpdateInstaller {
     private val logger = logger<WindowsUpdateInstaller>()

--- a/app/shared/src/desktopTest/kotlin/tools/update/LinuxUpdateInstallerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/tools/update/LinuxUpdateInstallerTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.tools.update
+
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+class LinuxUpdateInstallerTest {
+    @Test
+    fun `converts package URLs to zsync URLs`() {
+        assertEquals(
+            listOf(
+                "https://example.com/ani.appimage.zsync",
+                "https://example.com/already.appimage.zsync",
+            ),
+            listOf(
+                "https://example.com/ani.appimage",
+                "https://example.com/already.appimage.zsync",
+            ).toAppImageZsyncUrls(),
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `update script retries sources and exits without relaunching app`() {
+        val tempDir = createTempDirectory("linux-update-installer-test").toFile()
+        val updateLog = tempDir.resolve("updates.log")
+        val launchMarker = tempDir.resolve("launched")
+
+        val appImage = tempDir.resolve("Animeko.AppImage").apply {
+            writeText(
+                """
+                    #!/usr/bin/env bash
+                    touch "${launchMarker.absolutePath}"
+                """.trimIndent(),
+            )
+            assertTrue(setExecutable(true))
+        }
+        val updater = tempDir.resolve(LINUX_APPIMAGE_UPDATE_TOOL).apply {
+            writeText(
+                """
+                    #!/usr/bin/env bash
+                    echo "${'$'}3" >> "${updateLog.absolutePath}"
+                    if [[ "${'$'}3" == "zsync|https://fallback.example/update.zsync" ]]; then
+                      mv "${'$'}4" "${'$'}4.zs-old"
+                      printf 'updated' > "${'$'}4"
+                      exit 0
+                    fi
+                    exit 1
+                """.trimIndent(),
+            )
+            assertTrue(setExecutable(true))
+        }
+        val script = tempDir.resolve("update.sh").apply {
+            writeText(LINUX_APPIMAGE_UPDATE_SCRIPT)
+            assertTrue(setExecutable(true))
+        }
+
+        val process = ProcessBuilder(
+            script.absolutePath,
+            appImage.absolutePath,
+            updater.absolutePath,
+            "zsync|https://primary.example/update.zsync",
+            "zsync|https://fallback.example/update.zsync",
+        ).start()
+
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+        assertEquals(
+            listOf(
+                "zsync|https://primary.example/update.zsync",
+                "zsync|https://fallback.example/update.zsync",
+            ),
+            updateLog.readLines(),
+        )
+        assertFalse(launchMarker.exists())
+        assertEquals("updated", appImage.readText())
+        assertTrue(tempDir.listFiles().orEmpty().none { it.name.startsWith(".Animeko.AppImage.update.") })
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `failed update leaves original AppImage untouched`() {
+        val tempDir = createTempDirectory("linux-update-installer-test").toFile()
+        val appImage = tempDir.resolve("Animeko.AppImage").apply {
+            writeText("original")
+            assertTrue(setExecutable(true))
+        }
+        val updater = tempDir.resolve(LINUX_APPIMAGE_UPDATE_TOOL).apply {
+            writeText(
+                """
+                    #!/usr/bin/env bash
+                    mv "${'$'}4" "${'$'}4.zs-old"
+                    printf 'incomplete' > "${'$'}4"
+                    exit 1
+                """.trimIndent(),
+            )
+            assertTrue(setExecutable(true))
+        }
+        val script = tempDir.resolve("update.sh").apply {
+            writeText(LINUX_APPIMAGE_UPDATE_SCRIPT)
+            assertTrue(setExecutable(true))
+        }
+
+        val process = ProcessBuilder(
+            script.absolutePath,
+            appImage.absolutePath,
+            updater.absolutePath,
+            "zsync|https://example.com/update.zsync",
+        ).start()
+
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(1, process.exitValue())
+        assertEquals("original", appImage.readText())
+        assertTrue(tempDir.listFiles().orEmpty().none { it.name.startsWith(".Animeko.AppImage.update.") })
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `cancelled update leaves original AppImage untouched`() {
+        val tempDir = createTempDirectory("linux-update-installer-test").toFile()
+        val appImage = tempDir.resolve("Animeko.AppImage").apply {
+            writeText("original")
+            assertTrue(setExecutable(true))
+        }
+        val updateStarted = tempDir.resolve("update-started")
+        val updater = tempDir.resolve(LINUX_APPIMAGE_UPDATE_TOOL).apply {
+            writeText(
+                """
+                    #!/usr/bin/env bash
+                    mv "${'$'}4" "${'$'}4.zs-old"
+                    touch "${updateStarted.absolutePath}"
+                    sleep 30
+                    printf 'updated' > "${'$'}4"
+                """.trimIndent(),
+            )
+            assertTrue(setExecutable(true))
+        }
+        val script = tempDir.resolve("update.sh").apply {
+            writeText(LINUX_APPIMAGE_UPDATE_SCRIPT)
+            assertTrue(setExecutable(true))
+        }
+
+        val process = ProcessBuilder(
+            script.absolutePath,
+            appImage.absolutePath,
+            updater.absolutePath,
+            "zsync|https://example.com/update.zsync",
+        ).start()
+        val startDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!updateStarted.exists() && System.nanoTime() < startDeadline) {
+            Thread.sleep(10)
+        }
+        assertTrue(updateStarted.exists())
+
+        process.descendants().use { descendants -> descendants.forEach { it.destroy() } }
+        process.destroy()
+
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+        assertEquals("original", appImage.readText())
+        assertTrue(tempDir.listFiles().orEmpty().none { it.name.startsWith(".Animeko.AppImage.update.") })
+    }
+}

--- a/app/shared/ui-settings/src/commonMain/kotlin/tools/update/FileDownloader.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/tools/update/FileDownloader.kt
@@ -217,7 +217,8 @@ class DefaultFileDownloader(
     private suspend fun fetchRemoteChecksum(client: ScopedHttpClient, url: String): String? {
         return try {
             // The server should serve the checksum as plain text
-            client.use { get("$url.sha1").body() }
+            // Checksum sidecars may have no line ending, LF, or CRLF; trim all surrounding whitespace.
+            client.use { get("$url.sha1").body<String>().trim() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: ClientRequestException) {

--- a/app/shared/ui-settings/src/commonMain/kotlin/tools/update/UpdateInstaller.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/tools/update/UpdateInstaller.kt
@@ -9,8 +9,13 @@
 
 package me.him188.ani.app.tools.update
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import me.him188.ani.app.platform.ContextMP
 import me.him188.ani.utils.io.SystemPath
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * 安装包安装器
@@ -21,11 +26,75 @@ import me.him188.ani.utils.io.SystemPath
  */
 interface UpdateInstaller {
     /**
+     * 返回安装前需要下载的文件地址.
+     *
+     * 默认直接使用版本 API 返回的安装包地址. Linux AppImage 将其转换为较小的 zsync 元数据地址,
+     * 实际差分数据由外部更新器在安装阶段下载.
+     */
+    fun getUpdatePreparationUrls(packageUrls: List<String>): List<String> = packageUrls
+
+    /**
      * 如果 [install] 可能返回 [InstallationResult.Failed], 则需实现
      */
     suspend fun openForManualInstallation(file: SystemPath, context: ContextMP): Boolean = false
 
     fun install(file: SystemPath, context: ContextMP): InstallationResult
+
+    /**
+     * 使用版本 API 返回的原始安装包地址执行安装.
+     *
+     * 默认平台仍安装已经下载到 [file] 的完整安装包.
+     */
+    suspend fun install(
+        file: SystemPath,
+        packageUrls: List<String>,
+        context: ContextMP,
+    ): InstallationResult = install(file, context)
+}
+
+sealed class UpdateInstallationState {
+    data object Idle : UpdateInstallationState()
+    data object Installing : UpdateInstallationState()
+    data object Succeed : UpdateInstallationState()
+    data class Failed(val result: InstallationResult.Failed) : UpdateInstallationState()
+    data class Cancelled(val cause: CancellationException) : UpdateInstallationState()
+}
+
+class UpdateInstallationRunner(
+    private val installer: UpdateInstaller,
+) {
+    private val _state = MutableStateFlow<UpdateInstallationState>(UpdateInstallationState.Idle)
+    val state: StateFlow<UpdateInstallationState> = _state.asStateFlow()
+
+    suspend fun install(
+        file: SystemPath,
+        packageUrls: List<String>,
+        context: ContextMP,
+    ) {
+        _state.value = UpdateInstallationState.Installing
+        try {
+            _state.value = when (val result = installer.install(file, packageUrls, context)) {
+                InstallationResult.Succeed -> UpdateInstallationState.Succeed
+                is InstallationResult.Failed -> UpdateInstallationState.Failed(result)
+            }
+        } catch (e: CancellationException) {
+            _state.value = UpdateInstallationState.Cancelled(e)
+            throw e
+        } catch (e: Throwable) {
+            _state.value = UpdateInstallationState.Failed(
+                InstallationResult.Failed(
+                    InstallationFailureReason.FAILED_TO_COPY,
+                    e.message,
+                ),
+            )
+        }
+    }
+
+    fun dismissFailure() {
+        _state.update { state ->
+            if (state is UpdateInstallationState.Failed) UpdateInstallationState.Idle else state
+        }
+    }
 }
 
 sealed class InstallationResult {

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/AppUpdateState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/AppUpdateState.kt
@@ -69,5 +69,9 @@ sealed interface AppUpdateState {
         val file: SystemPath,
     ) : HasNewVersion
 
+    /** 正在安装更新, 应保持应用运行直到安装器返回结果. */
+    @Immutable
+    data class Installing(override val version: NewVersion) : HasNewVersion
+
     companion object
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/AppUpdateViewModel.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/AppUpdateViewModel.kt
@@ -33,6 +33,8 @@ import me.him188.ani.app.tools.MonoTasker
 import me.him188.ani.app.tools.update.DefaultFileDownloader
 import me.him188.ani.app.tools.update.FileDownloaderState
 import me.him188.ani.app.tools.update.InstallationResult
+import me.him188.ani.app.tools.update.UpdateInstallationRunner
+import me.him188.ani.app.tools.update.UpdateInstallationState
 import me.him188.ani.app.tools.update.UpdateInstaller
 import me.him188.ani.app.ui.foundation.AbstractViewModel
 import me.him188.ani.utils.io.createDirectories
@@ -57,6 +59,7 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
     private val updateManager: UpdateManager by inject()
     private val clientProvider: HttpClientProvider by inject()
     private val updateInstaller: UpdateInstaller by inject()
+    private val installationRunner by lazy { UpdateInstallationRunner(updateInstaller) }
 
     private val fileDownloader by lazy { DefaultFileDownloader(clientProvider.get()) }
     private val updateChecker: UpdateChecker = UpdateChecker()
@@ -72,19 +75,24 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
      */
     private val fileDownloaderPresenter = FileDownloaderPresenter(fileDownloader, backgroundScope)
     private val autoCheckTasker = MonoTasker(backgroundScope)
+    // Linux keeps the app alive while AppImageUpdate downloads and builds a replacement.
+    // Track that work separately so the UI can show installation state and cancel it safely.
+    private val installationTasker = MonoTasker(backgroundScope)
     private val checkUpdateErrorFlow = MutableStateFlow<LoadError?>(null)
 
     val presentationFlow = combine(
         latestVersionFlow,
         fileDownloaderPresenter.flow,
         autoCheckTasker.isRunning,
+        installationRunner.state,
         checkUpdateErrorFlow,
-    ) { latestVersion, fileDownloaderStats, isCheckingUpdate, checkUpdateError ->
+    ) { latestVersion, fileDownloaderStats, isCheckingUpdate, installationState, checkUpdateError ->
         val latestVersion = latestVersion
         val state = when {
             // 还没检查过
             lastCheckTime.value == 0L -> AppUpdateState.ClickToCheck
             latestVersion == null -> AppUpdateState.AlreadyUpToDate
+            installationState is UpdateInstallationState.Installing -> AppUpdateState.Installing(latestVersion)
             else -> {
                 when (fileDownloaderStats.state) {
                     FileDownloaderState.Idle -> AppUpdateState.HasUpdate(latestVersion)
@@ -111,6 +119,7 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
             fileDownloaderStats = fileDownloaderStats,
             isCheckingUpdate = isCheckingUpdate,
             checkUpdateError = checkUpdateError,
+            installationFailure = (installationState as? UpdateInstallationState.Failed)?.result,
             isPlaceholder = latestVersion == null && fileDownloaderStats.isPlaceholder,
         )
     }.stateIn(
@@ -188,10 +197,12 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
                 return@launch
             }
 
+            // Linux prepares a small zsync file; other platforms prepare the package URL unchanged.
+            val preparationUrls = updateInstaller.getUpdatePreparationUrls(ver.downloadUrlAlternatives)
             val dir = updateManager.saveDir
             if (dir.exists()) {
                 // 删除旧的文件
-                val allowedFilenames = ver.downloadUrlAlternatives.map {
+                val allowedFilenames = preparationUrls.map {
                     it.substringAfterLast("/", "")
                 }.let { list ->
                     list + list.map { "$it.sha1" }
@@ -208,7 +219,7 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
 
             withContext(Dispatchers.IO) { dir.createDirectories() }
             fileDownloader.download(
-                alternativeUrls = ver.downloadUrlAlternatives,
+                alternativeUrls = preparationUrls,
                 filenameProvider = { it.substringAfterLast("/", "") },
                 saveDir = dir,
             )
@@ -219,18 +230,28 @@ class AppUpdateViewModel : AbstractViewModel(), KoinComponent {
         latestVersionFlow.value?.let { startDownload(it, uriHandler) }
     }
 
-    fun install(context: ContextMP): InstallationResult.Failed? {
+    fun install(context: ContextMP) {
         val state = presentationFlow.value.state as? AppUpdateState.Downloaded
-            ?: return null
-        val result = updateInstaller.install(state.file, context)
-        return when (result) {
-            is InstallationResult.Failed -> result
-            InstallationResult.Succeed -> null
+            ?: return
+        installationTasker.launch(Dispatchers.Main) {
+            installationRunner.install(
+                file = state.file,
+                packageUrls = state.version.downloadUrlAlternatives,
+                context = context,
+            )
         }
     }
 
+    fun dismissInstallationFailure() {
+        installationRunner.dismissFailure()
+    }
+
     fun cancelDownload() {
-        downloadTasker.cancel()
+        if (installationTasker.isRunning.value) {
+            installationTasker.cancel()
+        } else {
+            downloadTasker.cancel()
+        }
     }
 }
 
@@ -241,6 +262,7 @@ data class AppUpdatePresentation(
     val fileDownloaderStats: FileDownloaderStats,
     val isCheckingUpdate: Boolean,
     val checkUpdateError: LoadError? = null,
+    val installationFailure: InstallationResult.Failed? = null,
     val currentVersion: String = currentAniBuildConfig.versionName,
     val isPlaceholder: Boolean = false,
 ) {
@@ -251,6 +273,7 @@ data class AppUpdatePresentation(
         is AppUpdateState.Downloaded -> true
         is AppUpdateState.Downloading -> true
         is AppUpdateState.HasUpdate -> false
+        is AppUpdateState.Installing -> true
     }
     val downloadError = (state as? AppUpdateState.DownloadFailed)?.throwable?.let { LoadError.fromException(it) }
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/DownloadingUpdatePopupCard.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/DownloadingUpdatePopupCard.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.ui.update
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -43,9 +44,12 @@ import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.settings_update_popup_cancel
 import me.him188.ani.app.ui.lang.settings_update_popup_cancel_download
+import me.him188.ani.app.ui.lang.settings_update_popup_cancel_install
 import me.him188.ani.app.ui.lang.settings_update_popup_continue_download
+import me.him188.ani.app.ui.lang.settings_update_popup_continue_update
 import me.him188.ani.app.ui.lang.settings_update_popup_download_complete
 import me.him188.ani.app.ui.lang.settings_update_popup_downloading
+import me.him188.ani.app.ui.lang.settings_update_popup_installing
 import me.him188.ani.app.ui.lang.settings_update_popup_restart_update
 import me.him188.ani.app.ui.search.LoadErrorCard
 import me.him188.ani.utils.platform.annotations.TestOnly
@@ -57,6 +61,7 @@ fun DownloadingUpdatePopupCard(
     version: NewVersion,
     fileDownloaderStats: FileDownloaderStats,
     error: LoadError?,
+    isInstalling: Boolean,
     onInstallClick: () -> Unit,
     onCancelClick: () -> Unit,
     onRetryClick: () -> Unit,
@@ -64,23 +69,29 @@ fun DownloadingUpdatePopupCard(
 ) {
     var showConfirmCancel by rememberSaveable { mutableStateOf(false) }
     val onRequestCancel = {
-        when (fileDownloaderStats.state) {
-            // 弹一个对话框问一下
+        // 下载或安装仍在进行时需要确认取消；其余下载终态没有活动任务，直接关闭卡片即可。
+        if (isInstalling) {
+            showConfirmCancel = true
+        } else when (fileDownloaderStats.state) {
             FileDownloaderState.Downloading -> showConfirmCancel = true
-
-            // 直接关闭
             is FileDownloaderState.Succeed,
             is FileDownloaderState.Failed,
             is FileDownloaderState.Cancelled,
             FileDownloaderState.Idle -> onCancelClick()
         }
-
     }
 
     if (showConfirmCancel) {
         AlertDialog(
             onDismissRequest = { showConfirmCancel = false },
-            text = { Text(stringResource(Lang.settings_update_popup_cancel_download)) },
+            text = {
+                Text(
+                    stringResource(
+                        if (isInstalling) Lang.settings_update_popup_cancel_install
+                        else Lang.settings_update_popup_cancel_download,
+                    ),
+                )
+            },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -95,21 +106,33 @@ fun DownloadingUpdatePopupCard(
                 TextButton(
                     onClick = { showConfirmCancel = false },
                 ) {
-                    Text(stringResource(Lang.settings_update_popup_continue_download))
+                    Text(
+                        stringResource(
+                            if (isInstalling) Lang.settings_update_popup_continue_update
+                            else Lang.settings_update_popup_continue_download,
+                        ),
+                    )
                 }
             },
         )
     }
 
     BasicNotificationPopupCard(
-        title = { Text(stringResource(Lang.settings_update_popup_downloading)) },
+        title = {
+            Text(
+                stringResource(
+                    if (isInstalling) Lang.settings_update_popup_installing
+                    else Lang.settings_update_popup_downloading,
+                ),
+            )
+        },
         modifier,
         dismissButton = {
             NotificationPopupDefaults.DismissButton(onRequestCancel)
         },
         subtitle = { Text(version.name) },
         actions = {
-            if (fileDownloaderStats.state is FileDownloaderState.Succeed) {
+            if (!isInstalling && fileDownloaderStats.state is FileDownloaderState.Succeed) {
                 Button(
                     onClick = onInstallClick,
                 ) {
@@ -119,7 +142,7 @@ fun DownloadingUpdatePopupCard(
         },
     ) {
         when {
-            fileDownloaderStats.state is FileDownloaderState.Succeed -> {
+            !isInstalling && fileDownloaderStats.state is FileDownloaderState.Succeed -> {
                 ListItem(
                     headlineContent = {
                         Text(stringResource(Lang.settings_update_popup_download_complete))
@@ -135,7 +158,7 @@ fun DownloadingUpdatePopupCard(
                 )
             }
 
-            error != null -> {
+            !isInstalling && error != null -> {
                 LoadErrorCard(
                     error,
                     onRetry = onRetryClick,
@@ -161,23 +184,31 @@ fun DownloadingUpdatePopupCard(
             }
 
             else -> {
+                val progress = if (isInstalling) null else fileDownloaderStats.progress
+                val indicatorModifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 8.dp)
+                    .wrapContentHeight(Alignment.CenterVertically)
                 ListItem(
                     headlineContent = {
-                        LinearProgressIndicator(
-                            progress = { fileDownloaderStats.progress },
-                            Modifier.weight(1f).heightIn(min = 8.dp).wrapContentHeight(Alignment.CenterVertically),
-                        )
+                        if (progress == null) {
+                            LinearProgressIndicator(modifier = indicatorModifier)
+                        } else {
+                            LinearProgressIndicator(progress = { progress }, modifier = indicatorModifier)
+                        }
                     },
-                    trailingContent = {
-                        Box(Modifier.padding(start = 16.dp), contentAlignment = Alignment.CenterEnd) {
-                            Text(
-                                "${999}%",
-                                Modifier.alpha(0f), // 占位
-                            )
-                            Text(
-                                "${(fileDownloaderStats.progress * 100).fastRoundToInt()}%",
-                                Modifier,
-                            )
+                    trailingContent = progress?.let {
+                        {
+                            Box(Modifier.padding(start = 16.dp), contentAlignment = Alignment.CenterEnd) {
+                                Text(
+                                    "${999}%",
+                                    Modifier.alpha(0f), // 占位
+                                )
+                                Text(
+                                    "${(progress * 100).fastRoundToInt()}%",
+                                    Modifier,
+                                )
+                            }
                         }
                     },
                     colors = ListItemDefaults.colors(
@@ -197,6 +228,7 @@ private fun PreviewDownloadingUpdatePopupCard() = ProvideCompositionLocalsForPre
         version = TestNewVersion,
         fileDownloaderStats = TestFileDownloaderStats.Downloading,
         error = null,
+        isInstalling = false,
         {}, {}, {},
     )
 }
@@ -209,6 +241,7 @@ private fun PreviewDownloadingUpdatePopupCardError() = ProvideCompositionLocalsF
         version = TestNewVersion,
         fileDownloaderStats = TestFileDownloaderStats.Failed,
         error = LoadError.NetworkError,
+        isInstalling = false,
         {}, {}, {},
     )
 }
@@ -222,6 +255,7 @@ private fun PreviewDownloadingUpdatePopupCardSuccess() = ProvideCompositionLocal
         version = TestNewVersion,
         fileDownloaderStats = TestFileDownloaderStats.Succeed,
         error = null,
+        isInstalling = false,
         {}, {}, {},
     )
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateNotifierHost.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateNotifierHost.kt
@@ -43,7 +43,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import me.him188.ani.app.platform.LocalContext
-import me.him188.ani.app.tools.update.InstallationResult
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
@@ -66,7 +65,6 @@ fun BoxScope.UpdateNotifier(
 
     val presentation by viewModel.presentationFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    var showInstallationError by rememberSaveable { mutableStateOf<InstallationResult.Failed?>(null) }
 
     UpdateNotifier(
         presentation = presentation,
@@ -76,9 +74,7 @@ fun BoxScope.UpdateNotifier(
             }
         },
         onInstallClick = {
-            viewModel.install(context)?.let {
-                showInstallationError = it
-            }
+            viewModel.install(context)
         },
         onCancelClick = {
             viewModel.cancelDownload()
@@ -90,11 +86,11 @@ fun BoxScope.UpdateNotifier(
         layoutKind = layoutKind,
     )
 
-    showInstallationError?.let {
+    presentation.installationFailure?.let {
         FailedToInstallDialog(
             it.reason.toString(),
             onDismissRequest = {
-                showInstallationError = null
+                viewModel.dismissInstallationFailure()
             },
             state = presentation.state,
         )
@@ -140,10 +136,13 @@ fun BoxScope.UpdateNotifier(
                     version = presentation.newVersion,
                     fileDownloaderStats = presentation.fileDownloaderStats,
                     error = presentation.downloadError,
+                    isInstalling = presentation.state is AppUpdateState.Installing,
                     onInstallClick = onInstallClick,
                     onCancelClick = {
                         onCancelClick()
-                        dismissedManually = true
+                        if (presentation.state !is AppUpdateState.Installing) {
+                            dismissedManually = true
+                        }
                     },
                     onRetryClick = onRetryClick,
                     modifier = positionModifiers,

--- a/app/shared/ui-settings/src/desktopTest/kotlin/tools/update/UpdateInstallationRunnerTest.kt
+++ b/app/shared/ui-settings/src/desktopTest/kotlin/tools/update/UpdateInstallationRunnerTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.tools.update
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+import me.him188.ani.app.platform.Context
+import me.him188.ani.utils.io.SystemPath
+import me.him188.ani.utils.io.inSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class UpdateInstallationRunnerTest {
+    @Test
+    fun `tracks installation failure and dismisses it`() = runTest {
+        val installationStarted = CompletableDeferred<Unit>()
+        val finishInstallation = CompletableDeferred<Unit>()
+        val failure = InstallationResult.Failed(InstallationFailureReason.FAILED_TO_COPY, "failed")
+        val runner = UpdateInstallationRunner(
+            object : UpdateInstaller {
+                override fun install(file: SystemPath, context: Context): InstallationResult = failure
+
+                override suspend fun install(
+                    file: SystemPath,
+                    packageUrls: List<String>,
+                    context: Context,
+                ): InstallationResult {
+                    installationStarted.complete(Unit)
+                    finishInstallation.await()
+                    return failure
+                }
+            },
+        )
+
+        val installation = async {
+            runner.install(Path("update").inSystem, emptyList(), object : Context() {})
+        }
+        installationStarted.await()
+        assertEquals(UpdateInstallationState.Installing, runner.state.value)
+
+        finishInstallation.complete(Unit)
+        installation.await()
+        assertEquals(failure, assertIs<UpdateInstallationState.Failed>(runner.state.value).result)
+
+        runner.dismissFailure()
+        assertEquals(UpdateInstallationState.Idle, runner.state.value)
+    }
+}

--- a/app/shared/ui-settings/src/jvmTest/kotlin/tools/update/DefaultFileDownloaderTest.kt
+++ b/app/shared/ui-settings/src/jvmTest/kotlin/tools/update/DefaultFileDownloaderTest.kt
@@ -147,7 +147,8 @@ class DefaultFileDownloaderTest {
                 // For instance, use an online SHA1 tool or write a snippet to compute it:
                 // echo -n "Hello, this is a test file!" | sha1sum
                 // => 6963709dcf9c2be481cba0498a4900a919feab84
-                call.respondText("0fc7c10d0d0193c654b2654dba75c319bcdc6edb")
+                // Release checksum sidecars are text files and include a trailing newline.
+                call.respondText("0fc7c10d0d0193c654b2654dba75c319bcdc6edb\n")
             }
 
             // Corrupted file with mismatched .sha1

--- a/buildSrc/src/main/kotlin/ciHelperTasks.kt
+++ b/buildSrc/src/main/kotlin/ciHelperTasks.kt
@@ -403,6 +403,11 @@ abstract class UploadDesktopInstallersTask : ReleaseUploadTask() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val linuxAppImage: RegularFileProperty
 
+    @get:Optional
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val linuxAppImageZsync: RegularFileProperty
+
     @TaskAction
     fun uploadInstallers() {
         val fullVersion = releaseFullVersion.get()
@@ -445,16 +450,28 @@ abstract class UploadDesktopInstallersTask : ReleaseUploadTask() {
                 }
             }
 
-            ReleaseHostOs.LINUX -> uploadReleaseAsset(
-                name = ReleaseArtifactNames.desktopDistributionFile(
-                    fullVersion = fullVersion,
-                    osName = "linux",
-                    archName = "x86_64",
-                    extension = "appimage",
-                ),
-                contentType = "application/x-appimage",
-                file = requiredFile(linuxAppImage, "linuxAppImage"),
-            )
+            ReleaseHostOs.LINUX -> {
+                uploadReleaseAsset(
+                    name = ReleaseArtifactNames.desktopDistributionFile(
+                        fullVersion = fullVersion,
+                        osName = "linux",
+                        archName = "x86_64",
+                        extension = "appimage",
+                    ),
+                    contentType = "application/x-appimage",
+                    file = requiredFile(linuxAppImage, "linuxAppImage"),
+                )
+                uploadReleaseAsset(
+                    name = ReleaseArtifactNames.desktopDistributionFile(
+                        fullVersion = fullVersion,
+                        osName = "linux",
+                        archName = "x86_64",
+                        extension = "appimage.zsync",
+                    ),
+                    contentType = "application/octet-stream",
+                    file = requiredFile(linuxAppImageZsync, "linuxAppImageZsync"),
+                )
+            }
         }
     }
 

--- a/ci-helper/build.gradle.kts
+++ b/ci-helper/build.gradle.kts
@@ -140,6 +140,7 @@ tasks.register("uploadDesktopInstallers", UploadDesktopInstallersTask::class) {
 
         ReleaseHostOs.LINUX -> {
             linuxAppImage.set(rootProject.layout.projectDirectory.file("Animeko-x86_64.AppImage"))
+            linuxAppImageZsync.set(rootProject.layout.projectDirectory.file("Animeko-x86_64.AppImage.zsync"))
         }
     }
 }


### PR DESCRIPTION
Related to #944.

## Summary

补全 #944 中尚未实现的 `LinuxUpdateInstaller`，为 Linux AppImage 增加基于 zsync 的增量更新。

增量下载由 AppImageUpdate 完成。它会复用当前 AppImage 中未变化的数据块，只下载新版本需要的内容。

Release workflow 现在会：

- 将 AppImageUpdate 打包进 Linux 应用；
- 在 AppImage 中写入 update information；
- 生成并上传对应的 `.zsync`；
- 上传 AppImage 和 `.zsync` 的 SHA-1 checksum。

版本 API 仍然返回完整安装包 URL。Linux 客户端根据 AppImage URL 获取同名的 `.zsync`，不需要修改现有 API。

## Update behavior

更新不会直接写入正在运行的 AppImage。客户端先在同一目录创建临时工作文件，让 AppImageUpdate 在临时文件上完成更新，成功后再通过 atomic rename 替换原文件。

更新失败或被取消时，临时文件会被删除，原 AppImage 不受影响。替换成功后应用直接退出，不尝试自动重启。

安装阶段沿用现有的 update card，显示 indeterminate progress，并提供带确认提示的取消操作。

<img width="797" height="285" alt="AppImage installation progress" src="https://github.com/user-attachments/assets/ad6a413a-2d23-4bf5-9498-924f819056cf" />

Windows、macOS 和 Android 继续使用原有安装流程。

## Validation

在 fork 仓库中分别为 `5.7.1` 和 `6.0.0-alpha01` 创建 GitHub Release，并实测了完整更新流程：

1. 启动 `5.7.1` AppImage，将 update channel 切换为 Alpha。
2. 通过版本 API 发现 fork Release 中的 `6.0.0-alpha01`。
3. 下载并校验对应的 `.zsync`。
4. 启动增量更新，确认 update card 正确显示安装状态。
5. 中途取消更新，确认 AppImageUpdate 进程退出，原 `5.7.1` AppImage 未被修改。
6. 再次检查更新，确认可以重新开始安装。
7. 完成更新，确认 AppImage 被替换为 `6.0.0-alpha01`，随后应用正常退出。

自动化测试覆盖：

- AppImage URL 到 `.zsync` URL 的转换；
- 成功更新后的 atomic replacement 和临时文件清理；
- 更新失败或取消后保留原 AppImage；
- 取消时终止 AppImageUpdate 子进程；
- installation state 的切换与失败状态清理；
- SHA-1 checksum 文件带行尾换行符时的解析。

执行过以下检查：

- `./gradlew :app:shared:ui-settings:compileKotlinDesktop`
- `./gradlew :app:desktop:compileKotlin`
- `LinuxUpdateInstallerTest`
- `UpdateInstallationRunnerTest`
- `DefaultFileDownloaderTest`
- buildSrc compilation
- workflow generation check
- `git diff --check`