### PR TITLE
feat(player): support video screenshots on Android

### DIFF
--- a/app/android/src/main/AndroidManifest.xml
+++ b/app/android/src/main/AndroidManifest.xml
@@ -21,8 +21,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"-->
-    <!--            tools:ignore="ScopedStorage" />-->
+    <uses-permission
+            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+            android:maxSdkVersion="28"
+            tools:ignore="ScopedStorage" />
 
     <application
             android:name="AniApplication"

--- a/app/shared/app-platform/src/commonMain/kotlin/platform/PermissionManager.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/platform/PermissionManager.kt
@@ -23,6 +23,11 @@ interface PermissionManager {
     suspend fun requestNotificationPermission(context: ContextMP): Boolean
 
     /**
+     * Android 9 及以下请求写入公共外部存储空间的权限。
+     */
+    suspend fun requestWriteExternalStoragePermission(context: ContextMP): Boolean
+
+    /**
      * 打开系统设置手动授权通知权限
      */
     fun openSystemNotificationSettings(context: ContextMP)
@@ -39,6 +44,10 @@ object GrantedPermissionManager : PermissionManager {
     }
     
     override suspend fun requestNotificationPermission(context: ContextMP): Boolean {
+        return true
+    }
+
+    override suspend fun requestWriteExternalStoragePermission(context: ContextMP): Boolean {
         return true
     }
 

--- a/app/shared/application/src/androidMain/kotlin/platform/AndroidPermissionManager.kt
+++ b/app/shared/application/src/androidMain/kotlin/platform/AndroidPermissionManager.kt
@@ -41,6 +41,18 @@ class AndroidPermissionManager : PermissionManager {
         return activity.requestPermission(Manifest.permission.POST_NOTIFICATIONS)
     }
 
+    override suspend fun requestWriteExternalStoragePermission(context: ContextMP): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) return true
+        val activity = context.findActivity() as? BaseComponentActivity ?: return false
+        if (
+            ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return true
+        }
+        return activity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    }
+
     override fun openSystemNotificationSettings(context: ContextMP) {
         val openSystemNotificationIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/PlayerScreenshot.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/PlayerScreenshot.android.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.episode
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import android.view.PixelCopy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.him188.ani.app.platform.Context
+import me.him188.ani.app.platform.PermissionManager
+import me.him188.ani.app.videoplayer.ui.findAndroidVideoSurface
+import org.koin.mp.KoinPlatform
+import org.openani.mediamp.MediampPlayer
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal actual suspend fun takeAndroidPlayerScreenshot(
+    context: Context,
+    player: MediampPlayer,
+    filename: String,
+): Boolean {
+    if (
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.Q &&
+        !KoinPlatform.getKoin().get<PermissionManager>().requestWriteExternalStoragePermission(context)
+    ) {
+        return false
+    }
+    val bitmap = capturePlayerSurface(player) ?: return false
+    return try {
+        savePlayerScreenshot(context, filename, bitmap)
+    } finally {
+        bitmap.recycle()
+    }
+}
+
+private suspend fun capturePlayerSurface(player: MediampPlayer): Bitmap? = withContext(Dispatchers.Main.immediate) {
+    val surfaceView = player.findAndroidVideoSurface() ?: return@withContext null
+    if (!surfaceView.holder.surface.isValid || surfaceView.width <= 0 || surfaceView.height <= 0) {
+        return@withContext null
+    }
+
+    val bitmap = Bitmap.createBitmap(surfaceView.width, surfaceView.height, Bitmap.Config.ARGB_8888)
+    val result = suspendCoroutine { continuation ->
+        PixelCopy.request(
+            surfaceView,
+            bitmap,
+            { copyResult -> continuation.resume(copyResult) },
+            Handler(Looper.getMainLooper()),
+        )
+    }
+    if (result == PixelCopy.SUCCESS) {
+        bitmap
+    } else {
+        bitmap.recycle()
+        null
+    }
+}
+
+private suspend fun savePlayerScreenshot(
+    context: Context,
+    filename: String,
+    bitmap: Bitmap,
+): Boolean = withContext(Dispatchers.IO) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        @Suppress("DEPRECATION")
+        val directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+            .resolve("Animeko")
+        if (!directory.exists() && !directory.mkdirs()) return@withContext false
+
+        val file = directory.resolve(filename)
+        val saved = file.outputStream().buffered().use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
+        if (!saved) return@withContext false
+        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf("image/png"), null)
+        return@withContext true
+    }
+
+    val values = ContentValues().apply {
+        put(MediaStore.Images.Media.DISPLAY_NAME, filename)
+        put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+        put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/Animeko")
+        put(MediaStore.Images.Media.IS_PENDING, 1)
+    }
+    val resolver = context.contentResolver
+    val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+        ?: return@withContext false
+
+    try {
+        val saved = resolver.openOutputStream(uri)?.use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        } == true
+        if (!saved) {
+            resolver.delete(uri, null, null)
+            return@withContext false
+        }
+
+        values.clear()
+        values.put(MediaStore.Images.Media.IS_PENDING, 0)
+        resolver.update(uri, values, null, null)
+        true
+    } catch (e: Exception) {
+        resolver.delete(uri, null, null)
+        throw e
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -883,6 +883,7 @@ private fun EpisodeVideo(
 ) {
     val context by rememberUpdatedState(LocalContext.current)
     val navigator = LocalNavigator.current
+    val isAndroid = LocalPlatform.current.isAndroid()
 
     // Don't rememberSavable. 刻意让每次切换都是隐藏的
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
@@ -982,7 +983,11 @@ private fun EpisodeVideo(
             // 条目ID-剧集序号-视频时间点.png
             val filename = "${vm.subjectId}-${page.episodePresentation.ep}-${currentPosition}.png"
             scope.launch {
-                vm.player.features[Screenshots]?.takeScreenshot(filename)
+                if (isAndroid) {
+                    takeAndroidPlayerScreenshot(context, vm.player, filename)
+                } else {
+                    vm.player.features[Screenshots]?.takeScreenshot(filename)
+                }
             }
         },
         detachedProgressSlider = {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -141,6 +141,7 @@ import me.him188.ani.app.videoplayer.ui.rememberVideoSideSheetsController
 import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
 import me.him188.ani.app.videoplayer.ui.top.SystemTime
 import me.him188.ani.utils.platform.annotations.TestOnly
+import me.him188.ani.utils.platform.isAndroid
 import me.him188.ani.utils.platform.isDesktop
 import me.him188.ani.utils.platform.isMobile
 import org.jetbrains.compose.resources.stringResource
@@ -385,7 +386,7 @@ internal fun EpisodeVideoImpl(
                 }
             },
             rhsButtons = {
-                if (expanded && LocalPlatform.current.isDesktop()) {
+                if (expanded && (LocalPlatform.current.isDesktop() || LocalPlatform.current.isAndroid())) {
                     ScreenshotButton(
                         onClick = onClickScreenshot,
                     )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/PlayerScreenshot.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/PlayerScreenshot.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.episode
+
+import me.him188.ani.app.platform.Context
+import org.openani.mediamp.MediampPlayer
+
+internal expect suspend fun takeAndroidPlayerScreenshot(
+    context: Context,
+    player: MediampPlayer,
+    filename: String,
+): Boolean

--- a/app/shared/src/skikoMain/kotlin/ui/subject/episode/PlayerScreenshot.skiko.kt
+++ b/app/shared/src/skikoMain/kotlin/ui/subject/episode/PlayerScreenshot.skiko.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.episode
+
+import me.him188.ani.app.platform.Context
+import org.openani.mediamp.MediampPlayer
+
+internal actual suspend fun takeAndroidPlayerScreenshot(
+    context: Context,
+    player: MediampPlayer,
+    filename: String,
+): Boolean = false

--- a/app/shared/video-player/src/androidMain/kotlin/ui/AndroidVideoSurface.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/ui/AndroidVideoSurface.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui
+
+import android.view.SurfaceView
+import org.openani.mediamp.MediampPlayer
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+
+private val videoSurfaces = WeakHashMap<MediampPlayer, WeakReference<SurfaceView>>()
+
+internal fun registerAndroidVideoSurface(player: MediampPlayer, surfaceView: SurfaceView) {
+    synchronized(videoSurfaces) {
+        videoSurfaces[player] = WeakReference(surfaceView)
+    }
+}
+
+fun MediampPlayer.findAndroidVideoSurface(): SurfaceView? = synchronized(videoSurfaces) {
+    videoSurfaces[this]?.get()
+}

--- a/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/ui/VideoPlayer.android.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.videoplayer.ui
 
 import android.graphics.Color
 import android.graphics.Typeface
+import android.view.SurfaceView
 import android.view.View
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ actual fun VideoPlayer(
         Box(modifier)
     } else {
         ExoPlayerMediampPlayerSurface(player as ExoPlayerMediampPlayer, modifier) {
+            (videoSurfaceView as? SurfaceView)?.let { registerAndroidVideoSurface(player, it) }
             controllerAutoShow = false
             useController = false
             controllerHideOnTouch = false


### PR DESCRIPTION
## 改动

为 Android 播放器增加截图功能。点击截图按钮后，Animeko 截取当前视频画面，并将 PNG 保存至系统相册的 `Pictures/Animeko`。

- Android 10 及以上使用 MediaStore 保存，无需存储权限。
- Android 8.1–9 首次截图时申请写入外部存储权限，保存后通知系统媒体库扫描。
- 截图不包含控制栏、弹幕等叠加 UI。
- 保留 Desktop 现有的截图行为。

## 实现

Android `VideoPlayer` 创建 `PlayerView` 时，会登记当前 `MediampPlayer` 对应的 `SurfaceView`。截图逻辑直接取得该 Surface，并使用 `PixelCopy` 复制当前画面，不需要遍历 Activity 的 View 树。

Android 未直接复用 Mediamp 的 `Screenshots` feature。该接口需要调用方提供目标文件，而 Android 需要根据系统版本处理 MediaStore、公共图片目录和运行时权限，因此保存逻辑仍由 Animeko 管理。

## 验证

- Android 16 实体机：截图成功，图片可在系统相册中查看。
- Android 8.1（API 27）AVD：权限申请、文件保存和图库收录均正常。
- `./gradlew :app:shared:compileAndroidMain :app:shared:compileKotlinDesktop`

Closes #1907
