### PR TITLE
feat(player): improve Android touch seeking

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -721,6 +721,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即将跳过 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">松开手指取消</string>
     <string name="video_player_stats_title">播放信息</string>
     <string name="video_player_stats_title_show">显示播放信息</string>
     <string name="video_player_stats_title_hide">隐藏播放信息</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -696,6 +696,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即將跳過 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">放開手指取消</string>
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -685,6 +685,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即將跳過 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">放開手指取消</string>
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -681,6 +681,7 @@
     <string name="video_player_speed">Speed</string>
     <string name="video_player_skip_op_ed">Skipping OP or ED soon</string>
     <string name="video_player_cancel">Cancel</string>
+    <string name="video_player_release_to_cancel">Release to cancel</string>
     <string name="video_player_stats_title">Playback Info</string>
     <string name="video_player_stats_title_show">Show Playback Info</string>
     <string name="video_player_stats_title_hide">Hide Playback Info</string>

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -990,8 +990,6 @@ private fun EpisodeVideo(
                 progressSliderState,
                 cacheProgressInfoFlow = vm.cacheProgressInfoFlow,
                 enabled = false,
-                framePreview = framePreview,
-                showFramePreviewInPopup = expanded,
             )
         },
         sidebarVisible = vm.sidebarVisible,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -42,10 +42,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -118,6 +123,8 @@ import me.him188.ani.app.videoplayer.ui.gesture.LevelController
 import me.him188.ani.app.videoplayer.ui.gesture.LockableVideoGestureHost
 import me.him188.ani.app.videoplayer.ui.gesture.NoOpLevelController
 import me.him188.ani.app.videoplayer.ui.gesture.ScreenshotButton
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerConfig
+import me.him188.ani.app.videoplayer.ui.gesture.isInCancelArea
 import me.him188.ani.app.videoplayer.ui.gesture.mouseFamily
 import me.him188.ani.app.videoplayer.ui.gesture.rememberGestureIndicatorState
 import me.him188.ani.app.videoplayer.ui.gesture.rememberSwipeSeekerState
@@ -133,6 +140,7 @@ import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults.VideoA
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
 import me.him188.ani.app.videoplayer.ui.progress.ProgressSliderCenteredPreviewFrame
 import me.him188.ani.app.videoplayer.ui.progress.SubtitleSwitcher
+import me.him188.ani.app.videoplayer.ui.progress.TouchSeekCancellation
 import me.him188.ani.app.videoplayer.ui.progress.rememberMediaProgressSliderState
 import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.app.videoplayer.ui.rememberPlayerStatsState
@@ -222,6 +230,54 @@ internal fun EpisodeVideoImpl(
                     || anySideSheetVisible)
         }
     }
+    val inlineProgressSliderRequester = remember(playerControllerState) { Any() }
+    var sliderSeekCancelled by remember { mutableStateOf(false) }
+    val useTouchSliderOnly =
+        gestureFamily == GestureFamily.TOUCH && (progressSliderState.isPreviewing || sliderSeekCancelled)
+    DisposableEffect(playerControllerState, inlineProgressSliderRequester, useTouchSliderOnly) {
+        if (useTouchSliderOnly) {
+            playerControllerState.setRequestInlineProgressSlider(inlineProgressSliderRequester)
+        }
+        onDispose {
+            playerControllerState.cancelRequestInlineProgressSlider(inlineProgressSliderRequester)
+        }
+    }
+    val indicatorState = rememberGestureIndicatorState()
+    var videoBounds by remember { mutableStateOf<Rect?>(null) }
+    var sliderCancellationTicket by remember { mutableStateOf<Int?>(null) }
+    DisposableEffect(indicatorState) {
+        onDispose {
+            sliderCancellationTicket?.let(indicatorState::stopSeekCancellation)
+        }
+    }
+    val touchSeekCancellation = if (gestureFamily == GestureFamily.TOUCH) {
+        val bounds = videoBounds
+        remember(indicatorState, bounds) {
+            TouchSeekCancellation(
+                isInCancelArea = { positionInRoot ->
+                    if (bounds == null) {
+                        false
+                    } else {
+                        SwipeSeekerConfig.Default.isInCancelArea(
+                            position = positionInRoot - Offset(bounds.left, bounds.top),
+                            containerSize = IntSize(bounds.width.toInt(), bounds.height.toInt()),
+                        )
+                    }
+                },
+                onCancellationChanged = { cancelled ->
+                    sliderSeekCancelled = cancelled
+                    if (cancelled && sliderCancellationTicket == null) {
+                        sliderCancellationTicket = indicatorState.startSeekCancellation()
+                    } else if (!cancelled) {
+                        sliderCancellationTicket?.let(indicatorState::stopSeekCancellation)
+                        sliderCancellationTicket = null
+                    }
+                },
+            )
+        }
+    } else {
+        null
+    }
 
     AniTheme(darkModeOverride = DarkMode.DARK) {
         val progressSliderColors = MediaProgressSliderDefaults.colors()
@@ -229,7 +285,10 @@ internal fun EpisodeVideoImpl(
             expanded = expanded,
             modifier = modifier
                 .hoverable(videoInteractionSource)
-                .cursorVisibility(showCursor),
+                .cursorVisibility(showCursor)
+                .onGloballyPositioned {
+                    videoBounds = it.boundsInRoot()
+                },
             contentWindowInsets = contentWindowInsets,
             maintainAspectRatio = maintainAspectRatio,
             controllerState = playerControllerState,
@@ -307,7 +366,6 @@ internal fun EpisodeVideoImpl(
                 }
 
                 val indicatorTasker = rememberUiMonoTasker()
-                val indicatorState = rememberGestureIndicatorState()
                 LockableVideoGestureHost(
                     playerControllerState,
                     swipeSeekerState,
@@ -445,6 +503,7 @@ internal fun EpisodeVideoImpl(
                             showPreviewTimeTextOnThumb = expanded,
                             framePreview = framePreview,
                             showFramePreviewInPopup = expanded,
+                            touchSeekCancellation = touchSeekCancellation,
                         )
                     },
                     danmakuEditor = danmakuEditor,
@@ -494,6 +553,7 @@ internal fun EpisodeVideoImpl(
                         )
                     },
                     expanded = expanded,
+                    sliderOnly = playerControllerState.visibility == ControllerVisibility.InlineSliderOnly,
                 )
             },
             detachedProgressSlider = detachedProgressSlider,

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -149,13 +150,13 @@ class EpisodeVideoControllerTest {
             detachedSlider = false,
         )
 
-        private val PREVIEW_DETACHED_SLIDER = ControllerVisibility(
+        private val PREVIEW_INLINE_SLIDER = ControllerVisibility(
             topBar = false,
-            bottomBar = false,
+            bottomBar = true,
             floatingBottomEnd = false,
             rhsBar = false,
             gestureLock = false,
-            detachedSlider = true,
+            detachedSlider = false,
         )
     }
 
@@ -252,8 +253,6 @@ class EpisodeVideoControllerTest {
                         cacheProgressInfoFlow = cacheProgressInfoFlow,
                         Modifier.testTag(TAG_DETACHED_PROGRESS_SLIDER),
                         enabled = false,
-                        framePreview = framePreview,
-                        showFramePreviewInPopup = expanded,
                     )
                 },
                 sidebarVisible = true,
@@ -1117,7 +1116,7 @@ class EpisodeVideoControllerTest {
      * @see GestureFamily.swipeToSeek
      */
     @Test
-    fun `touch - swipeToSeek shows detached slider`() = runAniComposeUiTest {
+    fun `touch - swipeToSeek shows inline slider`() = runAniComposeUiTest {
         setContent {
             Player(GestureFamily.TOUCH)
         }
@@ -1132,15 +1131,16 @@ class EpisodeVideoControllerTest {
             detachedProgressSlider.assertDoesNotExist()
         }
 
-        // 按下手指并移动, 显示独立进度条
+        // 按下手指并移动, 显示底栏原进度条
         root.performTouchInput {
             down(centerLeft)
             moveBy(Offset(width / 2f, 0f))
         }
         runOnIdle {
-            waitUntil(timeoutMillis = WAIT_TIMEOUT) { detachedProgressSlider.exists() }
-            assertEquals(PREVIEW_DETACHED_SLIDER, controllerState.visibility)
-//            root.assertScreenshot("/screenshots/EpisodeVideoControllerTest.touch___swipeToSeek_shows_detached_slider.png")
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) { progressSlider.exists() }
+            detachedProgressSlider.assertDoesNotExist()
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
+//            root.assertScreenshot("/screenshots/EpisodeVideoControllerTest.touch___swipeToSeek_shows_inline_slider.png")
         }
 
         // 松开手指
@@ -1148,7 +1148,7 @@ class EpisodeVideoControllerTest {
             up()
         }
         runOnIdle {
-            waitUntil(timeoutMillis = WAIT_TIMEOUT) { detachedProgressSlider.doesNotExist() }
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) { progressSlider.doesNotExist() }
             assertEquals(NORMAL_INVISIBLE, controllerState.visibility)
         }
     }
@@ -1157,9 +1157,9 @@ class EpisodeVideoControllerTest {
      * @see GestureFamily.swipeToSeek
      */
     @Test
-    fun `touch - swipe when controller is already fully visible`() = runAniComposeUiTest {
+    fun `touch - swipe hides visible controls without moving slider`() = runAniComposeUiTest {
         setContent {
-            Player(GestureFamily.TOUCH)
+            Player(gestureFamily = GestureFamily.TOUCH)
         }
         waitForIdle()
         val root = onAllNodes(isRoot()).onFirst()
@@ -1173,6 +1173,7 @@ class EpisodeVideoControllerTest {
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
             detachedProgressSlider.assertDoesNotExist()
         }
+        val progressSliderBoundsBeforeDrag = progressSlider.fetchSemanticsNode().boundsInRoot
 
         runOnUiThread {
             root.performTouchInput {
@@ -1181,9 +1182,18 @@ class EpisodeVideoControllerTest {
             }
         }
         runOnIdle {
+            mainClock.advanceTimeBy(1000L)
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { previewPopup.exists() }
+            // Top controls remain laid out but are drawn transparently, preserving the top scrim.
+            topBar.assertExists()
             detachedProgressSlider.assertDoesNotExist()
-            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            progressSlider.assertExists()
+            assertEquals(
+                progressSliderBoundsBeforeDrag,
+                progressSlider.fetchSemanticsNode().boundsInRoot,
+            )
+            onNodeWithTag(TAG_PROGRESS_SLIDER_PREVIEW_FRAME, useUnmergedTree = true).assertDoesNotExist()
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
         }
 
         runOnUiThread {
@@ -1192,6 +1202,7 @@ class EpisodeVideoControllerTest {
             }
         }
         runOnIdle {
+            mainClock.advanceTimeBy(1000L)
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { previewPopup.doesNotExist() }
             detachedProgressSlider.assertDoesNotExist()
             assertEquals(NORMAL_VISIBLE, controllerState.visibility)
@@ -1255,10 +1266,11 @@ class EpisodeVideoControllerTest {
             moveBy(Offset(centerX, 0f))
         }
         waitForIdle() // does nothing because autoAdvance is false
-        mainClock.advanceTimeByFrame() // renders the next frame (i.e. update derivedStateOf and Text)
-        mediaProgressIndicatorText.assertTextEquals("00:47 / 01:40")
+        mainClock.advanceTimeBy(1000L)
+        previewPopup.assertExists()
+        onAllNodesWithText("00:47", useUnmergedTree = true).onFirst().assertExists()
         runOnUiThread {
-            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
         }
 
         // 松开手指
@@ -1289,6 +1301,7 @@ class EpisodeVideoControllerTest {
                 waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
                 detachedProgressSlider.assertDoesNotExist()
             }
+            val progressSliderBoundsBeforeDrag = progressSlider.fetchSemanticsNode().boundsInRoot
 
             runOnUiThread {
                 progressSlider.performTouchInput {
@@ -1297,8 +1310,20 @@ class EpisodeVideoControllerTest {
                 }
             }
             runOnIdle {
-                waitUntil(timeoutMillis = WAIT_TIMEOUT) { onNodeWithText("00:48 / 01:40").exists() }
-                assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+                mainClock.advanceTimeBy(1000L)
+                waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                    controllerState.visibility == ControllerVisibility.InlineSliderOnly
+                }
+                topBar.assertExists()
+                // Other controller content stays composed so the slider keeps the same layout,
+                // but PlayerControllerBar draws it transparently while dragging.
+                mediaProgressIndicatorText.assertExists()
+                progressSlider.assertExists()
+                assertEquals(
+                    progressSliderBoundsBeforeDrag,
+                    progressSlider.fetchSemanticsNode().boundsInRoot,
+                )
+                assertEquals(true, progressSliderState.isPreviewing)
             }
 
             // 松开手指
@@ -1321,11 +1346,101 @@ class EpisodeVideoControllerTest {
             }
         }
 
+    @Test
+    fun `touch - progress slider drag can be cancelled`() = runAniComposeUiTest {
+        setContent {
+            Player(GestureFamily.TOUCH)
+        }
+        waitForIdle()
+        val root = onAllNodes(isRoot()).onFirst()
+
+        mainClock.autoAdvance = false
+        root.performClick()
+        mainClock.advanceTimeBy(1000L)
+        waitForIdle()
+
+        val playerBounds = player.fetchSemanticsNode().boundsInRoot
+        val sliderBounds = progressSlider.fetchSemanticsNode().boundsInRoot
+        progressSlider.performTouchInput {
+            down(centerLeft)
+            moveTo(Offset(width * 0.75f, centerY))
+        }
+        runOnIdle {
+            assertEquals(true, progressSliderState.isPreviewing)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(playerBounds.topLeft + Offset(1f, 1f) - sliderBounds.topLeft)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").exists()
+            }
+            assertEquals(false, progressSliderState.isPreviewing)
+            assertEquals(ControllerVisibility.InlineSliderOnly, controllerState.visibility)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(Offset(width * 0.6f, centerY))
+        }
+        runOnIdle {
+            mainClock.advanceTimeBy(1000L)
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").doesNotExist()
+            }
+            assertEquals(true, progressSliderState.isPreviewing)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(playerBounds.topLeft + Offset(1f, 1f) - sliderBounds.topLeft)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").exists()
+            }
+        }
+
+        progressSlider.performTouchInput {
+            up()
+        }
+        runOnIdle {
+            mainClock.advanceTimeBy(1000L)
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").doesNotExist()
+            }
+            assertEquals(0L, currentPositionMillis)
+            assertEquals(false, progressSliderState.isPreviewing)
+        }
+    }
+
+    @Test
+    fun `mouse - previewing progress slider keeps full controller visible`() = runAniComposeUiTest {
+        setContent {
+            Player(GestureFamily.MOUSE)
+        }
+        waitForIdle()
+
+        runOnUiThread {
+            controllerState.toggleFullVisible(true)
+            progressSliderState.previewPositionRatio(0.5f)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
+            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            mediaProgressIndicatorText.assertExists()
+            progressSlider.assertExists()
+        }
+
+        runOnUiThread {
+            progressSliderState.cancelPreview()
+        }
+    }
+
     /**
      * @see GestureFamily.swipeToSeek
      */
     @Test // https://github.com/open-ani/ani/issues/720
-    fun `touch - swipeToSeek shows detached slider and can still play`() = runAniComposeUiTest {
+    fun `touch - swipeToSeek shows inline slider and can still play`() = runAniComposeUiTest {
         setContent {
             Player(GestureFamily.TOUCH)
         }
@@ -1342,14 +1457,15 @@ class EpisodeVideoControllerTest {
             assertEquals(0.0f, progressSliderState.displayPositionRatio)
         }
 
-        // 按下手指并移动, 显示独立进度条
+        // 按下手指并移动, 显示底栏原进度条
         root.performTouchInput {
             down(centerLeft)
             moveBy(Offset(width / 2f, 0f))
         }
         runOnIdle {
-            waitUntil(timeoutMillis = WAIT_TIMEOUT) { detachedProgressSlider.exists() }
-            assertEquals(PREVIEW_DETACHED_SLIDER, controllerState.visibility)
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) { progressSlider.exists() }
+            detachedProgressSlider.assertDoesNotExist()
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
             assertEquals(true, progressSliderState.isPreviewing)
             assertEquals(0.47f, progressSliderState.displayPositionRatio)
         }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
@@ -162,6 +162,16 @@ data class ControllerVisibility(
             gestureLock = false,
             detachedSlider = true,
         )
+
+        @Stable
+        val InlineSliderOnly = ControllerVisibility(
+            topBar = false,
+            bottomBar = true,
+            floatingBottomEnd = false,
+            rhsBar = false,
+            gestureLock = false,
+            detachedSlider = false,
+        )
     }
 }
 
@@ -177,12 +187,20 @@ class PlayerControllerState(
 
     private var fullVisible by mutableStateOf(initialVisibility == ControllerVisibility.Visible)
     private val hasProgressBarRequester by derivedStateOf { progressBarRequesters.isNotEmpty() }
+    private val hasDetachedProgressSliderRequester by derivedStateOf {
+        detachedProgressSliderRequesters.isNotEmpty()
+    }
+    private val hasInlineProgressSliderRequester by derivedStateOf {
+        inlineProgressSliderRequesters.isNotEmpty()
+    }
 
     /**
      * 当前 UI 应当显示的状态
      */
     val visibility: ControllerVisibility by derivedStateOf {
         // 根据 hasProgressBarRequester, alwaysOn 和 fullVisible 计算正确的 `ControllerVisibility`
+        if (hasDetachedProgressSliderRequester) return@derivedStateOf ControllerVisibility.DetachedSliderOnly
+        if (hasInlineProgressSliderRequester) return@derivedStateOf ControllerVisibility.InlineSliderOnly
         if (alwaysOn) return@derivedStateOf ControllerVisibility.Visible
         if (fullVisible) return@derivedStateOf ControllerVisibility.Visible
         if (hasProgressBarRequester) return@derivedStateOf ControllerVisibility.DetachedSliderOnly
@@ -228,6 +246,40 @@ class PlayerControllerState(
     }
 
     private val progressBarRequesters = SnapshotStateList<Any>()
+
+    private val detachedProgressSliderRequesters = SnapshotStateList<Any>()
+    private val inlineProgressSliderRequesters = SnapshotStateList<Any>()
+
+    /**
+     * 只显示独立进度条, 暂时隐藏其他控制器元素.
+     *
+     * 取消请求后会恢复由 [fullVisible]、[alwaysOn] 和普通进度条请求共同决定的可见状态.
+     */
+    fun setRequestDetachedProgressSlider(requester: Any) {
+        if (requester in detachedProgressSliderRequesters) return
+        detachedProgressSliderRequesters.add(requester)
+    }
+
+    /**
+     * 取消只显示独立进度条的请求.
+     */
+    fun cancelRequestDetachedProgressSlider(requester: Any) {
+        detachedProgressSliderRequesters.remove(requester)
+    }
+
+    /**
+     * 保留底部控制栏中的原进度条, 同时隐藏其他控制器元素.
+     *
+     * 与 [setRequestDetachedProgressSlider] 不同, 该模式不会替换正在接收触摸事件的进度条.
+     */
+    fun setRequestInlineProgressSlider(requester: Any) {
+        if (requester in inlineProgressSliderRequesters) return
+        inlineProgressSliderRequesters.add(requester)
+    }
+
+    fun cancelRequestInlineProgressSlider(requester: Any) {
+        inlineProgressSliderRequesters.remove(requester)
+    }
 
     /**
      * 请求显示进度条

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -40,9 +40,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
@@ -101,6 +104,7 @@ fun VideoScaffold(
     framePreviewOverlay: @Composable BoxScope.() -> Unit = {},
     playerStatsOverlay: @Composable BoxScope.() -> Unit = {},
 ) {
+    val inlineSliderOnly = controllerState.visibility == ControllerVisibility.InlineSliderOnly
     val controllerVisibility = controllerState.visibility
         .withGestureLocked(gestureLocked)
         .withExpanded(expanded)
@@ -161,7 +165,7 @@ fun VideoScaffold(
                 Column(Modifier.fillMaxSize().background(Color.Transparent)) {
                     // 顶部控制栏: 返回键, 标题, 设置
                     me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility(
-                        visible = controllerVisibility.topBar,
+                        visible = controllerVisibility.topBar || inlineSliderOnly,
                         enter = enterTransition,
                         exit = exitTransition,
                     ) {
@@ -181,6 +185,7 @@ fun VideoScaffold(
 
                             Column(
                                 Modifier
+                                    .keepLayoutWhenHidden(inlineSliderOnly)
                                     .hoverToRequestAlwaysOn(alwaysOnRequester)
                                     .fillMaxWidth(),
                             ) {
@@ -206,6 +211,7 @@ fun VideoScaffold(
 
                             Box(
                                 Modifier.matchParentSize()
+                                    .keepLayoutWhenHidden(inlineSliderOnly)
                                     .windowInsetsPadding(contentWindowInsets.only(WindowInsetsSides.Top))
                                     .padding(top = 8.dp),
                                 contentAlignment = Alignment.TopCenter,
@@ -360,6 +366,19 @@ fun VideoScaffold(
             }
         }
     }
+}
+
+private fun Modifier.keepLayoutWhenHidden(hidden: Boolean): Modifier {
+    if (!hidden) return this
+    return alpha(0f)
+        .clearAndSetSemantics { }
+        .pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                }
+            }
+        }
 }
 
 

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.BrightnessHigh
 import androidx.compose.material.icons.rounded.BrightnessLow
 import androidx.compose.material.icons.rounded.BrightnessMedium
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
@@ -50,6 +51,7 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -79,6 +81,7 @@ import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.isSystemInFullscreen
+import me.him188.ani.app.ui.lang.*
 import me.him188.ani.app.utils.fixToString
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
@@ -93,10 +96,10 @@ import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.VOLU
 import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
 import me.him188.ani.app.videoplayer.ui.playerFocusHost
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
-import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.utils.platform.Platform
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.features.AudioLevelController
+import org.jetbrains.compose.resources.stringResource
 import kotlin.math.absoluteValue
 import kotlin.time.Duration.Companion.seconds
 
@@ -124,6 +127,7 @@ class GestureIndicatorState {
     internal var state: State? by mutableStateOf(null)
     internal var progressValue: Float by mutableFloatStateOf(0f)
     internal var deltaSeconds: Int by mutableIntStateOf(0)
+    internal var seekCancelled: Boolean by mutableStateOf(false)
     private var counter: Int = 0
 
     private inline fun startShow(
@@ -193,10 +197,26 @@ class GestureIndicatorState {
     @UiThread
     suspend fun showSeeking(
         deltaSeconds: Int,
+        cancelled: Boolean = false,
     ) {
-        show(SEEKING, setup = { this.deltaSeconds = deltaSeconds }) {
+        show(SEEKING, setup = {
+            this.deltaSeconds = deltaSeconds
+            this.seekCancelled = cancelled
+        }) {
             delay(SHORT)
         }
+    }
+
+    @UiThread
+    fun startSeekCancellation(): Int {
+        return startShow(SEEKING) {
+            seekCancelled = true
+        }
+    }
+
+    @UiThread
+    fun stopSeekCancellation(ticket: Int) {
+        stopShow(ticket)
     }
 
     @UiThread
@@ -293,30 +313,35 @@ fun GestureIndicator(
                         }
 
                         SEEKING -> {
-                            val deltaDuration = state.deltaSeconds
-                            // 记忆变为 0 之前的 delta, 这样在快进/快退结束后, 会显示上一次的 delta, 而不是显示 0
-                            val duration = if (deltaDuration == 0) {
-                                lastDelta
+                            if (state.seekCancelled) {
+                                Icon(Icons.Rounded.Close, null, Modifier.size(iconSize))
+                                Text(stringResource(Lang.video_player_release_to_cancel), maxLines = 1)
                             } else {
-                                deltaDuration.also {
-                                    lastDelta = deltaDuration
-                                }
-                            }
-
-                            Icon(
-                                if (duration > 0) {
-                                    Icons.Rounded.FastForward
+                                val deltaDuration = state.deltaSeconds
+                                // 记忆变为 0 之前的 delta, 这样在快进/快退结束后, 会显示上一次的 delta, 而不是显示 0
+                                val duration = if (deltaDuration == 0) {
+                                    lastDelta
                                 } else {
-                                    Icons.Rounded.FastRewind
-                                },
-                                null,
-                                Modifier.size(iconSize),
-                            )
-                            val text = renderTime(duration.absoluteValue)
-                            Text(
-                                text,
-                                maxLines = 1,
-                            )
+                                    deltaDuration.also {
+                                        lastDelta = deltaDuration
+                                    }
+                                }
+
+                                Icon(
+                                    if (duration > 0) {
+                                        Icons.Rounded.FastForward
+                                    } else {
+                                        Icons.Rounded.FastRewind
+                                    },
+                                    null,
+                                    Modifier.size(iconSize),
+                                )
+                                val text = renderTime(duration.absoluteValue)
+                                Text(
+                                    text,
+                                    maxLines = 1,
+                                )
+                            }
                         }
 
                         VOLUME -> {
@@ -441,9 +466,20 @@ fun PlayerGestureHost(
                 .systemGesturesPadding()
                 .padding(top = 16.dp),
         ) {
-            LaunchedEffect(seekerState.deltaSeconds) {
-                if (seekerState.isSeeking) {
-                    indicatorState.showSeeking(seekerState.deltaSeconds)
+            val showSeekCancellation = seekerState.isSeeking && seekerState.isCancelled
+            LaunchedEffect(showSeekCancellation) {
+                if (showSeekCancellation) {
+                    progressSliderState.cancelPreview()
+                }
+            }
+            DisposableEffect(indicatorState, showSeekCancellation) {
+                val ticket = if (showSeekCancellation) {
+                    indicatorState.startSeekCancellation()
+                } else {
+                    null
+                }
+                onDispose {
+                    ticket?.let(indicatorState::stopSeekCancellation)
                 }
             }
             GestureIndicator(indicatorState)
@@ -564,28 +600,35 @@ fun PlayerGestureHost(
             keyboardModifier
                 .combineClickableWithFamilyGesture()
                 .ifThen(family.swipeToSeek && enableSwipeToSeek) {
-                    val swipeToSeekRequester = rememberAlwaysOnRequester(controllerState, "swipeToSeek")
+                    val swipeToSeekRequester = remember(controllerState) { Any() }
+                    DisposableEffect(controllerState, swipeToSeekRequester) {
+                        onDispose {
+                            controllerState.cancelRequestInlineProgressSlider(swipeToSeekRequester)
+                        }
+                    }
                     swipeToSeek(
                         seekerState,
                         Orientation.Horizontal,
                         //调节音量/亮度时禁用水平seek
                         enabled = !adjustingVolumeOrBrightness,
                         onDragStarted = {
-                            if (controllerState.visibility.bottomBar) {
-                                swipeToSeekRequester.request()
-                            }
-                            controllerState.setRequestProgressBar(swipeToSeekRequester)
+                            controllerState.setRequestInlineProgressSlider(swipeToSeekRequester)
                         },
-                        onDragStopped = {
-                            if (controllerState.visibility.bottomBar) {
-                                swipeToSeekRequester.cancelRequest()
+                        onDragStopped = { _, cancelled ->
+                            controllerState.cancelRequestInlineProgressSlider(swipeToSeekRequester)
+                            if (cancelled) {
+                                progressSliderState.cancelPreview()
+                            } else {
+                                progressSliderState.finishPreview()
                             }
-                            controllerState.cancelRequestProgressBarVisible(swipeToSeekRequester)
-                            progressSliderState.finishPreview()
                         },
                     ) {
                         progressSliderState.run {
                             if (totalDurationMillis == 0L) return@run
+                            if (seekerState.isCancelled) {
+                                cancelPreview()
+                                return@run
+                            }
                             val offsetRatio =
                                 (currentPositionMillis + seekerState.deltaSeconds.times(1000)).toFloat() / totalDurationMillis
                             previewPositionRatio(offsetRatio.coerceIn(0f, 1f))

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
@@ -20,13 +20,19 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CoroutineScope
+import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import kotlin.math.roundToInt
 
 
@@ -58,6 +64,14 @@ data class SwipeSeekerConfig(
     // 用户不能从最左边开始滑. 因此稍微留了点余量.
     // 实测差不多可以滑到 87 秒, 看三秒 op 让他知道他完了 op
     val maxDragSeconds: Int = 97,
+    /**
+     * 屏幕顶部作为取消区域的高度占比.
+     */
+    val cancelAreaHeightRatio: Float = 0.25f,
+    /**
+     * 屏幕左右两侧各自作为取消区域的宽度占比.
+     */
+    val cancelAreaWidthRatio: Float = 0.25f,
 ) {
     companion object {
         val Default = SwipeSeekerConfig()
@@ -81,22 +95,47 @@ class SwipeSeekerState(
      */
     private var seekDelta: Float by mutableFloatStateOf(Float.NaN)
 
+    /**
+     * 当前滑动是否已进入取消区域.
+     */
+    var isCancelled: Boolean by mutableStateOf(false)
+        private set
+
+    private var lastPointerPosition: Offset = Offset.Unspecified
+    private var lastPointerContainerSize: IntSize = IntSize.Zero
+
     @UiThread
-    private fun onSwipeStarted() {
+    internal fun onSwipeStarted() {
         seekDelta = 0f
+        isCancelled = isInCancelArea(lastPointerPosition, lastPointerContainerSize)
     }
 
     @UiThread
-    private fun onSwipeStopped() {
+    internal fun onSwipeStopped() {
         if (seekDelta.isNaN()) return
-        onSeek(deltaSeconds)
+        if (!isCancelled) {
+            onSeek(deltaSeconds)
+        }
         seekDelta = Float.NaN
+        isCancelled = false
     }
 
     @UiThread
-    private fun onSwipeOffset(offsetPx: Float) {
+    internal fun onSwipeOffset(offsetPx: Float) {
         seekDelta += offsetPx
     }
+
+    @UiThread
+    internal fun onPointerMoved(position: Offset, containerSize: IntSize) {
+        lastPointerPosition = position
+        lastPointerContainerSize = containerSize
+        if (!isSeeking) return
+
+        isCancelled = isInCancelArea(position, containerSize)
+    }
+
+    private fun isInCancelArea(position: Offset, containerSize: IntSize): Boolean =
+        swipeSeekerConfig.isInCancelArea(position, containerSize)
 
     /**
      * 是否正在快进, 即用户是否正在滑动屏幕
@@ -133,7 +172,7 @@ class SwipeSeekerState(
             interactionSource: MutableInteractionSource? = null,
             reverseDirection: Boolean = false,
             onDragStarted: suspend CoroutineScope.(startedPosition: Offset) -> Unit = {},
-            onDragStopped: suspend CoroutineScope.(velocity: Float) -> Unit = {},
+            onDragStopped: suspend CoroutineScope.(velocity: Float, cancelled: Boolean) -> Unit = { _, _ -> },
             onDelta: (Float) -> Unit = {},
         ): Modifier {
             return composed(
@@ -142,25 +181,44 @@ class SwipeSeekerState(
                     properties["seekerState"] = seekerState
                 },
             ) {
-                draggable(
-                    rememberDraggableState {
-                        seekerState.onSwipeOffset(it)
-                        onDelta(it)
-                    },
-                    orientation,
-                    onDragStarted = {
-                        seekerState.onSwipeStarted()
-                        onDragStarted(it)
-                    },
-                    onDragStopped = {
-                        seekerState.onSwipeStopped()
-                        onDragStopped(it)
-                    },
-                    enabled = enabled,
-                    interactionSource = interactionSource,
-                    reverseDirection = reverseDirection,
-                )
+                Modifier
+                    .onPointerEventMultiplatform(
+                        PointerEventType.Move,
+                        pass = PointerEventPass.Initial,
+                    ) { event ->
+                        event.changes.firstOrNull()?.let { change ->
+                            seekerState.onPointerMoved(change.position, size)
+                        }
+                    }
+                    .draggable(
+                        rememberDraggableState {
+                            seekerState.onSwipeOffset(it)
+                            onDelta(it)
+                        },
+                        orientation,
+                        onDragStarted = {
+                            seekerState.onSwipeStarted()
+                            onDragStarted(it)
+                        },
+                        onDragStopped = {
+                            val cancelled = seekerState.isCancelled
+                            seekerState.onSwipeStopped()
+                            onDragStopped(it, cancelled)
+                        },
+                        enabled = enabled,
+                        interactionSource = interactionSource,
+                        reverseDirection = reverseDirection,
+                    )
             }
         }
     }
+}
+
+fun SwipeSeekerConfig.isInCancelArea(position: Offset, containerSize: IntSize): Boolean {
+    if (!position.isSpecified || containerSize.width <= 0 || containerSize.height <= 0) return false
+
+    val inTopArea = position.y <= containerSize.height * cancelAreaHeightRatio
+    val inLeftArea = position.x <= containerSize.width * cancelAreaWidthRatio
+    val inRightArea = position.x >= containerSize.width * (1f - cancelAreaWidthRatio)
+    return inTopArea && (inLeftArea || inRightArea)
 }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -33,6 +35,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -57,7 +60,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -157,6 +165,13 @@ class PlayerProgressSliderState(
         onPreviewFinished((ratio * totalDurationMillis).roundToLong())
         previewPositionRatio = Float.NaN
     }
+
+    /**
+     * Stops previewing without seeking to the previewed position.
+     */
+    fun cancelPreview() {
+        previewPositionRatio = Float.NaN
+    }
 }
 
 private class Data(
@@ -252,6 +267,12 @@ class MediaProgressSliderColors(
     val previewTimeTextColor: Color,
 )
 
+@Stable
+class TouchSeekCancellation(
+    val isInCancelArea: (positionInRoot: Offset) -> Boolean,
+    val onCancellationChanged: (cancelled: Boolean) -> Unit,
+)
+
 /**
  * 视频播放器的进度条, 支持拖动调整播放位置, 支持显示缓冲进度.
  */
@@ -264,6 +285,7 @@ fun MediaProgressSlider(
     showPreviewTimeTextOnThumb: Boolean = true,
     framePreview: MediaProgressFramePreviewState? = null,
     showFramePreviewInPopup: Boolean = true,
+    touchSeekCancellation: TouchSeekCancellation? = null,
 //    drawThumb: @Composable DrawScope.() -> Unit = {
 //        drawCircle(
 //            MaterialTheme.colorScheme.primary,
@@ -384,6 +406,17 @@ fun MediaProgressSlider(
         var mousePosX by rememberSaveable { mutableStateOf(0f) }
         var thumbWidth by rememberSaveable { mutableIntStateOf(0) }
         var sliderWidth by rememberSaveable { mutableIntStateOf(0) }
+        var sliderCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+        var touchSeekCancelled by remember { mutableStateOf(false) }
+        var latestTouchPreviewRatio by remember { mutableFloatStateOf(Float.NaN) }
+
+        DisposableEffect(touchSeekCancellation) {
+            onDispose {
+                if (touchSeekCancelled) {
+                    touchSeekCancellation?.onCancellationChanged(false)
+                }
+            }
+        }
 
         fun renderPreviewTime(previewTimeMillis: Long): String {
             state.chapters.find {
@@ -488,7 +521,12 @@ fun MediaProgressSlider(
         Slider(
             value = state.displayPositionRatio,
             valueRange = 0f..1f,
-            onValueChange = { state.previewPositionRatio(it) },
+            onValueChange = {
+                latestTouchPreviewRatio = it
+                if (!touchSeekCancelled) {
+                    state.previewPositionRatio(it)
+                }
+            },
             interactionSource = interactionSource,
             thumb = {
                 Canvas(Modifier.width(12.dp).height(24.dp)) {
@@ -542,12 +580,54 @@ fun MediaProgressSlider(
             },
             enabled = enabled,
             modifier = Modifier.fillMaxWidth().height(24.dp)
+                .onGloballyPositioned {
+                    sliderCoordinates = it
+                }
                 .onSizeChanged {
                     sliderWidth = it.width
                 }
                 .hoverable(interactionSource = hoverInteraction)
                 .onPointerEventMultiplatform(PointerEventType.Move) {
                     mousePosX = it.changes.firstOrNull()?.position?.x ?: return@onPointerEventMultiplatform
+                }
+                .pointerInput(touchSeekCancellation) {
+                    val cancellation = touchSeekCancellation ?: return@pointerInput
+                    awaitEachGesture {
+                        val down = awaitFirstDown(
+                            requireUnconsumed = false,
+                            pass = PointerEventPass.Initial,
+                        )
+                        if (down.type != PointerType.Touch) return@awaitEachGesture
+
+                        try {
+                            while (true) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                if (!change.pressed) break
+
+                                val coordinates = sliderCoordinates ?: continue
+                                val cancelled = cancellation.isInCancelArea(coordinates.localToRoot(change.position))
+                                if (cancelled == touchSeekCancelled) continue
+
+                                touchSeekCancelled = cancelled
+                                if (cancelled) {
+                                    cancellation.onCancellationChanged(true)
+                                    state.cancelPreview()
+                                } else {
+                                    if (!latestTouchPreviewRatio.isNaN()) {
+                                        state.previewPositionRatio(latestTouchPreviewRatio)
+                                    }
+                                    cancellation.onCancellationChanged(false)
+                                }
+                            }
+                        } finally {
+                            if (touchSeekCancelled) {
+                                state.cancelPreview()
+                                touchSeekCancelled = false
+                                cancellation.onCancellationChanged(false)
+                            }
+                        }
+                    }
                 },
         )
     }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -75,14 +75,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
@@ -616,6 +620,7 @@ object PlayerControllerDefaults {
         showPreviewTimeTextOnThumb: Boolean = true,
         framePreview: MediaProgressFramePreviewState? = null,
         showFramePreviewInPopup: Boolean = true,
+        touchSeekCancellation: TouchSeekCancellation? = null,
     ) {
         val cacheProgressInfo by cacheProgressInfoFlow.collectAsStateWithLifecycle(null)
         MediaProgressSlider(
@@ -624,6 +629,7 @@ object PlayerControllerDefaults {
             showPreviewTimeTextOnThumb = showPreviewTimeTextOnThumb,
             framePreview = framePreview,
             showFramePreviewInPopup = showFramePreviewInPopup,
+            touchSeekCancellation = touchSeekCancellation,
             modifier = modifier,
         )
     }
@@ -669,6 +675,7 @@ object PlayerControllerDefaults {
  * @param expanded Whether the controller bar is expanded.
  * If `true`, the [progressIndicator] and [progressSlider] will be shown on a separate row above. The bottom row will contain a [danmakuEditor].
  * If `false`, the entire bar will be only one row. [danmakuEditor] will be ignored.
+ * @param sliderOnly Whether to keep only [progressSlider] visible without replacing its composition.
  */
 @Composable
 fun PlayerControllerBar(
@@ -678,6 +685,7 @@ fun PlayerControllerBar(
     danmakuEditor: @Composable RowScope.() -> Unit,
     endActions: @Composable RowScope.() -> Unit,
     expanded: Boolean,
+    sliderOnly: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -692,6 +700,7 @@ fun PlayerControllerBar(
             ProvideTextStyle(MaterialTheme.typography.labelMedium) {
                 Row(
                     Modifier
+                        .keepLayoutWhenHidden(sliderOnly)
                         .padding(start = if (expanded) 8.dp else 4.dp)
                         .padding(vertical = if (expanded) 4.dp else 2.dp),
                 ) {
@@ -714,6 +723,7 @@ fun PlayerControllerBar(
         ) {
             // 播放 / 暂停按钮
             Row(
+                Modifier.keepLayoutWhenHidden(sliderOnly),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 startActions()
@@ -724,8 +734,10 @@ fun PlayerControllerBar(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (expanded) {
-                    ProvideTextStyle(MaterialTheme.typography.labelSmall) {
-                        danmakuEditor()
+                    Row(Modifier.keepLayoutWhenHidden(sliderOnly)) {
+                        ProvideTextStyle(MaterialTheme.typography.labelSmall) {
+                            danmakuEditor()
+                        }
                     }
                 } else {
                     progressSlider()
@@ -733,10 +745,24 @@ fun PlayerControllerBar(
             }
 
             Row(
+                Modifier.keepLayoutWhenHidden(sliderOnly),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 endActions()
             }
         }
     }
+}
+
+private fun Modifier.keepLayoutWhenHidden(hidden: Boolean): Modifier {
+    if (!hidden) return this
+    return alpha(0f)
+        .clearAndSetSemantics { }
+        .pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                }
+            }
+        }
 }

--- a/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
@@ -65,6 +65,58 @@ class PlayerControllerStateTest {
     }
 
     @Test
+    fun `detached slider request temporarily hides visible controller`() {
+        val state = PlayerControllerState(ControllerVisibility.Visible)
+        val requester = Any()
+
+        state.setRequestDetachedProgressSlider(requester)
+        assertEquals(ControllerVisibility.DetachedSliderOnly, state.visibility)
+
+        state.cancelRequestDetachedProgressSlider(requester)
+        assertEquals(ControllerVisibility.Visible, state.visibility)
+    }
+
+    @Test
+    fun `detached slider request takes priority over always on`() {
+        val state = PlayerControllerState(ControllerVisibility.Invisible)
+        val alwaysOnRequester = Any()
+        val sliderRequester = Any()
+        state.setRequestAlwaysOn(alwaysOnRequester, true)
+
+        state.setRequestDetachedProgressSlider(sliderRequester)
+        assertEquals(ControllerVisibility.DetachedSliderOnly, state.visibility)
+
+        state.cancelRequestDetachedProgressSlider(sliderRequester)
+        assertEquals(ControllerVisibility.Visible, state.visibility)
+    }
+
+    @Test
+    fun `inline slider request keeps bottom bar while hiding other controls`() {
+        val state = PlayerControllerState(ControllerVisibility.Visible)
+        val requester = Any()
+
+        state.setRequestInlineProgressSlider(requester)
+        assertEquals(ControllerVisibility.InlineSliderOnly, state.visibility)
+
+        state.cancelRequestInlineProgressSlider(requester)
+        assertEquals(ControllerVisibility.Visible, state.visibility)
+    }
+
+    @Test
+    fun `detached slider takes priority over inline slider`() {
+        val state = PlayerControllerState(ControllerVisibility.Visible)
+        val inlineRequester = Any()
+        val detachedRequester = Any()
+        state.setRequestInlineProgressSlider(inlineRequester)
+
+        state.setRequestDetachedProgressSlider(detachedRequester)
+        assertEquals(ControllerVisibility.DetachedSliderOnly, state.visibility)
+
+        state.cancelRequestDetachedProgressSlider(detachedRequester)
+        assertEquals(ControllerVisibility.InlineSliderOnly, state.visibility)
+    }
+
+    @Test
     fun `visibility when nothing`() {
         val state = createStateRequested(false, false, false)
         assertEquals(ControllerVisibility.Invisible, state.visibility)

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GestureIndicatorStateTest {
+    @Test
+    fun `seek cancellation remains visible until stopped`() {
+        val state = GestureIndicatorState()
+
+        val ticket = state.startSeekCancellation()
+        assertTrue(state.visible)
+        assertTrue(state.seekCancelled)
+
+        state.stopSeekCancellation(ticket)
+        assertFalse(state.visible)
+    }
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SwipeSeekerStateTest {
+    private val containerSize = IntSize(width = 1000, height = 600)
+
+    @Test
+    fun `releasing in top corner cancels seek`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+        state.onPointerMoved(Offset(100f, 100f), containerSize)
+
+        assertTrue(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(emptyList(), seeks)
+        assertFalse(state.isSeeking)
+        assertFalse(state.isCancelled)
+    }
+
+    @Test
+    fun `pointer entering cancel area before drag recognition is retained`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.onPointerMoved(Offset(100f, 100f), containerSize)
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+
+        assertTrue(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(emptyList(), seeks)
+    }
+
+    @Test
+    fun `moving out of top corner resumes seek`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+        state.onPointerMoved(Offset(900f, 100f), containerSize)
+        assertTrue(state.isCancelled)
+
+        state.onPointerMoved(Offset(500f, 300f), containerSize)
+        assertFalse(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(listOf(49), seeks)
+    }
+
+    @Test
+    fun `top center is outside cancel area`() {
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = {})
+
+        state.onSwipeStarted()
+        state.onPointerMoved(Offset(500f, 100f), containerSize)
+
+        assertFalse(state.isCancelled)
+    }
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PlayerProgressSliderStateTest {
+    @Test
+    fun `cancel preview does not finish seek`() {
+        val finishedPositions = mutableListOf<Long>()
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { 10_000L },
+            totalDurationMillis = { 100_000L },
+            chapters = { emptyList() },
+            onPreview = {},
+            onPreviewFinished = finishedPositions::add,
+        )
+
+        state.previewPositionRatio(0.5f)
+        state.cancelPreview()
+
+        assertFalse(state.isPreviewing)
+        assertEquals(emptyList(), finishedPositions)
+        assertEquals(0.1f, state.displayPositionRatio)
+    }
+}

--- a/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
+++ b/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SwipeToSeekTest {
+    @Test
+    fun `release in top corner cancels seek`() = runAniComposeUiTest {
+        val seeks = mutableListOf<Int>()
+        setContent {
+            BoxWithConstraints(Modifier.fillMaxSize()) {
+                val state = rememberSwipeSeekerState(constraints.maxWidth, onSeek = seeks::add)
+                Box(
+                    Modifier.fillMaxSize()
+                        .testTag("swipeTarget")
+                        .swipeToSeek(state, Orientation.Horizontal),
+                )
+            }
+        }
+
+        onNodeWithTag("swipeTarget").performTouchInput {
+            down(center)
+            moveTo(Offset(width * 0.4f, height * 0.5f))
+            moveTo(Offset(width * 0.1f, height * 0.1f))
+            up()
+        }
+
+        assertEquals(emptyList(), seeks)
+    }
+}


### PR DESCRIPTION
## 主要改动

优化 Android 端的触屏进度拖动交互，并实现 #2510 提出的 seek 取消能力。

- 屏幕横向滑动和直接拖动底部进度条使用一致的取消交互。
- 手指移入左上角或右上角取消区域后，持续显示“松开手指取消”。
- 移出取消区域后恢复进度预览；在取消区域内松手不会提交 seek。
- 拖动期间仅显示原位置的进度条，隐藏其他控制器元素。
- 隐藏控制器元素时保留原布局及上下渐变遮罩，避免进度条位移或闪动。
- 相关逻辑仅对 `GestureFamily.TOUCH` 生效，不改变 mouse/desktop 行为。

取消区域为播放器顶部 25% 高度内、左右各 25% 宽度的区域。

## 演示

<img width="960" height="436" alt="Android 进度拖动与取消交互" src="https://github.com/user-attachments/assets/f61f70e2-8a60-49b8-80da-85c89f7a33da" />

## 测试

- `:app:shared:desktopTest --tests '*EpisodeVideoControllerTest*'`
- `:app:shared:video-player:desktopTest`
- `:app:shared:video-player:testAndroidHostTest`
- `:app:shared:video-player:compileAndroidMain`
- `:app:shared:compileAndroidMain`

Closes #2510
