### PR TITLE
Report active playback progress periodically

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/PlaybackHistoryDao.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/PlaybackHistoryDao.kt
@@ -16,6 +16,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.PrimaryKey
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -99,8 +100,25 @@ interface PlaybackHistoryDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertPendingOps(ops: List<PlaybackHistoryPendingOpEntity>): List<Long>
 
+    @Query("DELETE FROM playback_history_pending_op WHERE episodeId = :episodeId")
+    suspend fun deletePendingOpsByEpisodeId(episodeId: Int)
+
     @Query("DELETE FROM playback_history_pending_op WHERE id IN (:ids)")
     suspend fun deletePendingOpsByIds(ids: Collection<Long>)
+
+    @Transaction
+    suspend fun replacePendingOp(op: PlaybackHistoryPendingOpEntity): Long {
+        deletePendingOpsByEpisodeId(op.episodeId)
+        return insertPendingOp(op)
+    }
+
+    @Transaction
+    suspend fun replacePendingOps(ops: List<PlaybackHistoryPendingOpEntity>): List<Long> {
+        return ops.map { op ->
+            deletePendingOpsByEpisodeId(op.episodeId)
+            insertPendingOp(op)
+        }
+    }
 }
 
 fun PlaybackHistoryRecordEntity.toEpisodeHistory(): EpisodeHistory {
@@ -242,6 +260,10 @@ fun createMemoryPlaybackHistoryDao(): PlaybackHistoryDao {
 
         override suspend fun insertPendingOps(ops: List<PlaybackHistoryPendingOpEntity>): List<Long> {
             return ops.map { insertPendingOp(it) }
+        }
+
+        override suspend fun deletePendingOpsByEpisodeId(episodeId: Int) {
+            pendingOpsStore.value = pendingOpsStore.value.filterNot { it.episodeId == episodeId }
         }
 
         override suspend fun deletePendingOpsByIds(ids: Collection<Long>) {

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/player/EpisodePlayHistoryRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/player/EpisodePlayHistoryRepository.kt
@@ -130,7 +130,7 @@ class EpisodePlayHistoryRepositoryImpl(
                 history.copy(deletedAtMillis = now, isDirty = false).toEntity()
             },
         )
-        playbackHistoryDao.insertPendingOps(
+        playbackHistoryDao.replacePendingOps(
             activeHistories.map { history ->
                 PlaybackHistoryPendingOp.Delete(
                     id = 0,
@@ -163,7 +163,7 @@ class EpisodePlayHistoryRepositoryImpl(
                 history.copy(deletedAtMillis = now, isDirty = false).toEntity()
             },
         )
-        playbackHistoryDao.insertPendingOps(
+        playbackHistoryDao.replacePendingOps(
             histories.map { history ->
                 PlaybackHistoryPendingOp.Delete(
                     id = 0,
@@ -206,7 +206,7 @@ class EpisodePlayHistoryRepositoryImpl(
 
         val pendingOp = episodeHistory.toPendingUpsertOrNull()
         if (pendingOp != null) {
-            playbackHistoryDao.insertPendingOp(pendingOp.toEntity())
+            playbackHistoryDao.replacePendingOp(pendingOp.toEntity())
             onDirtyChanged()
         }
     }
@@ -280,7 +280,7 @@ class EpisodePlayHistoryRepositoryImpl(
                     .filterNot(EpisodeHistory::isDeleted)
                     .mapNotNull { it.toPendingUpsertOrNull() }
                 if (pendingOps.isNotEmpty()) {
-                    playbackHistoryDao.insertPendingOps(pendingOps.map { it.toEntity() })
+                    playbackHistoryDao.replacePendingOps(pendingOps.map { it.toEntity() })
                     onDirtyChanged()
                 }
             }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/player/PlaybackHistorySyncer.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/player/PlaybackHistorySyncer.kt
@@ -12,8 +12,12 @@ package me.him188.ani.app.data.repository.player
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -35,6 +39,8 @@ import me.him188.ani.utils.coroutines.IO_
 import me.him188.ani.utils.ktor.ApiInvoker
 import me.him188.ani.utils.logging.info
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class PlaybackHistorySyncer(
@@ -43,35 +49,39 @@ class PlaybackHistorySyncer(
     private val sessionStateProvider: SessionStateProvider,
     private val scope: CoroutineScope,
     private val ioDispatcher: CoroutineContext = Dispatchers.IO_,
+    requestCooldown: Duration = 5.seconds,
 ) : Repository() {
     private val syncMutex = Mutex()
+    private val requestGate = LeadingTrailingSyncGate(
+        scope = scope,
+        cooldown = requestCooldown,
+        task = ::syncOnceCatching,
+    )
 
     fun start() {
         scope.launch(CoroutineName("PlaybackHistorySyncer")) {
             sessionStateProvider.stateFlow
                 .filterIsInstance<SessionState.Valid>()
                 .first()
-            syncOnceCatching()
+            requestSync()
 
             sessionStateProvider.eventFlow.collect { event ->
                 if (event is SessionEvent.NewLogin) {
-                    syncOnceCatching()
+                    requestSync()
                 }
             }
         }
     }
 
     fun requestSync() {
-        scope.launch(CoroutineName("PlaybackHistorySyncer.requestSync")) {
-            syncOnceCatching()
-        }
+        requestGate.request()
     }
 
     suspend fun syncOnce() = syncMutex.withLock {
         if (sessionStateProvider.stateFlow.first() !is SessionState.Valid) return@withLock
 
         val pendingOps = repository.pendingOpsFlow.first()
-        val ops = pendingOps.map { it.toApiOp() }
+        val ops = pendingOps.latestPerEpisode().map { it.toApiOp() }
         val cursor = repository.lastSyncAtMillisFlow.first()
 
         val response = withContext(ioDispatcher) {
@@ -163,4 +173,44 @@ class PlaybackHistorySyncer(
     private fun String.toEpochMillis(): Long {
         return Instant.parse(this).toEpochMilliseconds()
     }
+}
+
+/**
+ * Runs the first request immediately, then coalesces requests received during [cooldown] into one trailing run.
+ * Every trailing run starts a new cooldown of its own.
+ */
+internal class LeadingTrailingSyncGate(
+    scope: CoroutineScope,
+    private val cooldown: Duration,
+    private val task: suspend () -> Unit,
+) {
+    private val requests = Channel<Unit>(Channel.CONFLATED)
+
+    init {
+        require(cooldown.isPositive()) { "cooldown must be positive" }
+        scope.launch(CoroutineName("PlaybackHistorySyncer.requestGate")) {
+            while (currentCoroutineContext().isActive) {
+                requests.receive()
+                do {
+                    task()
+                    delay(cooldown)
+                } while (requests.tryReceive().isSuccess)
+            }
+        }
+    }
+
+    fun request() {
+        requests.trySend(Unit)
+    }
+}
+
+internal fun List<PlaybackHistoryPendingOp>.latestPerEpisode(): List<PlaybackHistoryPendingOp> {
+    return groupBy(PlaybackHistoryPendingOp::episodeId)
+        .values
+        .map { episodeOps ->
+            episodeOps.maxWith(
+                compareBy(PlaybackHistoryPendingOp::versionMillis, PlaybackHistoryPendingOp::id),
+            )
+        }
+        .sortedBy(PlaybackHistoryPendingOp::id)
 }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
@@ -12,8 +12,8 @@ package me.him188.ani.app.domain.player.extension
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -28,11 +28,16 @@ import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import org.koin.core.Koin
 import org.openani.mediamp.PlaybackState
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * 记忆播放进度.
  *
  * 在以下情况时保存播放进度:
+ * - 开始或恢复播放 5 秒后
+ * - 播放中每分钟
  * - 切换数据源
  * - 暂停
  * - 播放完成
@@ -40,6 +45,8 @@ import org.openani.mediamp.PlaybackState
 class RememberPlayProgressExtension(
     private val context: PlayerExtensionContext,
     koin: Koin,
+    private val periodicReportInterval: Duration = 1.minutes,
+    private val initialReportDelay: Duration = 5.seconds,
 ) : PlayerExtension(name = "SaveProgressExtension") {
     private val playProgressRepository: EpisodePlayHistoryRepository by koin.inject()
     private val latestInfoBundleMutex = Mutex()
@@ -75,39 +82,44 @@ class RememberPlayProgressExtension(
             }
         }
 
-        backgroundTaskScope.launch("PlayProgressLoader") {
-            val player = context.player
-            var haveResumedOnce = false
-
-            player.playbackState
-                .filter { it == PlaybackState.PLAYING || it == PlaybackState.READY }
-                .collect {
-                    if (it == PlaybackState.READY) {
-                        haveResumedOnce = false
-                        return@collect
-                    }
-
-                    if (haveResumedOnce) return@collect
-
-                    val positionMillis = playProgressRepository.getPositionMillisByEpisodeId(episodeSession.episodeId)
-                    if (positionMillis == null) {
-                        logger.info { "Did not find saved position" }
-                        return@collect
-                    }
-
-                    logger.info { "Loaded saved position: $positionMillis, seeking to $positionMillis" }
-                    withContext(Dispatchers.Main + NonCancellable) { // android must call in main thread
-                        player.seekTo(positionMillis)
-                    }
-
-                    haveResumedOnce = true
-                }
-        }
-
         backgroundTaskScope.launch("PlaybackStateListener") {
             val player = context.player
+            var haveResumedOnce = false
             player.playbackState.collectLatest { playbackState ->
                 when (playbackState) {
+                    PlaybackState.READY -> {
+                        haveResumedOnce = false
+                    }
+
+                    PlaybackState.PLAYING -> {
+                        // Restore immediately, but only report after PLAYING has remained active for 5 seconds.
+                        withContext(NonCancellable) {
+                            if (!haveResumedOnce) {
+                                val positionMillis =
+                                    playProgressRepository.getPositionMillisByEpisodeId(episodeSession.episodeId)
+                                if (positionMillis == null) {
+                                    logger.info { "Did not find saved position" }
+                                } else {
+                                    logger.info { "Loaded saved position: $positionMillis, seeking to $positionMillis" }
+                                    withContext(Dispatchers.Main) { // android must call in main thread
+                                        player.seekTo(positionMillis)
+                                    }
+                                    haveResumedOnce = true
+                                }
+                            }
+                        }
+
+                        delay(initialReportDelay)
+                        savePlayProgressOrRemove(episodeSession, allowZeroPosition = true)
+
+                        if (periodicReportInterval != Duration.INFINITE) {
+                            while (true) {
+                                delay(periodicReportInterval)
+                                savePlayProgressOrRemove(episodeSession, allowZeroPosition = true)
+                            }
+                        }
+                    }
+
                     PlaybackState.PAUSED -> {
                         mediaLoaded.await() // 播放器开始播放了一次之后再保存状态
                         savePlayProgressOrRemove(episodeSession)
@@ -137,8 +149,9 @@ class RememberPlayProgressExtension(
 
     private suspend fun savePlayProgressOrRemove(
         episodeSession: EpisodeSession,
+        allowZeroPosition: Boolean = false,
     ) {
-        savePlayProgressOrRemove(episodeSession.episodeId, episodeSession)
+        savePlayProgressOrRemove(episodeSession.episodeId, episodeSession, allowZeroPosition)
     }
 
     private suspend fun savePlayProgressOrRemove(
@@ -150,6 +163,7 @@ class RememberPlayProgressExtension(
     private suspend fun savePlayProgressOrRemove(
         episodeId: Int,
         episodeSession: EpisodeSession?,
+        allowZeroPosition: Boolean = false,
     ) {
         val player = context.player
         val playbackState = player.playbackState.value
@@ -179,7 +193,7 @@ class RememberPlayProgressExtension(
                     }
                 }
 
-                if (currentPositionMillis <= 0L) {
+                if (currentPositionMillis < 0L || (currentPositionMillis == 0L && !allowZeroPosition)) {
                     return
                 }
 

--- a/app/shared/app-data/src/commonTest/kotlin/data/repository/player/EpisodePlayHistoryRepositoryTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/repository/player/EpisodePlayHistoryRepositoryTest.kt
@@ -74,6 +74,41 @@ class EpisodePlayHistoryRepositoryTest {
     }
 
     @Test
+    fun `successive saves keep only the latest pending op for each episode`() = runTest {
+        val repository = createRepository()
+
+        repository.saveOrUpdate(
+            episodeId = 1,
+            positionMillis = 20_000,
+            subjectId = 10,
+            durationMillis = 100_000,
+        )
+        now = 200
+        repository.saveOrUpdate(
+            episodeId = 1,
+            positionMillis = 40_000,
+            subjectId = 10,
+            durationMillis = 100_000,
+        )
+        repository.saveOrUpdate(
+            episodeId = 2,
+            positionMillis = 30_000,
+            subjectId = 20,
+            durationMillis = 100_000,
+        )
+
+        val pendingOps = repository.pendingOpsFlow.first()
+        assertEquals(2, pendingOps.size)
+        assertEquals(
+            mapOf(1 to 40_000L, 2 to 30_000L),
+            pendingOps.associate { op ->
+                val upsert = op as PlaybackHistoryPendingOp.Upsert
+                upsert.episodeId to upsert.positionMillis
+            },
+        )
+    }
+
+    @Test
     fun `legacy migration stores records and enqueues pending upsert ops`() = runTest {
         val repository = createRepository(
             EpisodeHistories(
@@ -131,8 +166,9 @@ class EpisodePlayHistoryRepositoryTest {
         assertNull(repository.getPositionMillisByEpisodeId(1))
 
         val pendingOps = repository.pendingOpsFlow.first()
-        assertTrue(pendingOps.last() is PlaybackHistoryPendingOp.Delete)
-        assertEquals(1, pendingOps.last().episodeId)
+        assertEquals(1, pendingOps.size)
+        assertTrue(pendingOps.single() is PlaybackHistoryPendingOp.Delete)
+        assertEquals(1, pendingOps.single().episodeId)
     }
 
     @Test

--- a/app/shared/app-data/src/commonTest/kotlin/data/repository/player/PlaybackHistorySyncerTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/repository/player/PlaybackHistorySyncerTest.kt
@@ -9,6 +9,9 @@
 
 package me.him188.ani.app.data.repository.player
 
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -17,6 +20,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import me.him188.ani.client.models.AniDELETE
 import me.him188.ani.client.models.AniSyncRequest
 import me.him188.ani.client.models.AniUPSERT
+import kotlin.time.Duration.Companion.seconds
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -47,5 +51,87 @@ class PlaybackHistorySyncerTest {
         val ops = json.parseToJsonElement(encoded).jsonObject.getValue("ops").jsonArray
         assertEquals("UPSERT", ops[0].jsonObject.getValue("opType").jsonPrimitive.content)
         assertEquals("DELETE", ops[1].jsonObject.getValue("opType").jsonPrimitive.content)
+    }
+
+    @Test
+    fun `first request runs immediately and requests during cooldown merge into one trailing run`() = runTest {
+        val runTimes = mutableListOf<Long>()
+        val gate = LeadingTrailingSyncGate(backgroundScope, 5.seconds) {
+            runTimes += testScheduler.currentTime
+        }
+
+        gate.request()
+        runCurrent()
+        assertEquals(listOf(0L), runTimes)
+
+        gate.request()
+        gate.request()
+        advanceTimeBy(4_999)
+        runCurrent()
+        assertEquals(listOf(0L), runTimes)
+
+        gate.request()
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(listOf(0L, 5_000L), runTimes)
+    }
+
+    @Test
+    fun `request after an idle cooldown runs immediately`() = runTest {
+        val runTimes = mutableListOf<Long>()
+        val gate = LeadingTrailingSyncGate(backgroundScope, 5.seconds) {
+            runTimes += testScheduler.currentTime
+        }
+
+        gate.request()
+        runCurrent()
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        gate.request()
+        runCurrent()
+        assertEquals(listOf(0L, 5_000L), runTimes)
+    }
+
+    @Test
+    fun `pending operations keep only the latest value per episode`() {
+        val latest = listOf(
+            PlaybackHistoryPendingOp.Upsert(
+                id = 1,
+                episodeId = 10,
+                subjectId = 100,
+                positionMillis = 1_000,
+                durationMillis = 100_000,
+                updatedAtMillis = 100,
+            ),
+            PlaybackHistoryPendingOp.Upsert(
+                id = 2,
+                episodeId = 10,
+                subjectId = 100,
+                positionMillis = 2_000,
+                durationMillis = 100_000,
+                updatedAtMillis = 200,
+            ),
+            PlaybackHistoryPendingOp.Upsert(
+                id = 3,
+                episodeId = 20,
+                subjectId = 200,
+                positionMillis = 3_000,
+                durationMillis = 100_000,
+                updatedAtMillis = 300,
+            ),
+            PlaybackHistoryPendingOp.Delete(
+                id = 4,
+                episodeId = 10,
+                deletedAtMillis = 200,
+            ),
+            PlaybackHistoryPendingOp.Delete(
+                id = 5,
+                episodeId = 20,
+                deletedAtMillis = 200,
+            ),
+        ).latestPerEpisode()
+
+        assertEquals(listOf(3L, 4L), latest.map { it.id })
     }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodeFetchPlayStateSwitchEpisodeTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodeFetchPlayStateSwitchEpisodeTest.kt
@@ -29,11 +29,13 @@ import me.him188.ani.app.domain.media.TestMediaList
 import me.him188.ani.app.domain.media.resolver.MediaResolver
 import me.him188.ani.app.domain.media.resolver.TestUniversalMediaResolver
 import me.him188.ani.app.domain.player.extension.AbstractPlayerExtensionTest
+import me.him188.ani.app.domain.player.extension.EpisodePlayerExtensionFactory
 import me.him188.ani.app.domain.player.extension.RememberPlayProgressExtension
 import me.him188.ani.app.domain.player.extension.SwitchNextEpisodeExtension
 import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
 import me.him188.ani.utils.coroutines.childScope
 import org.openani.mediamp.PlaybackState
+import kotlin.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -61,9 +63,16 @@ class EpisodeFetchPlayStateSwitchEpisodeTest : AbstractPlayerExtensionTest() {
             TestUniversalMediaResolver
         }
 
+        val rememberPlayProgress = EpisodePlayerExtensionFactory { context, koin ->
+            RememberPlayProgressExtension(
+                context,
+                koin,
+                periodicReportInterval = Duration.INFINITE,
+            )
+        }
         val state = suite.createState(
             listOf(
-                RememberPlayProgressExtension,
+                rememberPlayProgress,
                 SwitchNextEpisodeExtension.Factory(
                     getNextEpisode = { currentEpisodeId ->
                         assertEquals(initialEpisodeId, currentEpisodeId)
@@ -81,70 +90,72 @@ class EpisodeFetchPlayStateSwitchEpisodeTest : AbstractPlayerExtensionTest() {
     fun `switchEpisode then load play history - no media source`() = runTest {
         val (testScope, suite, state) =
             createCase()
+        try {
+            playHistory.saveOrUpdate(initialEpisodeId, 3000)
+            playHistory.saveOrUpdate(newEpisodeId, 5000)
 
-        playHistory.saveOrUpdate(initialEpisodeId, 3000)
-        playHistory.saveOrUpdate(newEpisodeId, 5000)
+            // 播放到一半
 
-        // 播放到一半
+            assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
 
-        assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
+            // 播到最尾部了
+            suite.setMediaDuration(100_000)
+            advanceUntilIdle()
 
-        // 播到最尾部了
-        suite.setMediaDuration(100_000)
-        advanceUntilIdle()
+            suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
+            suite.player.playbackState.value = PlaybackState.FINISHED
+            advanceUntilIdle() // 自动切换到下一集数
 
-        suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
-        suite.player.playbackState.value = PlaybackState.FINISHED
-        advanceUntilIdle() // 自动切换到下一集数
+            // 没有实际加载媒体源时，不会覆盖或删除旧进度
+            assertEquals(3000, playHistory.getPositionMillisByEpisodeId(initialEpisodeId))
 
-        // 没有实际加载媒体源时，不会覆盖或删除旧进度
-        assertEquals(3000, playHistory.getPositionMillisByEpisodeId(initialEpisodeId))
-
-        assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
-
-        testScope.cancel()
+            assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
+        } finally {
+            testScope.cancel()
+        }
     }
 
     @Test
     fun `switchEpisode then load play history - wait for media source`() = runTest {
         val (testScope, suite, state) =
             createCase()
+        try {
+            val ms1 = suite.mediaSelectorTestBuilder.delayedMediaSource("1")
 
-        val ms1 = suite.mediaSelectorTestBuilder.delayedMediaSource("1")
+            playHistory.saveOrUpdate(initialEpisodeId, 3000)
+            playHistory.saveOrUpdate(newEpisodeId, 5000)
 
-        playHistory.saveOrUpdate(initialEpisodeId, 3000)
-        playHistory.saveOrUpdate(newEpisodeId, 5000)
+            // 播放到一半
+            assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
 
-        // 播放到一半
-        assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
+            val myMedia = TestMediaList[0]
+            ms1.complete(listOf(myMedia))
+            state.mediaSelectorFlow.filterNotNull().first().select(myMedia)
+            suite.setMediaDuration(100_000)
+            advanceUntilIdle()
 
-        val myMedia = TestMediaList[0]
-        ms1.complete(listOf(myMedia))
-        state.mediaSelectorFlow.filterNotNull().first().select(myMedia)
-        suite.setMediaDuration(100_000)
-        advanceUntilIdle()
+            assertEquals(3000, suite.player.currentPositionMillis.value)
 
-        assertEquals(3000, suite.player.currentPositionMillis.value)
+            // 播到最尾部了
+            suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
+            suite.player.playbackState.value = PlaybackState.FINISHED
+            advanceUntilIdle() // 自动切换到下一集数
 
-        // 播到最尾部了
-        suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
-        suite.player.playbackState.value = PlaybackState.FINISHED
-        advanceUntilIdle() // 自动切换到下一集数
+            // 前一集播放完毕了
+            assertEquals(null, playHistory.getPositionMillisByEpisodeId(initialEpisodeId))
 
-        // 前一集播放完毕了
-        assertEquals(null, playHistory.getPositionMillisByEpisodeId(initialEpisodeId))
+            assertEquals(newEpisodeId, state.getCurrentEpisodeId())
 
-        assertEquals(newEpisodeId, state.getCurrentEpisodeId())
+            val myMedia1 = TestMediaList[1]
+            ms1.complete(listOf(myMedia1))
+            state.mediaSelectorFlow.filterNotNull().first().select(myMedia1)
+            suite.setMediaDuration(100_000)
+            advanceUntilIdle() // 自动加载播放进度
 
-        val myMedia1 = TestMediaList[1]
-        ms1.complete(listOf(myMedia1))
-        state.mediaSelectorFlow.filterNotNull().first().select(myMedia1)
-        suite.setMediaDuration(100_000)
-        advanceUntilIdle() // 自动加载播放进度
-
-        // should load the saved progress for new episode
-        assertEquals(5000, suite.player.currentPositionMillis.value)
-
-        testScope.cancel()
+            // should load the saved progress for new episode
+            assertEquals(5000, suite.player.currentPositionMillis.value)
+        } finally {
+            testScope.cancel()
+        }
     }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import me.him188.ani.app.data.models.player.EpisodeHistory
@@ -24,6 +26,7 @@ import me.him188.ani.app.data.persistent.database.dao.createMemoryPlaybackHistor
 import me.him188.ani.app.data.repository.player.EpisodeHistories
 import me.him188.ani.app.data.repository.player.EpisodePlayHistoryRepository
 import me.him188.ani.app.data.repository.player.EpisodePlayHistoryRepositoryImpl
+import me.him188.ani.app.data.repository.player.PlaybackHistoryPendingOp
 import me.him188.ani.app.domain.episode.EpisodeFetchSelectPlayState
 import me.him188.ani.app.domain.episode.EpisodePlayerTestSuite
 import me.him188.ani.app.domain.episode.UnsafeEpisodeSessionApi
@@ -36,6 +39,8 @@ import me.him188.ani.utils.coroutines.childScope
 import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.metadata.MediaProperties
 import org.openani.mediamp.source.UriMediaData
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -54,16 +59,23 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
         state: EpisodeFetchSelectPlayState,
         durationMillis: Long = 100_000L,
         mediaIndex: Int = 0,
+        advanceUntilSettled: Boolean = true,
     ) {
         val media = TestMediaList[mediaIndex]
         val source = suite.mediaSelectorTestBuilder.delayedMediaSource("remember-$mediaIndex")
         source.complete(listOf(media))
         state.mediaSelectorFlow.filterNotNull().first().select(media)
         suite.setMediaDuration(durationMillis)
-        advanceUntilIdle()
+        if (advanceUntilSettled) {
+            advanceUntilIdle()
+        } else {
+            runCurrent()
+        }
     }
 
-    private fun TestScope.createCase() = run {
+    private fun TestScope.createCase(
+        periodicReportInterval: Duration = Duration.INFINITE,
+    ) = run {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
 
         val testScope = this.childScope()
@@ -71,9 +83,12 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
         suite.registerComponent<EpisodePlayHistoryRepository> { repository }
         suite.registerComponent<MediaResolver> { TestUniversalMediaResolver }
 
+        val rememberPlayProgress = EpisodePlayerExtensionFactory { context, koin ->
+            RememberPlayProgressExtension(context, koin, periodicReportInterval)
+        }
         val state = suite.createState(
             listOf(
-                RememberPlayProgressExtension,
+                rememberPlayProgress,
             ),
         )
         state.onUIReady()
@@ -101,6 +116,71 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
     ///////////////////////////////////////////////////////////////////////////
     // Normal save cases
     ///////////////////////////////////////////////////////////////////////////
+
+    @Test
+    fun `reports after playback remains playing for five seconds`() = runTest {
+        val (testScope, suite, state) = createCase()
+        advanceUntilIdle()
+
+        loadSelectedMedia(suite, state, advanceUntilSettled = false)
+        runCurrent()
+        assertEquals(emptyList(), repository.pendingOpsFlow.first())
+
+        advanceTimeBy(4_999)
+        runCurrent()
+        assertEquals(emptyList(), repository.pendingOpsFlow.first())
+
+        advanceTimeBy(1)
+        runCurrent()
+
+        assertSingleSavedHistoryList(0)
+        assertEquals(
+            listOf(0L),
+            repository.pendingOpsFlow.first()
+                .filterIsInstance<PlaybackHistoryPendingOp.Upsert>()
+                .map { it.positionMillis },
+        )
+
+        testScope.cancel()
+    }
+
+    @Test
+    fun `reports once per minute while playing`() = runTest {
+        val (testScope, suite, state) = createCase(periodicReportInterval = 1.minutes)
+        advanceUntilIdle()
+
+        loadSelectedMedia(suite, state, advanceUntilSettled = false)
+        runCurrent()
+        assertEquals(emptyList(), repository.pendingOpsFlow.first())
+
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        assertEquals(
+            listOf(0L),
+            repository.pendingOpsFlow.first()
+                .filterIsInstance<PlaybackHistoryPendingOp.Upsert>()
+                .map { it.positionMillis },
+        )
+
+        suite.player.seekTo(2000)
+        advanceTimeBy(59_999)
+        runCurrent()
+        assertEquals(1, repository.pendingOpsFlow.first().size)
+
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(
+            listOf(0L, 2000L),
+            repository.pendingOpsFlow.first()
+                .filterIsInstance<PlaybackHistoryPendingOp.Upsert>()
+                .map { it.positionMillis },
+        )
+
+        suite.player.playbackState.value = PlaybackState.PAUSED
+        runCurrent()
+        testScope.cancel()
+    }
 
     @Test
     fun `does nothing initially`() = runTest {

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
@@ -171,7 +171,7 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
         advanceTimeBy(1)
         runCurrent()
         assertEquals(
-            listOf(0L, 2000L),
+            listOf(2000L),
             repository.pendingOpsFlow.first()
                 .filterIsInstance<PlaybackHistoryPendingOp.Upsert>()
                 .map { it.positionMillis },


### PR DESCRIPTION
## Summary

- report playback progress after the player remains in `PLAYING` for 5 seconds
- report the latest progress every minute while playback continues
- coalesce sync requests with an immediate leading request and one latest trailing request after a 5-second cooldown
- keep at most one local pending operation per episode by replacing older unsynced progress or delete operations
- send only the latest pending operation for each episode in a sync batch, including duplicates created by older app versions

## Why

Playback history was previously updated only for lifecycle events such as pause, finish, source changes, episode changes, and page close. That made active playback difficult to observe and allowed rapid state changes to trigger redundant sync requests.

The new heartbeat makes active playback visible while the delayed initial report avoids counting very short `PLAYING` transitions. The sync gate keeps network traffic bounded without losing the latest durable Room state. Coalescing pending operations also prevents an offline playback session from accumulating one database row per heartbeat.

## Behavior

- saved-position restoration still happens immediately on `PLAYING`
- the initial activity report is cancelled if playback leaves `PLAYING` within 5 seconds
- minute heartbeats start after the initial delayed report
- pause, finish, source switch, episode switch, and close reports continue to work
- each episode keeps only its latest pending operation; different episodes remain independent
- pending Room operations survive page/ViewModel destruction and are synced by the application-scoped syncer

## Validation

- `./gradlew :app:shared:app-data:desktopTest --tests me.him188.ani.app.data.repository.player.EpisodePlayHistoryRepositoryTest --tests me.him188.ani.app.data.repository.player.PlaybackHistorySyncerTest --tests me.him188.ani.app.domain.player.extension.RememberPlayProgressExtensionTest`
- `git diff --check`
