### PR TITLE
fix(player): improve keyboard shortcut behavior

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -724,7 +724,7 @@
     <string name="video_player_stats_title">播放信息</string>
     <string name="video_player_stats_title_show">显示播放信息</string>
     <string name="video_player_stats_title_hide">隐藏播放信息</string>
-    <string name="video_player_stats_hide_hint">Tab 隐藏</string>
+    <string name="video_player_stats_hide_hint">按 I 隐藏</string>
     <string name="video_player_stats_backend">后端</string>
     <string name="video_player_stats_state">状态</string>
     <string name="video_player_stats_media_title">标题</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -699,7 +699,7 @@
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>
-    <string name="video_player_stats_hide_hint">Tab 隱藏</string>
+    <string name="video_player_stats_hide_hint">按 I 隱藏</string>
     <string name="video_player_stats_backend">後端</string>
     <string name="video_player_stats_state">狀態</string>
     <string name="video_player_stats_media_title">標題</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -688,7 +688,7 @@
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>
-    <string name="video_player_stats_hide_hint">Tab 隱藏</string>
+    <string name="video_player_stats_hide_hint">按 I 隱藏</string>
     <string name="video_player_stats_backend">後端</string>
     <string name="video_player_stats_state">狀態</string>
     <string name="video_player_stats_media_title">標題</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -684,7 +684,7 @@
     <string name="video_player_stats_title">Playback Info</string>
     <string name="video_player_stats_title_show">Show Playback Info</string>
     <string name="video_player_stats_title_hide">Hide Playback Info</string>
-    <string name="video_player_stats_hide_hint">Tab to hide</string>
+    <string name="video_player_stats_hide_hint">I to hide</string>
     <string name="video_player_stats_backend">Backend</string>
     <string name="video_player_stats_state">State</string>
     <string name="video_player_stats_media_title">Title</string>

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -845,6 +845,40 @@ class EpisodeVideoControllerTest {
     }
 
     @Test
+    fun `mouse - keyboard shortcuts - I toggles playback info and Tab does not`() = runAniComposeUiTest {
+        val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
+        setContent {
+            Player(
+                GestureFamily.MOUSE,
+                playerControllerState = visibleControllerState,
+            )
+        }
+        waitForIdle()
+
+        videoGestureHost.assertIsFocused()
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Tab)
+        }
+        waitForIdle()
+        onNodeWithText("Playback Info", substring = true).doesNotExist()
+
+        videoGestureHost.performClick()
+        videoGestureHost.performKeyInput {
+            pressKey(Key.I)
+        }
+        waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+            onNodeWithText("Playback Info", substring = true).exists()
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.I)
+        }
+        waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+            !onNodeWithText("Playback Info", substring = true).exists()
+        }
+    }
+
+    @Test
     fun `touch - keyboard shortcuts - reclaim focus from editor on mouse move`() = runAniComposeUiTest {
         val visibleControllerState = PlayerControllerState(NORMAL_VISIBLE)
         setContent {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -622,6 +623,10 @@ fun PlayerGestureHost(
                         }
                     }
                 }
+                // Do not remove this as redundant with combinedClickable. Its focus target uses
+                // Focusability.SystemDefined, which is not focusable while Android is in touch input mode.
+                // This always-focusable child is the fallback that keeps hardware shortcuts working.
+                .focusable()
                 .fillMaxSize(),
         ) {
             Row(

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
@@ -74,7 +74,7 @@ internal fun Modifier.playerKeyboardShortcuts(
     }
     return result
         .onKey(ComposeKey.B, onToggleDanmaku)
-        .onKey(ComposeKey.Tab, onTogglePlayerStats)
+        .onKey(ComposeKey.I, onTogglePlayerStats)
         // The same node carries combinedClickable, which treats Enter as a click when focused.
         // Enter is not a player shortcut, so swallow it; DPad center is left for clickable so that
         // remote/DPad activation still works like a tap.


### PR DESCRIPTION
## Summary

- Restore an always-focusable player target so hardware keyboard shortcuts work on Android while Compose remains in touch input mode.
- Move the playback information shortcut from Tab to I so Tab remains available for focus navigation.
- Document why the explicit focusable modifier is required.

## Root cause

combinedClickable uses SystemDefined focusability, which cannot receive focus while Android is in touch input mode. Removing the explicit focusable modifier therefore prevented hardware keyboard shortcuts from reaching the player on Android.

Binding playback information to Tab also consumed a standard focus-navigation key on desktop.

## Validation

- Verified the Android focus regression on a physical Android device with a hardware keyboard.
- Passed the Compose UI keyboard shortcut coverage for touch controls.
- Passed the desktop test that verifies I toggles playback information while Tab does not.
- Passed the existing Enter and NumPad Enter regression test.