### PR TITLE
feat(desktop): add Windows ARM64 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,221 @@ jobs:
       timeout-minutes: 180
       run: './gradlew testAndroidHostTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel"'
       if: '${{ steps.step-27.outcome == ''failure'' }}'
+  build_github-windows-11-arm64:
+    name: 'Build (Windows 11 AArch64 (GitHub))'
+    runs-on:
+    - 'windows-11-arm'
+    permissions:
+      actions: 'write'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+      with:
+        submodules: 'recursive'
+    - id: 'step-1'
+      continue-on-error: true
+      run: 'rm local.properties'
+    - id: 'step-2'
+      continue-on-error: true
+      run: |
+        echo "ani.android.abis=arm64-v8a" >> local.properties
+        echo "ani.dandanplay.app.id=${{ secrets.DANDANPLAY_APP_ID }}" >> local.properties
+        echo "ani.dandanplay.app.secret=${{ secrets.DANDANPLAY_APP_SECRET }}" >> local.properties
+        echo "ani.sentry.dsn=${{ secrets.SENTRY_DSN }}" >> local.properties
+        echo "kotlin.native.ignoreDisabledTargets=true" >> local.properties
+    - id: 'step-3'
+      continue-on-error: true
+      run: |
+        echo "ani.enable.firebase=true" >> local.properties
+        echo "firebase.ga.app.id=${{ secrets.FIREBASE_GA_APP_ID }}" >> local.properties
+        echo "firebase.ga.api.secret=${{ secrets.FIREBASE_GA_API_SECRET }}" >> local.properties
+      if: '${{ (github.repository == ''open-ani/animeko'') && (!(github.event_name == ''pull_request'')) }}'
+    - id: 'step-4'
+      name: 'Setup Android SDK'
+      uses: 'android-actions/setup-android@v3'
+      with:
+        accept-android-sdk-licenses: 'true'
+        packages: 'platform-tools platforms;android-36 build-tools;36.0.0'
+    - id: 'step-5'
+      name: 'Get JBR (Windows)'
+      env:
+        RUNNER_TOOL_CACHE: '${{ runner.tool_cache }}'
+        JBR_URL: 'https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-21.0.10-windows-aarch64-b1163.110.tar.gz'
+        JBR_CHECKSUM_URL: 'https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-21.0.10-windows-aarch64-b1163.110.tar.gz.checksum'
+      shell: 'cmd'
+      run: 'python .github/workflows/download_jbr.py'
+    - id: 'step-6'
+      name: 'Setup JBR 21 for Windows'
+      uses: 'gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d'
+      with:
+        java-version: '21'
+        distribution: 'jdkfile'
+        jdkFile: '${{ steps.step-5.outputs.jbrLocation }}'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-7'
+      name: 'Dump Local Properties'
+      run: 'echo "jvm.toolchain.version=21" >> local.properties'
+    - id: 'step-8'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-disabled: 'true'
+    - id: 'step-9'
+      name: 'Clean and download dependencies (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew --scan "--stacktrace" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-10'
+      name: 'Clean and download dependencies (Attempt #2)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew --scan "--stacktrace" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-9.outcome == ''failure'' }}'
+    - id: 'step-11'
+      name: 'Update dev version name (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew updateDevVersionNameFromGit "--no-configuration-cache" "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-12'
+      name: 'Update dev version name (Attempt #2)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew updateDevVersionNameFromGit "--no-configuration-cache" "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-11.outcome == ''failure'' }}'
+    - id: 'step-13'
+      name: 'Prepare google-services.json'
+      env:
+        BASE64_CONTENT: '${{ secrets.GOOGLE_SERVICES_JSON }}'
+        FILE_PATH: './app/android/google-services.json'
+      continue-on-error: true
+      shell: 'bash'
+      run: |-
+        set -euo pipefail
+
+        if [ -z "${BASE64_CONTENT:-}" ]; then
+          echo "BASE64_CONTENT is empty" >&2
+          exit 1
+        fi
+
+        mkdir -p "$(dirname "$FILE_PATH")"
+        if ! printf '%s' "$BASE64_CONTENT" | base64 --decode > "$FILE_PATH" 2>/dev/null; then
+          printf '%s' "$BASE64_CONTENT" | base64 -D > "$FILE_PATH"
+        fi
+        chmod 600 "$FILE_PATH"
+        echo "filePath=$FILE_PATH" >> "$GITHUB_OUTPUT"
+      if: '${{ (github.repository == ''open-ani/animeko'') && (!(github.event_name == ''pull_request'')) }}'
+    - id: 'step-14'
+      name: 'Compile Kotlin (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew compileKotlin compileCommonMainKotlinMetadata compileJvmMainKotlinMetadata compileKotlinDesktop compileKotlinMetadata "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-15'
+      name: 'Compile Kotlin (Attempt #2)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew compileKotlin compileCommonMainKotlinMetadata compileJvmMainKotlinMetadata compileKotlinDesktop compileKotlinMetadata "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-14.outcome == ''failure'' }}'
+    - id: 'step-16'
+      name: 'Compile Kotlin Android (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew compileDefaultDebugKotlin compileDefaultReleaseKotlin "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-17'
+      name: 'Compile Kotlin Android (Attempt #2)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew compileDefaultDebugKotlin compileDefaultReleaseKotlin "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-16.outcome == ''failure'' }}'
+    - id: 'step-18'
+      name: 'Prepare VLC runtime for Windows ARM64'
+      shell: 'powershell'
+      run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File ci-helper/vlc-woa64/prepare-vlc-windows-arm64.ps1 app/desktop/appResources/windows-arm64/lib'
+    - id: 'step-19'
+      name: 'Package Desktop (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-20'
+      name: 'Package Desktop (Attempt #2)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-19.outcome == ''failure'' }}'
+    - id: 'step-21'
+      name: 'Patch AndroidX SQLite bundled runtime for Windows ARM64'
+      shell: 'powershell'
+      run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File ci-helper/sqlite-woa64/patch-sqlite-bundled-windows-arm64.ps1 app/desktop/build/compose/binaries/main-release/app'
+    - id: 'step-22'
+      name: 'Upload compose logs'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'compose-logs-github-windows-11-arm64'
+        path: 'app/desktop/build/compose/logs'
+      if: '${{ always() }}'
+    - id: 'step-23'
+      name: 'Upload Windows packages (Attempt #1)'
+      continue-on-error: true
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: 'app/desktop/build/compose/binaries/main-release/app'
+        if-no-files-found: 'error'
+        overwrite: 'true'
+    - id: 'step-24'
+      name: 'Upload Windows packages (Attempt #2)'
+      continue-on-error: true
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: 'app/desktop/build/compose/binaries/main-release/app'
+        if-no-files-found: 'error'
+        overwrite: 'true'
+      if: '${{ steps.step-23.outcome == ''failure'' }}'
+    - id: 'step-25'
+      name: 'Upload Windows packages (Attempt #3)'
+      continue-on-error: false
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: 'app/desktop/build/compose/binaries/main-release/app'
+        if-no-files-found: 'error'
+        overwrite: 'true'
+      if: '${{ steps.step-24.outcome == ''failure'' }}'
+    - id: 'step-26'
+      name: 'Check (Desktop) (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew desktopTest -x :torrent:anitorrent:desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-27'
+      name: 'Check (Desktop) (Attempt #2)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew desktopTest -x :torrent:anitorrent:desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-26.outcome == ''failure'' }}'
+    - id: 'step-28'
+      name: 'Check (Desktop) (Attempt #3)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew desktopTest -x :torrent:anitorrent:desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-27.outcome == ''failure'' }}'
+    - id: 'step-29'
+      name: 'Check (Android Host) (Attempt #1)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew testAndroidHostTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+    - id: 'step-30'
+      name: 'Check (Android Host) (Attempt #2)'
+      continue-on-error: true
+      timeout-minutes: 180
+      run: './gradlew testAndroidHostTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-29.outcome == ''failure'' }}'
+    - id: 'step-31'
+      name: 'Check (Android Host) (Attempt #3)'
+      continue-on-error: false
+      timeout-minutes: 180
+      run: './gradlew testAndroidHostTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache"'
+      if: '${{ steps.step-30.outcome == ''failure'' }}'
   build_github-ubuntu-2404:
     name: 'Build (Ubuntu 24.04 x86_64 (GitHub))'
     runs-on:
@@ -1465,6 +1680,56 @@ jobs:
       shell: 'powershell'
       run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${{ github.workspace }}/ci-helper/verify/run-ani-test-windows-x64.ps1" "${{ github.workspace }}\ci-helper\verify" "sentry-dsn"'
       if: '${{ (github.repository == ''open-ani/animeko'') && (!(github.event_name == ''pull_request'')) }}'
+  verify_github-windows-11-arm64:
+    name: 'Verify (Windows 11 AArch64 (GitHub))'
+    runs-on:
+    - 'windows-11-arm'
+    permissions:
+      actions: 'read'
+    needs:
+    - 'build_github-windows-11-arm64'
+    if: '${{ needs.build_github-windows-11-arm64.result == ''success'' }}'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Download Windows AArch64 Portable (Attempt #1)'
+      continue-on-error: true
+      uses: 'actions/download-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: '${{ github.workspace }}/ci-helper/verify'
+    - id: 'step-2'
+      name: 'Download Windows AArch64 Portable (Attempt #2)'
+      continue-on-error: true
+      uses: 'actions/download-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: '${{ github.workspace }}/ci-helper/verify'
+      if: '${{ steps.step-1.outcome == ''failure'' }}'
+    - id: 'step-3'
+      name: 'Download Windows AArch64 Portable (Attempt #3)'
+      continue-on-error: false
+      uses: 'actions/download-artifact@v4'
+      with:
+        name: 'ani-windows-aarch64-portable'
+        path: '${{ github.workspace }}/ci-helper/verify'
+      if: '${{ steps.step-2.outcome == ''failure'' }}'
+    - id: 'step-4'
+      name: 'Check that MediaMP FFmpeg can run'
+      timeout-minutes: 5
+      shell: 'powershell'
+      run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${{ github.workspace }}/ci-helper/verify/run-ani-test-windows-x64.ps1" "${{ github.workspace }}\ci-helper\verify" "mediamp-ffmpeg-smoke-test"'
+    - id: 'step-5'
+      name: 'Check that MediaMP VLC can be loaded'
+      timeout-minutes: 5
+      shell: 'powershell'
+      run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${{ github.workspace }}/ci-helper/verify/run-ani-test-windows-x64.ps1" "${{ github.workspace }}\ci-helper\verify" "mediamp-vlc-load-test"'
+    - id: 'step-6'
+      name: 'Check that bundled SQLite can be loaded'
+      timeout-minutes: 5
+      shell: 'powershell'
+      run: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${{ github.workspace }}/ci-helper/verify/run-ani-test-windows-x64.ps1" "${{ github.workspace }}\ci-helper\verify" "sqlite-bundled-load-test"'
   verify_self-hosted-macos-15:
     name: 'Verify (macOS 15 AArch64 (Self-Hosted))'
     runs-on:

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -82,6 +82,7 @@ import io.github.typesafegithub.workflows.domain.Permission
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.Shell
 import io.github.typesafegithub.workflows.domain.actions.Action
+import io.github.typesafegithub.workflows.domain.actions.CustomAction
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.JobBuilder
@@ -231,7 +232,9 @@ data class MatrixInstance(
         add(quote("-Porg.gradle.daemon.idletimeout=60000"))
         add(quote("-Dfile.encoding=UTF-8"))
 
-        if (os == OS.WINDOWS) {
+        // These native build settings are for the x64-only anitorrent runtime;
+        // WOA64 disables anitorrent.
+        if (os == OS.WINDOWS && arch == Arch.X64) {
             add(quote("-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"))
             add(quote("-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include"))
         }
@@ -319,6 +322,14 @@ sealed class Runner(
         os = OS.WINDOWS,
         arch = Arch.X64,
         labels = setOf("windows-2022"),
+    )
+
+    object GithubWindows11Arm64 : GithubHosted(
+        id = "github-windows-11-arm64",
+        displayName = "Windows 11 AArch64 (GitHub)",
+        os = OS.WINDOWS,
+        arch = Arch.AARCH64,
+        labels = setOf("windows-11-arm"),
     )
 
     object GithubMacOS14 : GithubHosted(
@@ -418,6 +429,19 @@ run {
         gradleHeap = "4g",
         gradleParallel = true,
     )
+    val ghWinArm64 = MatrixInstance(
+        runner = Runner.GithubWindows11Arm64,
+        uploadApk = false,
+        composeResourceTriple = "windows-arm64",
+        uploadDesktopInstallers = true,
+        extraGradleArgs = listOf(
+            "-P$ANI_ANDROID_ABIS=arm64-v8a",
+            "--no-configuration-cache", // WOA64: Gradle fails storing KotlinCompile state on windows-11-arm.
+        ),
+        buildAllAndroidAbis = false,
+        gradleHeap = "4g",
+        gradleParallel = true,
+    )
     val ghUbuntu2404 = MatrixInstance(
         runner = Runner.GithubUbuntu2404,
         uploadApk = true,
@@ -486,6 +510,7 @@ run {
     buildMatrixInstances = listOf(
 //        selfWin10,
         ghWin,
+        ghWinArm64,
         ghUbuntu2404,
         ghMac15Intel,
         selfMac15.copy(
@@ -521,6 +546,7 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
         enableSwap()
         deleteLocalProperties()
         writeLocalProperties()
+        setupAndroidSdkForWindowsArm64()
         installJbr21()
         chmod777()
         setupGradle()
@@ -554,7 +580,10 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
 }
 
 object ArtifactNames {
-    fun windowsPortable() = "ani-windows-portable"
+    fun windowsPortable(arch: Arch) = when (arch) {
+        Arch.X64 -> "ani-windows-portable"
+        Arch.AARCH64 -> "ani-windows-aarch64-portable"
+    }
     fun macosDmg(arch: Arch) = "ani-macos-dmg-${arch}"
     fun macosPortable(arch: Arch) = "ani-macos-portable-${arch}"
     fun iosIpa() = "ani-ios-ipa"
@@ -571,8 +600,9 @@ fun getVerifyJobBody(
         // We must not destroy the self-hosted runner, 
         // but we are free to remove anything from the GitHub-hosted runners
 
-        when (runner.os) {
-            OS.MACOS -> {
+        when (runner.os to runner.arch) {
+            OS.MACOS to Arch.X64,
+            OS.MACOS to Arch.AARCH64 -> {
                 run(
                     name = "Delete libraries from system",
                     command = shell(
@@ -587,7 +617,7 @@ fun getVerifyJobBody(
                 )
             }
 
-            OS.WINDOWS -> {
+            OS.WINDOWS to Arch.X64 -> {
                 run(
                     name = "Delete libraries from system",
                     shell = Shell.PowerShell,
@@ -601,7 +631,7 @@ fun getVerifyJobBody(
                 )
             }
 
-            OS.UBUNTU -> {}
+            else -> {}
         }
     }
 
@@ -624,17 +654,36 @@ fun getVerifyJobBody(
         VerifyTask(
             name = "anitorrent-load-test",
             step = "Check that Anitorrent can be loaded",
-            disabledOn = listOf(Runner.GithubUbuntu2404),
+            disabledOn = listOf(Runner.GithubUbuntu2404, Runner.GithubWindows11Arm64),
+        ),
+        // Windows ARM64 FFmpeg and VLC use new packaging paths. Startup only logs native load failures,
+        // so the packaged application must verify them explicitly.
+        VerifyTask(
+            name = "mediamp-ffmpeg-smoke-test",
+            step = "Check that MediaMP FFmpeg can run",
+            enabledOnlyOn = listOf(Runner.GithubWindows11Arm64),
+        ),
+        VerifyTask(
+            name = "mediamp-vlc-load-test",
+            step = "Check that MediaMP VLC can be loaded",
+            enabledOnlyOn = listOf(Runner.GithubWindows11Arm64),
         ),
         VerifyTask(
             name = "dandanplay-app-id",
             step = "Check that Dandanplay APP ID is valid",
             `if` = expr { github.isAnimekoRepository and !github.isPullRequest },
+            disabledOn = listOf(Runner.GithubWindows11Arm64),
         ),
         VerifyTask(
             name = "sentry-dsn",
             step = "Check that sentryDsn is valid",
             `if` = expr { github.isAnimekoRepository and !github.isPullRequest },
+            disabledOn = listOf(Runner.GithubWindows11Arm64),
+        ),
+        VerifyTask(
+            name = "sqlite-bundled-load-test",
+            step = "Check that bundled SQLite can be loaded",
+            enabledOnlyOn = listOf(Runner.GithubWindows11Arm64),
         ),
     ).filter { task ->
         // Filter task that should execute on this runner.
@@ -652,11 +701,12 @@ fun getVerifyJobBody(
     }
 
     when (runner.os to runner.arch) {
-        OS.WINDOWS to Arch.X64 -> {
+        OS.WINDOWS to Arch.X64,
+        OS.WINDOWS to Arch.AARCH64 -> {
             usesWithAttempts(
-                name = "Download Windows x64 Portable",
+                name = "Download Windows ${if (runner.arch == Arch.X64) "x64" else "AArch64"} Portable",
                 action = DownloadArtifact(
-                    name = ArtifactNames.windowsPortable(),
+                    name = ArtifactNames.windowsPortable(runner.arch),
                     path = "${expr { github.workspace }}/ci-helper/verify",
                 ),
             )
@@ -819,12 +869,17 @@ workflow(
 
     builds.filter { (matrix, _) ->
         matrix.runner.os == OS.WINDOWS && matrix.uploadDesktopInstallers
-    }.forEach { (_, build) ->
-        listOf(
-            Runner.GithubWindowsServer2025,
-            Runner.GithubWindowsServer2022,
-//            Runner.SelfHostedWindows10,
-        ).forEach { runner ->
+    }.forEach { (matrix, build) ->
+        val verifyRunners = when (matrix.arch) {
+            Arch.X64 -> listOf(
+                Runner.GithubWindowsServer2025,
+                Runner.GithubWindowsServer2022,
+//                Runner.SelfHostedWindows10,
+            )
+
+            Arch.AARCH64 -> listOf(Runner.GithubWindows11Arm64)
+        }
+        verifyRunners.forEach { runner ->
             addVerifyJob(build, runner, build.result.eq(AbstractResult.Status.Success))
         }
     }
@@ -1211,6 +1266,25 @@ class WithMatrix(
         }
     }
 
+    fun JobBuilder<*>.setupAndroidSdkForWindowsArm64() {
+        if (matrix.isWindowsAArch64) {
+            // Unlike the x64 Windows images, windows-11-arm does not provide the Android SDK
+            // used by the shared build.
+            uses(
+                name = "Setup Android SDK",
+                action = CustomAction(
+                    actionOwner = "android-actions",
+                    actionName = "setup-android",
+                    actionVersion = "v3",
+                    inputs = mapOf(
+                        "accept-android-sdk-licenses" to "true",
+                        "packages" to "platform-tools platforms;android-36 build-tools;36.0.0",
+                    ),
+                ),
+            )
+        }
+    }
+
     fun JobBuilder<*>.installJbr21() {
         // For mac
         fun downloadJbrUnix(
@@ -1317,7 +1391,12 @@ class WithMatrix(
             }
 
             OS.WINDOWS -> {
-                val jbrLocationExpr = downloadJbrUsingPython("jbrsdk_jcef-21.0.5-windows-x64-b750.29.tar.gz")
+                val jbrLocationExpr = if (matrix.arch == Arch.AARCH64) {
+                    // WoA-only: Windows ARM64 needs a JBR/JCEF build matching the process architecture.
+                    downloadJbrUsingPython("jbrsdk_jcef-21.0.10-windows-aarch64-b1163.110.tar.gz")
+                } else {
+                    downloadJbrUsingPython("jbrsdk_jcef-21.0.5-windows-x64-b750.29.tar.gz")
+                }
                 uses(
                     name = "Setup JBR 21 for Windows",
                     action = SetupJava_Untyped(
@@ -1638,7 +1717,12 @@ class WithMatrix(
         if (matrix.runTests) {
             runGradle(
                 name = "Check (Desktop)",
-                tasks = arrayOf("desktopTest"),
+                // There is no Windows ARM64 anitorrent runtime, so its native desktop tests cannot run here.
+                tasks = if (matrix.isWindowsAArch64) {
+                    arrayOf("desktopTest", "-x", ":torrent:anitorrent:desktopTest")
+                } else {
+                    arrayOf("desktopTest")
+                },
                 maxAttempts = 3,
                 timeoutMinutes = 180,
             )
@@ -1717,7 +1801,40 @@ class WithMatrix(
     class PackageDesktopAndUploadOutputs {
     }
 
+    fun JobBuilder<*>.patchBundledSqliteForWindowsArm64() {
+        if (matrix.isWindowsAArch64) {
+            // AndroidX does not yet publish the bundled SQLite native library for Windows ARM64.
+            run(
+                name = "Patch AndroidX SQLite bundled runtime for Windows ARM64",
+                shell = Shell.PowerShell,
+                command = shell(
+                    """
+                    powershell.exe -NoProfile -ExecutionPolicy Bypass -File ci-helper/sqlite-woa64/patch-sqlite-bundled-windows-arm64.ps1 app/desktop/build/compose/binaries/main-release/app
+                    """.trimIndent(),
+                ),
+            )
+        }
+    }
+
+    fun JobBuilder<*>.prepareVlcForWindowsArm64() {
+        if (matrix.isWindowsAArch64) {
+            // The vendored VLC 3.0.20 resources are x64-only;
+            // inject VideoLAN's ARM64 runtime before packaging.
+            run(
+                name = "Prepare VLC runtime for Windows ARM64",
+                shell = Shell.PowerShell,
+                command = shell(
+                    """
+                    powershell.exe -NoProfile -ExecutionPolicy Bypass -File ci-helper/vlc-woa64/prepare-vlc-windows-arm64.ps1 app/desktop/appResources/windows-arm64/lib
+                    """.trimIndent(),
+                ),
+            )
+        }
+    }
+
     fun JobBuilder<*>.packageDesktopAndUpload(): PackageDesktopAndUploadOutputs {
+        prepareVlcForWindowsArm64()
+
         if (matrix.isWindows) {
             // Windows does not support installers
             runGradle(
@@ -1749,6 +1866,7 @@ class WithMatrix(
             )
         }
 
+        patchBundledSqliteForWindowsArm64()
         uploadComposeLogs()
 
         return PackageDesktopAndUploadOutputs().also {
@@ -1780,7 +1898,7 @@ class WithMatrix(
                 usesWithAttempts(
                     name = "Upload Windows packages",
                     action = UploadArtifact(
-                        name = ArtifactNames.windowsPortable(),
+                        name = ArtifactNames.windowsPortable(matrix.arch),
                         path_Untyped = "app/desktop/build/compose/binaries/main-release/app",
                         overwrite = true,
                         ifNoFilesFound = UploadArtifact.BehaviorIfNoFilesFound.Error,
@@ -2064,6 +2182,7 @@ val MatrixInstance.isUnix get() = (os == OS.UBUNTU) or (os == (OS.MACOS))
 
 val MatrixInstance.isMacOSAArch64 get() = (os == OS.MACOS) and (arch == Arch.AARCH64)
 val MatrixInstance.isMacOSX64 get() = (os == OS.MACOS) and (arch == Arch.X64)
+val MatrixInstance.isWindowsAArch64 get() = (os == OS.WINDOWS) and (arch == Arch.AARCH64)
 
 // only for highlighting (though this does not work in KT 2.1.0)
 fun shell(@Language("shell") command: String) = command

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ kls_database.db
 /torrent/anitorrent/*.dylib
 /torrent/anitorrent/*.dll
 /torrent/anitorrent/*.so
+/app/desktop/appResources/windows-arm64/lib/
 /app/ios/Animeko/GoogleService-Info.plist
 /app/ios/12.4.0
 /app/ios/xcb2.log

--- a/app/desktop/appResources/README.md
+++ b/app/desktop/appResources/README.md
@@ -8,3 +8,5 @@ See <https://github.com/JetBrains/compose-multiplatform/blob/master/tutorials/Na
 
 - macos-x64: 3.0.18
 - linux-x64: 3.0.20
+- windows-x64: 3.0.20
+- windows-arm64: 3.0.23 (3.0.20 is unavailable for winarm64)

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
         "linux-x64" -> runtimeOnly(libs.mediamp.ffmpeg.runtime.linux.x64)
         "macos-x64" -> runtimeOnly(libs.mediamp.ffmpeg.runtime.macos.x64)
         "macos-arm64" -> runtimeOnly(libs.mediamp.ffmpeg.runtime.macos.arm64)
+        "windows-arm64" -> runtimeOnly(libs.mediamp.ffmpeg.runtime.windows.arm64)
         else -> throw UnsupportedOperationException("Unknown os: $triple")
     }
 

--- a/app/desktop/src/main/kotlin/DesktopModules.kt
+++ b/app/desktop/src/main/kotlin/DesktopModules.kt
@@ -41,6 +41,7 @@ import me.him188.ani.app.domain.media.resolver.TorrentMediaResolver
 import me.him188.ani.app.domain.mediasource.web.DesktopWebCaptchaCoordinator
 import me.him188.ani.app.domain.mediasource.web.WebCaptchaCoordinator
 import me.him188.ani.app.domain.torrent.DefaultTorrentManager
+import me.him188.ani.app.domain.torrent.TorrentEngine
 import me.him188.ani.app.domain.torrent.TorrentManager
 import me.him188.ani.app.navigation.BrowserNavigator
 import me.him188.ani.app.navigation.DesktopBrowserNavigator
@@ -62,6 +63,8 @@ import me.him188.ani.utils.io.inSystem
 import me.him188.ani.utils.io.toKtPath
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.platform.Arch
+import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatformDesktop
 import org.koin.dsl.module
 import org.openani.mediamp.MediampPlayerFactory
@@ -73,6 +76,11 @@ import org.openani.mediamp.vlc.VlcMediampPlayerFactory
 import org.openani.mediamp.vlc.compose.VlcMediampPlayerSurfaceProvider
 import java.io.File
 import kotlin.io.path.Path
+
+internal fun isWindowsArm64(): Boolean {
+    val platform = currentPlatformDesktop()
+    return platform is Platform.Windows && platform.arch == Arch.AARCH64
+}
 
 fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) = module {
     single<TorrentEngineAccess> { AlwaysUseTorrentEngineAccess }
@@ -106,6 +114,14 @@ fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) =
     }
 
     single<TorrentManager> {
+        if (isWindowsArm64()) {
+            // No Windows ARM64 anitorrent runtime is published; match iOS by exposing no local torrent engine.
+            logger<TorrentManager>().info { "Anitorrent is disabled on Windows ARM64" }
+            return@single object : TorrentManager {
+                override val engines: List<TorrentEngine> = emptyList()
+            }
+        }
+
         val saveDir = get<MediaSaveDirProvider>().saveDir
         logger<TorrentManager>().info { "TorrentManager base save dir: $saveDir" }
 

--- a/app/desktop/src/main/kotlin/MediampPlatform.kt
+++ b/app/desktop/src/main/kotlin/MediampPlatform.kt
@@ -9,8 +9,8 @@
 
 package me.him188.ani.app.desktop
 
+import me.him188.ani.utils.platform.Arch
 import me.him188.ani.utils.platform.Platform
-import me.him188.ani.utils.platform.is64bit
 import me.him188.ani.utils.platform.isAArch
 import me.him188.ani.utils.platform.isMacOS
 import me.him188.ani.utils.platform.isWindows
@@ -23,4 +23,4 @@ import me.him188.ani.utils.platform.isWindows
  * `app/desktop/build.gradle.kts` 中按平台选择的 native runtime 依赖保持一致.
  */
 internal fun Platform.Desktop.usesMpv(): Boolean =
-    (isWindows() && is64bit()) || (isMacOS() && isAArch())
+    (isWindows() && arch == Arch.X86_64) || (isMacOS() && isAArch())

--- a/app/desktop/src/main/kotlin/TestTasks.kt
+++ b/app/desktop/src/main/kotlin/TestTasks.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.desktop
 
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.domain.foundation.HttpClientProvider
 import me.him188.ani.app.domain.foundation.ScopedHttpClientUserAgent
@@ -28,6 +29,8 @@ import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatformDesktop
 import org.koin.core.context.GlobalContext
 import org.koin.mp.KoinPlatform
+import org.openani.mediamp.ffmpeg.FFmpegKit
+import org.openani.mediamp.vlc.VlcMediampPlayer
 import java.io.File
 import kotlin.system.exitProcess
 
@@ -40,6 +43,21 @@ object TestTasks {
         when (taskName) {
             "anitorrent-load-test" -> {
                 AnitorrentLibraryLoader.loadLibraries()
+                exitProcess(0)
+            }
+
+            "mediamp-ffmpeg-smoke-test" -> {
+                checkMediampFfmpeg()
+                exitProcess(0)
+            }
+
+            "mediamp-vlc-load-test" -> {
+                VlcMediampPlayer.prepareLibraries()
+                exitProcess(0)
+            }
+
+            "sqlite-bundled-load-test" -> {
+                checkBundledSqlite()
                 exitProcess(0)
             }
 
@@ -72,6 +90,20 @@ object TestTasks {
                 exitProcess(1)
             }
         }
+    }
+
+    private fun checkMediampFfmpeg() {
+        val runtimeDirectory = File(System.getProperty("compose.application.resources.dir"))
+            .parentFile.absolutePath
+        FFmpegKit.setRuntimeLibraryDirectory(runtimeDirectory, false)
+        val result = runBlocking {
+            FFmpegKit().execute(listOf("-version"))
+        }
+        check(result.isSuccess) { "FFmpeg smoke test failed: $result" }
+    }
+
+    private fun checkBundledSqlite() {
+        BundledSQLiteDriver().open(":memory:").use { }
     }
 
     // https://d.myani.org/v4.0.0-release-checksum-1/ani-4.0.0-release-checksum-1-macos-aarch64.dmg

--- a/buildSrc/src/main/kotlin/os.kt
+++ b/buildSrc/src/main/kotlin/os.kt
@@ -43,7 +43,7 @@ fun getArch(): Arch {
 
 fun getOsTriple(): String {
     return when (getOs()) {
-        Os.Windows -> "windows-x64"
+        Os.Windows -> if (getArch() == Arch.AARCH64) "windows-arm64" else "windows-x64"
         Os.MacOS -> if (getArch() == Arch.AARCH64) "macos-arm64" else "macos-x64"
         Os.Linux -> "linux-x64"
         Os.Unknown -> throw UnsupportedOperationException("Unknown OS")

--- a/ci-helper/sqlite-woa64/patch-sqlite-bundled-windows-arm64.ps1
+++ b/ci-helper/sqlite-woa64/patch-sqlite-bundled-windows-arm64.ps1
@@ -1,0 +1,187 @@
+<#
+  Copyright (C) 2024-2026 OpenAni and contributors.
+
+  此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+  Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+
+  https://github.com/open-ani/ani/blob/main/LICENSE
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageDirectory
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Script,
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+        [int]$Attempts = 5
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            return & $Script
+        }
+        catch {
+            if ($attempt -eq $Attempts) {
+                throw "Failed to $Description after $Attempts attempts. Last error: $($_.Exception.Message)"
+            }
+
+            $delaySeconds = [int][Math]::Min(60, [Math]::Pow(2, $attempt) * 5)
+            Write-Warning "$Description failed on attempt $attempt/$Attempts. Retrying in $delaySeconds seconds. $($_.Exception.Message)"
+            Start-Sleep -Seconds $delaySeconds
+        }
+    }
+}
+
+function Assert-Sha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Expected
+    )
+
+    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash
+    if ($actual -ne $Expected) {
+        throw "SHA256 mismatch for $Path. Expected $Expected, got $actual."
+    }
+}
+
+$sqliteJars = @(Get-ChildItem -LiteralPath $PackageDirectory -Recurse -Filter "sqlite-bundled-jvm-*.jar")
+if ($sqliteJars.Count -ne 1) {
+    throw "Expected exactly one sqlite-bundled-jvm jar under $PackageDirectory, found $($sqliteJars.Count)."
+}
+$sqliteJar = $sqliteJars[0]
+
+$outputDir = "build/sqlite-woa64"
+$workDir = Join-Path $outputDir "work"
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+
+$sqliteVersion = "3.50.1"
+$sqliteZipVersion = "3500100"
+$sqliteYear = "2025"
+$sqliteZipHash = "41716B44AC8777188C4C3F1F370F01C9CB9E3B6428EB5C981D086C35DE2D9D3F"
+$sqliteZip = Join-Path $workDir "sqlite-amalgamation-$sqliteZipVersion.zip"
+$sqliteDir = Join-Path $workDir "sqlite-amalgamation-$sqliteZipVersion"
+$sqliteC = Join-Path $sqliteDir "sqlite3.c"
+
+$androidxSqlite262Commit = "fe30df161d480829efb21f37ff67a9f8cac9c620"
+$androidxBindingHash = "F9F4747111A6635DFFD5991126247CA0F2F6C851DE1EAF4ADD3866A0518AC2E0"
+$binding = Join-Path $workDir "sqlite_bindings.cpp"
+
+# AndroidX sqlite-bundled-jvm currently publishes Windows x64, Linux, and macOS
+# native binaries, but not Windows ARM64. Remove this workaround once AndroidX
+# ships natives/windows_arm64/sqliteJni.dll in sqlite-bundled-jvm.
+if (!(Test-Path $sqliteZip)) {
+    Invoke-WithRetry `
+        -Description "download SQLite amalgamation" `
+        -Script {
+            Invoke-WebRequest `
+                -UseBasicParsing `
+                -Uri "https://www.sqlite.org/$sqliteYear/sqlite-amalgamation-$sqliteZipVersion.zip" `
+                -OutFile $sqliteZip
+        }
+}
+Assert-Sha256 -Path $sqliteZip -Expected $sqliteZipHash
+
+if (!(Test-Path $sqliteC)) {
+    Expand-Archive -Path $sqliteZip -DestinationPath $workDir -Force
+}
+
+$sqliteHeader = Get-Content (Join-Path $sqliteDir "sqlite3.h") -Raw
+if ($sqliteHeader -notmatch "#define\s+SQLITE_VERSION\s+`"$([regex]::Escape($sqliteVersion))`"") {
+    throw "Downloaded SQLite amalgamation does not match $sqliteVersion."
+}
+
+if (!(Test-Path $binding)) {
+    $encodedBinding = Invoke-WithRetry `
+        -Description "download AndroidX SQLite JNI binding" `
+        -Script {
+            (Invoke-WebRequest `
+                    -UseBasicParsing `
+                    -Uri "https://android.googlesource.com/platform/frameworks/support/+/$androidxSqlite262Commit/sqlite/sqlite-bundled/src/jvmAndroidMain/jni/sqlite_bindings.cpp?format=TEXT").Content.Trim()
+        }
+    [System.IO.File]::WriteAllBytes($binding, [System.Convert]::FromBase64String($encodedBinding))
+}
+Assert-Sha256 -Path $binding -Expected $androidxBindingHash
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+if ([string]::IsNullOrWhiteSpace($vsInstall)) {
+    throw "Visual Studio ARM64 C++ tools were not found."
+}
+
+$vcvars = Join-Path $vsInstall "VC\Auxiliary\Build\vcvarsall.bat"
+$javaInclude = Join-Path $env:JAVA_HOME "include"
+$javaWinInclude = Join-Path $javaInclude "win32"
+$sqliteObj = Join-Path $outputDir "sqlite3.obj"
+$bindingObj = Join-Path $outputDir "sqlite_bindings.obj"
+$sqliteDll = Join-Path $outputDir "sqliteJni.dll"
+
+$sqliteDefines = @(
+    "/DHAVE_USLEEP=1",
+    "/DSQLITE_DEFAULT_AUTOVACUUM=1",
+    "/DSQLITE_DEFAULT_MEMSTATUS=0",
+    "/DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1",
+    "/DSQLITE_ENABLE_COLUMN_METADATA",
+    "/DSQLITE_ENABLE_FTS3",
+    "/DSQLITE_ENABLE_FTS3_PARENTHESIS",
+    "/DSQLITE_ENABLE_FTS4",
+    "/DSQLITE_ENABLE_FTS5",
+    "/DSQLITE_ENABLE_JSON1",
+    "/DSQLITE_ENABLE_MATH_FUNCTIONS",
+    "/DSQLITE_ENABLE_NORMALIZE",
+    "/DSQLITE_ENABLE_RTREE",
+    "/DSQLITE_ENABLE_STAT4",
+    "/DSQLITE_HAVE_ISNAN",
+    "/DSQLITE_OMIT_BUILTIN_TEST",
+    "/DSQLITE_OMIT_DEPRECATED",
+    "/DSQLITE_OMIT_PROGRESS_CALLBACK",
+    "/DSQLITE_OMIT_SHARED_CACHE",
+    "/DSQLITE_SECURE_DELETE",
+    "/DSQLITE_TEMP_STORE=3",
+    "/DSQLITE_THREADSAFE=2"
+) -join " "
+
+$compile = @(
+    "`"$vcvars`" arm64",
+    "cl /nologo /O2 /MT /utf-8 $sqliteDefines /I`"$sqliteDir`" /Fo`"$sqliteObj`" /c `"$sqliteC`"",
+    "cl /nologo /O2 /MT /EHsc /std:c++17 /utf-8 $sqliteDefines /I`"$sqliteDir`" /I`"$javaInclude`" /I`"$javaWinInclude`" /Fo`"$bindingObj`" /c `"$binding`"",
+    "link /nologo /DLL /OUT:`"$sqliteDll`" /IMPLIB:`"$outputDir\sqliteJni.lib`" `"$sqliteObj`" `"$bindingObj`""
+) -join " && "
+
+cmd.exe /d /s /c $compile
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to build Windows ARM64 AndroidX SQLite JNI runtime."
+}
+
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$entryName = "natives/windows_arm64/sqliteJni.dll"
+$zip = [System.IO.Compression.ZipFile]::Open($sqliteJar.FullName, [System.IO.Compression.ZipArchiveMode]::Update)
+try {
+    $existing = $zip.GetEntry($entryName)
+    if ($null -ne $existing) {
+        $existing.Delete()
+    }
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+        $zip,
+        (Resolve-Path -LiteralPath $sqliteDll).Path,
+        $entryName,
+        [System.IO.Compression.CompressionLevel]::Optimal
+    ) | Out-Null
+}
+finally {
+    $zip.Dispose()
+}
+
+Write-Host "Patched $($sqliteJar.FullName) with $entryName"

--- a/ci-helper/vlc-woa64/prepare-vlc-windows-arm64.ps1
+++ b/ci-helper/vlc-woa64/prepare-vlc-windows-arm64.ps1
@@ -1,0 +1,46 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory,
+    [string]$CacheDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) "ani-vlc-windows-arm64")
+)
+
+$ErrorActionPreference = "Stop"
+
+# VideoLAN did not publish a Windows ARM64 build for VLC 3.0.20, which is the
+# version currently vendored for windows-x64 app resources. Use the first
+# official 3.0.x Windows ARM64 runtime that is available instead.
+$version = "3.0.23"
+$url = "https://download.videolan.org/pub/videolan/vlc/$version/winarm64/vlc-$version-winarm64.zip"
+$expectedSha256 = "9c0917dc521ffc8ce30e70bca7f6c9dc8fec80909d763e75cd976351dee8db0b"
+
+$outputPath = [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $OutputDirectory))
+if ($outputPath -notmatch "[\\/]appResources[\\/]windows-arm64[\\/]lib$") {
+    throw "Refusing to replace unexpected VLC output directory: $outputPath"
+}
+
+$archive = Join-Path $CacheDirectory "vlc-$version-winarm64.zip"
+$extractDir = Join-Path $CacheDirectory "extract"
+$vlcRoot = Join-Path $extractDir "vlc-$version"
+
+New-Item -ItemType Directory -Force -Path $CacheDirectory | Out-Null
+if (!(Test-Path -LiteralPath $archive)) {
+    Invoke-WebRequest -Uri $url -OutFile $archive
+}
+
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $expectedSha256) {
+    throw "Unexpected VLC archive SHA256: $actualSha256"
+}
+
+Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive -LiteralPath $archive -DestinationPath $extractDir -Force
+
+foreach ($required in @("libvlc.dll", "libvlccore.dll", "plugins")) {
+    if (!(Test-Path -LiteralPath (Join-Path $vlcRoot $required))) {
+        throw "VLC archive is missing $required"
+    }
+}
+
+Remove-Item -LiteralPath $outputPath -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $outputPath | Out-Null
+Copy-Item -Path (Join-Path $vlcRoot "*") -Destination $outputPath -Recurse -Force

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -277,6 +277,7 @@ mediamp-exoplayer = { module = "org.openani.mediamp:mediamp-exoplayer", version.
 mediamp-ffmpeg = { module = "org.openani.mediamp:mediamp-ffmpeg", version.ref = "mediamp" }
 mediamp-ffmpeg-desktop = { module = "org.openani.mediamp:mediamp-ffmpeg-desktop", version.ref = "mediamp" }
 mediamp-ffmpeg-runtime-windows-x64 = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-windows-x64", version.ref = "mediamp" }
+mediamp-ffmpeg-runtime-windows-arm64 = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-windows-arm64", version.ref = "mediamp" }
 mediamp-ffmpeg-runtime-linux-x64 = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-linux-x64", version.ref = "mediamp" }
 mediamp-ffmpeg-runtime-macos-x64 = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-macos-x64", version.ref = "mediamp" }
 mediamp-ffmpeg-runtime-macos-arm64 = { module = "org.openani.mediamp:mediamp-ffmpeg-runtime-macos-arm64", version.ref = "mediamp" }

--- a/torrent/anitorrent/build.gradle.kts
+++ b/torrent/anitorrent/build.gradle.kts
@@ -56,7 +56,8 @@ fun getAnitorrentTriple(): String? {
         Os.Windows -> {
             when (getArch()) {
                 Arch.X86_64 -> "windows-x64"
-                else -> error("Unsupported architecture: ${getArch()}")
+                // Windows ARM64 builds intentionally ship without the local BT engine.
+                Arch.AARCH64 -> null
             }
         }
 

--- a/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
+++ b/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.torrent.anitorrent
 import me.him188.ani.app.torrent.api.TorrentLibraryLoader
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.platform.Arch
 import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatform
 import me.him188.ani.utils.platform.isAndroid
@@ -144,6 +145,8 @@ object AnitorrentLibraryLoader : TorrentLibraryLoader {
     @Synchronized
     @Throws(UnsatisfiedLinkError::class)
     override fun loadLibraries() = synchronized(this) {
+        // Windows ARM64 intentionally ships without the local anitorrent runtime.
+        if (platform is Platform.Windows && platform.arch == Arch.AARCH64) return@synchronized
         if (libraryLoaded) return@synchronized
 
         try {

--- a/utils/http-downloader/build.gradle.kts
+++ b/utils/http-downloader/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
         "linux-x64" -> desktopTestRuntimeOnly(libs.mediamp.ffmpeg.runtime.linux.x64)
         "macos-x64" -> desktopTestRuntimeOnly(libs.mediamp.ffmpeg.runtime.macos.x64)
         "macos-arm64" -> desktopTestRuntimeOnly(libs.mediamp.ffmpeg.runtime.macos.arm64)
+        "windows-arm64" -> desktopTestRuntimeOnly(libs.mediamp.ffmpeg.runtime.windows.arm64)
         else -> throw UnsupportedOperationException("Unknown os: $triple")
     }
 


### PR DESCRIPTION
## 概要

为桌面端增加 Windows ARM64 构建、打包和产物验证。GitHub Actions 使用 `windows-11-arm` runner 构建，并发布 `ani-windows-aarch64-portable` 产物。

Windows x64 的构建路径、native runtime、JBR 版本、播放器选择和产物名称保持不变。

## 运行时适配

### MediaMP

Windows ARM64 使用项目现有 MediaMP 0.1.16 发布的 `mediamp-ffmpeg-runtime-windows-arm64`。

MediaMP 仍使用项目统一的版本定义。本 PR 只增加 Windows ARM64 FFmpeg runtime 条目，不调整 MediaMP 版本，也不改变其他平台解析的组件。

Windows ARM64 使用 VLC 播放后端，不加载仅适用于 Windows x64 的 MPV runtime。现有 Windows x64 和 macOS ARM64 MPV 路径保持不变。

### VLC

项目现有的 VLC 3.0.20 Windows runtime 仅支持 x64，VideoLAN 没有发布该版本的 Windows ARM64 包。

Windows ARM64 CI 因此下载并打包 VLC 3.0.23 ARM64 runtime。下载地址、版本和 SHA-256 均固定，并检查必要的 DLL 和插件目录。Windows x64 继续使用现有的 VLC 3.0.20。

### SQLite

AndroidX 尚未提供 Windows ARM64 的 bundled SQLite JNI runtime。

Windows ARM64 CI 会下载固定版本的 SQLite amalgamation 和 AndroidX SQLite JNI 源码，校验 SHA-256 后构建 `sqliteJni.dll`，再将其注入桌面应用使用的 bundled SQLite runtime。该处理仅在 Windows ARM64 构建中启用。

### AniTorrent

AniTorrent 暂未提供 Windows ARM64 native runtime，因此本 PR 暂时在 WoA 路径禁用 AniTorrent：

- Windows ARM64 不解析或打包 AniTorrent native runtime。
- Windows ARM64 使用空的 `TorrentManager`。
- Windows ARM64 CI 跳过依赖 AniTorrent native runtime 的 desktop test。

其他平台的 AniTorrent 构建和运行行为保持不变。

## CI

新增 Windows ARM64 构建矩阵和 `windows-11-arm` runner 配置，并处理该 runner 与现有 Windows x64 runner 的差异：

- 安装 Android SDK。当前 Windows ARM64 runner 镜像未预装项目构建所需的 Android SDK。
- 使用 Windows ARM64 JBR/JCEF。
- 禁用 Gradle configuration cache。当前 runner 无法保存 Kotlin compile task state。
- 准备 VLC 3.0.23 ARM64 runtime。
- 构建并注入 AndroidX SQLite ARM64 JNI runtime。
- 生成 `ani-windows-aarch64-portable` 产物。

打包完成后，CI 会在产物中实际验证：

- MediaMP FFmpeg runtime 可以执行。
- MediaMP VLC runtime 可以加载。
- bundled SQLite 数据库可以打开。

这些检查用于发现 native runtime 缺失、架构不匹配和打包路径错误。现有 Windows x64 验证逻辑保持不变。

## 验证

- 从 `.github/workflows/src.main.kts` 重新生成 `.github/workflows/build.yml`。
- 解析生成的 GitHub Actions workflow YAML。
- 运行 `:app:desktop:compileKotlin`。
- 运行 `:app:desktop:createReleaseDistributable`。
- 确认 Windows ARM64 可以解析 MediaMP 0.1.16 FFmpeg runtime。
- 启动 Windows ARM64 portable 产物并验证视频播放。
- 确认 FFmpeg、VLC 和 SQLite 未出现 native runtime 加载错误。
- 确认 Windows ARM64 不再尝试加载 MPV runtime。
- 运行 `git diff --check`。

## 已知限制

Windows ARM64 暂不支持 AniTorrent。待 AniTorrent 发布对应的 native runtime 后，可恢复该平台的 Torrent 功能。

Closes [#2366
](https://github.com/open-ani/animeko/issues/2366)