### PR TITLE
Redesign cache management multi-select: floating batch toolbar and lighter selection

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -840,6 +840,9 @@
     <string name="cache_management_exit_selection">退出选择</string>
     <string name="cache_management_select_all">选择所有</string>
     <string name="cache_management_delete_selected">删除所选</string>
+    <string name="cache_management_resume_selected">继续</string>
+    <string name="cache_management_pause_selected">暂停</string>
+    <string name="cache_management_selection_summary">已选 %1$d 项 · 共 %2$s</string>
     <string name="cache_management_enter_selection_mode">进入选择模式</string>
     <string name="cache_management_delete_cache_title">删除缓存</string>
     <string name="cache_management_delete_cache_confirmation">删除后不可恢复，确认删除吗？</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -815,6 +815,9 @@
     <string name="cache_management_exit_selection">退出選擇</string>
     <string name="cache_management_select_all">選擇所有</string>
     <string name="cache_management_delete_selected">刪除所選</string>
+    <string name="cache_management_resume_selected">繼續</string>
+    <string name="cache_management_pause_selected">暫停</string>
+    <string name="cache_management_selection_summary">已選 %1$d 項 · 共 %2$s</string>
     <string name="cache_management_enter_selection_mode">進入選擇模式</string>
     <string name="cache_management_delete_cache_title">刪除緩存</string>
     <string name="cache_management_delete_cache_confirmation">刪除後不可恢復，確認刪除嗎？</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -804,6 +804,9 @@
     <string name="cache_management_exit_selection">退出選擇</string>
     <string name="cache_management_select_all">選擇所有</string>
     <string name="cache_management_delete_selected">刪除所選</string>
+    <string name="cache_management_resume_selected">繼續</string>
+    <string name="cache_management_pause_selected">暫停</string>
+    <string name="cache_management_selection_summary">已選 %1$d 項 · 共 %2$s</string>
     <string name="cache_management_enter_selection_mode">進入選擇模式</string>
     <string name="cache_management_delete_cache_title">刪除緩存</string>
     <string name="cache_management_delete_cache_confirmation">刪除後不可恢復，確認刪除嗎？</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -800,6 +800,9 @@
     <string name="cache_management_exit_selection">Exit Selection</string>
     <string name="cache_management_select_all">Select All</string>
     <string name="cache_management_delete_selected">Delete Selected</string>
+    <string name="cache_management_resume_selected">Resume</string>
+    <string name="cache_management_pause_selected">Pause</string>
+    <string name="cache_management_selection_summary">%1$d selected · %2$s in total</string>
     <string name="cache_management_enter_selection_mode">Enter Selection Mode</string>
     <string name="cache_management_delete_cache_title">Delete Cache</string>
     <string name="cache_management_delete_cache_confirmation">Deletion cannot be undone. Delete this cache?</string>

--- a/app/shared/src/desktopTest/kotlin/ui/cache/CacheManagementSelectionTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/cache/CacheManagementSelectionTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.cache
+
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.runBlocking
+import me.him188.ani.app.domain.media.cache.engine.MediaStats
+import me.him188.ani.app.tools.toProgress
+import me.him188.ani.app.ui.cache.components.CacheEpisodePaused
+import me.him188.ani.app.ui.cache.components.CacheEpisodeState
+import me.him188.ani.app.ui.cache.components.CacheGroupState
+import me.him188.ani.app.ui.cache.components.CacheSelectionToolbarTestTags
+import me.him188.ani.app.ui.cache.components.createTestCacheEpisode
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.cache_management_enter_selection_mode
+import me.him188.ani.app.ui.lang.cache_management_select_all
+import me.him188.ani.app.ui.lang.cache_management_selected_count
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import me.him188.ani.utils.platform.annotations.TestOnly
+import org.jetbrains.compose.resources.getString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(TestOnly::class)
+class CacheManagementSelectionTest {
+    private val inProgress = createTestCacheEpisode(1, initialState = CacheEpisodePaused.IN_PROGRESS)
+    private val paused = createTestCacheEpisode(2, initialState = CacheEpisodePaused.PAUSED)
+    private val finished = createTestCacheEpisode(
+        3,
+        initialState = CacheEpisodePaused.COMPLETED,
+        progress = 1f.toProgress(),
+    )
+    private val failed = createTestCacheEpisode(4, initialState = CacheEpisodePaused.FAILED)
+    private val episodes = listOf(inProgress, paused, finished, failed)
+
+    private val state = CacheManagementState(
+        MediaStats.Unspecified,
+        listOf(
+            CacheGroupState(
+                subjectId = 1,
+                subjectName = "孤独摇滚",
+                entries = episodes,
+                collectionType = UnifiedCollectionType.DOING,
+            ),
+        ),
+    )
+
+    @Test
+    fun `batch resume, pause and delete selected caches`() = runAniComposeUiTest {
+        val enterSelectionText = runBlocking { getString(Lang.cache_management_enter_selection_mode) }
+        val selectAllText = runBlocking { getString(Lang.cache_management_select_all) }
+        val selectedCountText = runBlocking { getString(Lang.cache_management_selected_count, episodes.size) }
+
+        val resumedIds = mutableSetOf<String>()
+        val pausedIds = mutableSetOf<String>()
+        val deletedIds = mutableSetOf<String>()
+
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                CacheManagementScreen(
+                    state = state,
+                    selfInfo = null,
+                    onPlay = {},
+                    onResume = { resumedIds += it.cacheId },
+                    onPause = { pausedIds += it.cacheId },
+                    onViewDetail = {},
+                    onDelete = { deletedIds += it.cacheId },
+                    onClickLogin = {},
+                )
+            }
+        }
+
+        // 进入多选并全选
+        onNodeWithContentDescription(enterSelectionText).performClick()
+        onNodeWithContentDescription(selectAllText).performClick()
+        onNodeWithText(selectedCountText).assertExists()
+
+        // 批量继续: 只作用于已暂停的
+        onNodeWithTag(CacheSelectionToolbarTestTags.RESUME).performClick()
+        runOnIdle {
+            assertEquals(setOf(paused.cacheId), resumedIds)
+        }
+
+        // 批量暂停: 只作用于下载中的 (不含已完成/已失败)
+        onNodeWithTag(CacheSelectionToolbarTestTags.PAUSE).performClick()
+        runOnIdle {
+            assertEquals(setOf(inProgress.cacheId), pausedIds)
+        }
+
+        // 批量删除: 需要确认, 作用于所有选中项, 然后退出多选
+        onNodeWithTag(CacheSelectionToolbarTestTags.DELETE).performClick()
+        onNodeWithTag(CacheManagementTestTags.DELETE_CONFIRM_BUTTON).performClick()
+        runOnIdle {
+            assertEquals(episodes.map { it.cacheId }.toSet(), deletedIds)
+        }
+        onNodeWithText(selectedCountText).assertDoesNotExist()
+    }
+}

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/CacheManagementScreen.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/CacheManagementScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
@@ -95,6 +96,7 @@ import me.him188.ani.app.ui.cache.components.CacheFilterAndSortBar
 import me.him188.ani.app.ui.cache.components.CacheFilterAndSortState
 import me.him188.ani.app.ui.cache.components.CacheGroupState
 import me.him188.ani.app.ui.cache.components.CacheManagementOverallStats
+import me.him188.ani.app.ui.cache.components.CacheSelectionFloatingToolbar
 import me.him188.ani.app.ui.cache.components.CacheSelectionState
 import me.him188.ani.app.ui.cache.components.DownloadStateIcon
 import me.him188.ani.app.ui.cache.components.TestCacheGroupSates
@@ -120,7 +122,6 @@ import me.him188.ani.app.ui.lang.cache_episode_pause_download
 import me.him188.ani.app.ui.lang.cache_episode_resume_download
 import me.him188.ani.app.ui.lang.cache_management_delete_cache_confirmation
 import me.him188.ani.app.ui.lang.cache_management_delete_cache_title
-import me.him188.ani.app.ui.lang.cache_management_delete_selected
 import me.him188.ani.app.ui.lang.cache_management_downloading_count
 import me.him188.ani.app.ui.lang.cache_management_enter_selection_mode
 import me.him188.ani.app.ui.lang.cache_management_episode_label
@@ -133,6 +134,7 @@ import me.him188.ani.app.ui.lang.cache_management_play
 import me.him188.ani.app.ui.lang.cache_management_select_all
 import me.him188.ani.app.ui.lang.cache_management_select_item_for_details
 import me.him188.ani.app.ui.lang.cache_management_selected_count
+import me.him188.ani.app.ui.lang.cache_management_selection_summary
 import me.him188.ani.app.ui.lang.cache_management_streaming_not_supported
 import me.him188.ani.app.ui.lang.cache_subject_cancel
 import me.him188.ani.app.ui.lang.cache_subject_delete
@@ -140,6 +142,7 @@ import me.him188.ani.app.ui.lang.cache_unknown
 import me.him188.ani.app.ui.lang.main_screen_page_cache_management
 import me.him188.ani.app.ui.settings.rendering.P2p
 import me.him188.ani.app.ui.user.SelfInfoUiState
+import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
 import me.him188.ani.utils.platform.annotations.TestOnly
 import org.jetbrains.compose.resources.stringResource
 
@@ -225,6 +228,10 @@ fun CacheManagementScreen(
     // region selection
     var deleteSelectedCacheDialog by rememberSaveable { mutableStateOf(false) }
 
+    // 当前选中的 entries
+    val selectedEntries = remember(selectionEntries, selectionState.selectedIds) {
+        selectionEntries.filter { it.cacheId in selectionState.selectedIds }
+    }
     // 当前选中的 entries 数量
     val selectionCount = selectionState.selectedIds.size
     // 是否已经全选
@@ -290,7 +297,6 @@ fun CacheManagementScreen(
                         if (allSelected) emptySet() else selectionEntries.map { it.cacheId }.toSet(),
                     )
                 },
-                onDeleteSelected = { deleteSelectedCacheDialog = true },
                 selfInfo = selfInfo,
                 onClickLogin = onClickLogin,
                 navigationIcon = navigationIcon,
@@ -299,6 +305,24 @@ fun CacheManagementScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
+        bottomBar = {
+            AniAnimatedVisibility(selectionState.inSelection) {
+                CacheSelectionFloatingToolbar(
+                    resumeEnabled = selectedEntries.any { !it.isFinished && it.isPaused },
+                    pauseEnabled = selectedEntries.any { !it.isFinished && !it.isPaused && !it.isFailed },
+                    deleteEnabled = selectedEntries.isNotEmpty(),
+                    onResumeSelected = {
+                        selectedEntries.filter { !it.isFinished && it.isPaused }.forEach(onResume)
+                    },
+                    onPauseSelected = {
+                        selectedEntries.filter { !it.isFinished && !it.isPaused && !it.isFailed }.forEach(onPause)
+                    },
+                    onDeleteSelected = { deleteSelectedCacheDialog = true },
+                    windowInsets = windowInsets.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+                )
+            }
+        },
+        selectedEntries = selectedEntries,
         selectedGroup = currentViewingGroup,
         appBarColors = appBarColors,
         scrollBehavior = scrollBehavior,
@@ -349,6 +373,8 @@ private fun CacheManagementLayout(
     onViewDetail: (CacheEpisodeState) -> Unit,
     appBarColors: TopAppBarColors,
     topBar: @Composable () -> Unit,
+    bottomBar: @Composable () -> Unit,
+    selectedEntries: List<CacheEpisodeState>,
     scrollBehavior: TopAppBarScrollBehavior,
     listState: LazyListState,
     detailListState: LazyListState,
@@ -361,6 +387,7 @@ private fun CacheManagementLayout(
     Scaffold(
         modifier = modifier,
         topBar = topBar,
+        bottomBar = bottomBar,
         containerColor = AniThemeDefaults.pageContentBackgroundColor,
         contentWindowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
     ) { paddingValues ->
@@ -398,13 +425,23 @@ private fun CacheManagementLayout(
                                 color = appBarColors.containerColor,
                                 contentColor = contentColorFor(appBarColors.containerColor),
                             ) {
-                                CacheManagementOverallStats(
-                                    { state.overallStats },
-                                    Modifier
-                                        .paneContentPadding()
-                                        .padding(horizontal = listSpacedBy)
-                                        .fillMaxWidth(),
-                                )
+                                if (selectionState.inSelection) {
+                                    CacheSelectionSummary(
+                                        selectedEntries,
+                                        Modifier
+                                            .paneContentPadding()
+                                            .padding(horizontal = listSpacedBy)
+                                            .fillMaxWidth(),
+                                    )
+                                } else {
+                                    CacheManagementOverallStats(
+                                        { state.overallStats },
+                                        Modifier
+                                            .paneContentPadding()
+                                            .padding(horizontal = listSpacedBy)
+                                            .fillMaxWidth(),
+                                    )
+                                }
                             }
                         }
                         stickyHeader("filter_row") {
@@ -448,12 +485,21 @@ private fun CacheManagementLayout(
                                 color = appBarColors.containerColor,
                                 contentColor = contentColorFor(appBarColors.containerColor),
                             ) {
-                                CacheManagementOverallStats(
-                                    { state.overallStats },
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 12.dp, vertical = 8.dp),
-                                )
+                                if (selectionState.inSelection) {
+                                    CacheSelectionSummary(
+                                        selectedEntries,
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                                    )
+                                } else {
+                                    CacheManagementOverallStats(
+                                        { state.overallStats },
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                                    )
+                                }
                             }
                         }
                         items(groupedEntries, key = { it.key }) { group ->
@@ -544,7 +590,6 @@ private fun CacheManagementTopBar(
     onEnterSelection: () -> Unit,
     onExitSelection: () -> Unit,
     onToggleSelectAll: () -> Unit,
-    onDeleteSelected: () -> Unit,
     selfInfo: SelfInfoUiState?,
     onClickLogin: () -> Unit,
     navigationIcon: @Composable () -> Unit,
@@ -556,7 +601,6 @@ private fun CacheManagementTopBar(
         val selectedCountText = stringResource(Lang.cache_management_selected_count, selectionCount)
         val exitSelectionText = stringResource(Lang.cache_management_exit_selection)
         val selectAllText = stringResource(Lang.cache_management_select_all)
-        val deleteSelectedText = stringResource(Lang.cache_management_delete_selected)
         AniTopAppBar(
             title = { AniTopAppBarDefaults.Title(selectedCountText) },
             navigationIcon = {
@@ -573,14 +617,7 @@ private fun CacheManagementTopBar(
                     )
                 }
             },
-            avatar = {
-                IconButton(
-                    onClick = onDeleteSelected,
-                    enabled = selectionCount > 0,
-                ) {
-                    Icon(Icons.Rounded.Delete, deleteSelectedText, tint = MaterialTheme.colorScheme.error)
-                }
-            },
+            avatar = { },
             colors = appBarColors,
             windowInsets = windowInsets,
             scrollBehavior = scrollBehavior,
@@ -615,6 +652,34 @@ private fun CacheManagementTopBar(
 }
 
 
+/**
+ * 多选模式下代替总体统计的选择摘要: "已选 n 项 · 共 x GB · n 个下载中".
+ */
+@Composable
+private fun CacheSelectionSummary(
+    selectedEntries: List<CacheEpisodeState>,
+    modifier: Modifier = Modifier,
+) {
+    val totalSize = remember(selectedEntries) {
+        selectedEntries.fold(0L) { acc, entry -> acc + entry.totalSize.inBytes }.bytes
+    }
+    val downloadingCount = remember(selectedEntries) {
+        selectedEntries.count { !it.isFinished && !it.isPaused && !it.isFailed }
+    }
+    val summaryText = stringResource(Lang.cache_management_selection_summary, selectedEntries.size, "$totalSize")
+    val downloadingText = stringResource(Lang.cache_management_downloading_count, downloadingCount)
+    Text(
+        if (downloadingCount > 0) "$summaryText · $downloadingText" else summaryText,
+        modifier.padding(vertical = 12.dp),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+object CacheManagementTestTags {
+    const val DELETE_CONFIRM_BUTTON = "cache_management_delete_confirm_button"
+}
+
 @Composable
 internal fun DeleteActionDialog(
     onDismiss: () -> Unit,
@@ -628,6 +693,7 @@ internal fun DeleteActionDialog(
         confirmButton = {
             TextButton(
                 onClick = onConfirm,
+                modifier = Modifier.testTag(CacheManagementTestTags.DELETE_CONFIRM_BUTTON),
             ) { Text(stringResource(Lang.cache_subject_delete), color = MaterialTheme.colorScheme.error) }
         },
         dismissButton = {
@@ -659,7 +725,16 @@ private fun CacheSubjectListItem(
         Row(
             Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (selectionMode) {
+                val allGroupSelected = group.entries.all { it.cacheId in selectedCacheIds }
+                Checkbox(
+                    checked = allGroupSelected,
+                    onCheckedChange = { onToggleGroupSelection(group) },
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+            }
 
             Column(
                 Modifier.weight(1f).animateContentSize(),
@@ -706,14 +781,6 @@ private fun CacheSubjectListItem(
                 }
             }
 
-            if (selectionMode) {
-                val allGroupSelected = group.entries.all { it.cacheId in selectedCacheIds }
-                Checkbox(
-                    checked = allGroupSelected,
-                    onCheckedChange = { onToggleGroupSelection(group) },
-                    modifier = Modifier.padding(start = 16.dp),
-                )
-            }
         }
     }
 }
@@ -764,8 +831,9 @@ private fun CacheListItem(
                 },
             ),
         shape = MaterialTheme.shapes.large,
-        tonalElevation = if (selected) 6.dp else 1.dp,
-        color = if (selected) MaterialTheme.colorScheme.secondaryContainer else
+        tonalElevation = 1.dp,
+        // 多选选中态用较轻的 surfaceContainer (≈ primary 8% 状态层), 强指示交给 Checkbox.
+        color = if (selected) MaterialTheme.colorScheme.surfaceContainer else
             (if (transparentBackgroundIfUnselected) Color.Transparent else MaterialTheme.colorScheme.surface),
     ) {
         Column(Modifier.padding(contentPadding), verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -774,6 +842,13 @@ private fun CacheListItem(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                // 设计稿: 多选模式下复选框在行首, 行尾单项操作隐藏.
+                if (selectionMode) {
+                    Checkbox(
+                        checked = selected,
+                        onCheckedChange = { onToggleSelected() },
+                    )
+                }
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         entry.engineKey?.let { key ->
@@ -801,21 +876,14 @@ private fun CacheListItem(
                     )
                 }
 
-                Row(
+                if (!selectionMode) Row(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     DownloadStateIcon(entry.state)
-                    if (selectionMode) {
-                        Checkbox(
-                            checked = selected,
-                            onCheckedChange = { onToggleSelected() },
-                        )
-                    } else {
-                        val moreActionsText = stringResource(Lang.cache_management_more_actions)
-                        IconButton(onClick = { showMenu = true }) {
-                            Icon(Icons.Rounded.MoreVert, moreActionsText)
-                        }
+                    val moreActionsText = stringResource(Lang.cache_management_more_actions)
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(Icons.Rounded.MoreVert, moreActionsText)
                     }
 
                     CacheActionDropdown(

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/components/CacheSelectionToolbar.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/components/CacheSelectionToolbar.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.cache.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.cache_management_pause_selected
+import me.him188.ani.app.ui.lang.cache_management_resume_selected
+import me.him188.ani.app.ui.lang.cache_subject_delete
+import org.jetbrains.compose.resources.stringResource
+
+object CacheSelectionToolbarTestTags {
+    const val RESUME = "cache_selection_toolbar_resume"
+    const val PAUSE = "cache_selection_toolbar_pause"
+    const val DELETE = "cache_selection_toolbar_delete"
+}
+
+/**
+ * 多选模式下的浮动批量操作工具栏 (M3 floating toolbar): 继续 / 暂停 / 删除.
+ */
+@Composable
+internal fun CacheSelectionFloatingToolbar(
+    resumeEnabled: Boolean,
+    pauseEnabled: Boolean,
+    deleteEnabled: Boolean,
+    onResumeSelected: () -> Unit,
+    onPauseSelected: () -> Unit,
+    onDeleteSelected: () -> Unit,
+    windowInsets: WindowInsets,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier
+            .windowInsetsPadding(windowInsets)
+            .fillMaxWidth()
+            .padding(top = 8.dp, bottom = 24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 3.dp,
+        ) {
+            Row(
+                Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(
+                    onClick = onResumeSelected,
+                    enabled = resumeEnabled,
+                    colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+                    modifier = Modifier.testTag(CacheSelectionToolbarTestTags.RESUME),
+                ) {
+                    Icon(Icons.Rounded.PlayArrow, stringResource(Lang.cache_management_resume_selected))
+                }
+                IconButton(
+                    onClick = onPauseSelected,
+                    enabled = pauseEnabled,
+                    colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+                    modifier = Modifier.testTag(CacheSelectionToolbarTestTags.PAUSE),
+                ) {
+                    Icon(Icons.Rounded.Pause, stringResource(Lang.cache_management_pause_selected))
+                }
+                VerticalDivider(
+                    Modifier.height(24.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+                IconButton(
+                    onClick = onDeleteSelected,
+                    enabled = deleteEnabled,
+                    colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                    modifier = Modifier.testTag(CacheSelectionToolbarTestTags.DELETE),
+                ) {
+                    Icon(Icons.Rounded.Delete, stringResource(Lang.cache_subject_delete))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Aligns the cache management selection mode with the adopted Figma design (「缓存管理 · 定稿设计」 → 条目缓存页 · 多选模式):

- **Floating batch toolbar (M3 floating-toolbar style)**: in selection mode, a centered pill (`surfaceContainerHigh`, 28dp corners, shadow) offers batch **resume / pause / delete**. Resume only affects paused entries, pause only affects downloading ones (same semantics as the per-item menu); delete keeps the confirmation dialog. Actions are disabled when no selected entry qualifies.
- **Lighter selected state**: selected rows now use `surfaceContainer` (≈ primary 8% state layer) instead of `secondaryContainer` + raised tonal elevation, with a leading checkbox as the primary indicator — select-all no longer floods the page with purple.
- **Selection summary**: while selecting, the overall stats row is replaced by "n selected · x GB in total · n downloading".
- Per-row play/menu/state icons are hidden during selection; the delete action moved from the top bar into the toolbar.
- New strings in en / zh-CN / zh-HK / zh-TW (MO/SG populated automatically).

Builds on the basic selection mode from #2885.

## Test plan

- New interactive UI test `CacheManagementSelectionTest` (enter selection → select all → batch resume/pause/delete incl. confirmation, verifying which entries each action affects).
- `compileKotlinDesktop` / `compileAndroidMain` pass; visually verified against the Figma frame via a Skiko screenshot at 412dp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)