### PR TITLE
feat(player): improve Android seek interactions

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -721,6 +721,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即将跳过 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">松开手指取消</string>
     <string name="video_player_stats_title">播放信息</string>
     <string name="video_player_stats_title_show">显示播放信息</string>
     <string name="video_player_stats_title_hide">隐藏播放信息</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -696,6 +696,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即將跳過 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">放開手指取消</string>
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -685,6 +685,7 @@
     <string name="video_player_speed">倍速</string>
     <string name="video_player_skip_op_ed">即將跳過 OP 或 ED</string>
     <string name="video_player_cancel">取消</string>
+    <string name="video_player_release_to_cancel">放開手指取消</string>
     <string name="video_player_stats_title">播放資訊</string>
     <string name="video_player_stats_title_show">顯示播放資訊</string>
     <string name="video_player_stats_title_hide">隱藏播放資訊</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -681,6 +681,7 @@
     <string name="video_player_speed">Speed</string>
     <string name="video_player_skip_op_ed">Skipping OP or ED soon</string>
     <string name="video_player_cancel">Cancel</string>
+    <string name="video_player_release_to_cancel">Release to cancel</string>
     <string name="video_player_stats_title">Playback Info</string>
     <string name="video_player_stats_title_show">Show Playback Info</string>
     <string name="video_player_stats_title_hide">Hide Playback Info</string>

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -113,11 +113,14 @@ import me.him188.ani.app.videoplayer.ui.VideoPlayer
 import me.him188.ani.app.videoplayer.ui.VideoScaffold
 import me.him188.ani.app.videoplayer.ui.VideoSideSheetsController
 import me.him188.ani.app.videoplayer.ui.gesture.GestureFamily
+import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState
 import me.him188.ani.app.videoplayer.ui.gesture.GestureLock
 import me.him188.ani.app.videoplayer.ui.gesture.LevelController
 import me.him188.ani.app.videoplayer.ui.gesture.LockableVideoGestureHost
 import me.him188.ani.app.videoplayer.ui.gesture.NoOpLevelController
 import me.him188.ani.app.videoplayer.ui.gesture.ScreenshotButton
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerConfig
+import me.him188.ani.app.videoplayer.ui.gesture.isInCancelArea
 import me.him188.ani.app.videoplayer.ui.gesture.mouseFamily
 import me.him188.ani.app.videoplayer.ui.gesture.rememberGestureIndicatorState
 import me.him188.ani.app.videoplayer.ui.gesture.rememberSwipeSeekerState
@@ -133,6 +136,7 @@ import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults.VideoA
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
 import me.him188.ani.app.videoplayer.ui.progress.ProgressSliderCenteredPreviewFrame
 import me.him188.ani.app.videoplayer.ui.progress.SubtitleSwitcher
+import me.him188.ani.app.videoplayer.ui.progress.TouchSeekState
 import me.him188.ani.app.videoplayer.ui.progress.rememberMediaProgressSliderState
 import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.app.videoplayer.ui.rememberPlayerStatsState
@@ -222,6 +226,14 @@ internal fun EpisodeVideoImpl(
                     || anySideSheetVisible)
         }
     }
+    val indicatorState = rememberGestureIndicatorState()
+    // commonMain 中的 TOUCH 仅表示移动端触屏交互。CMP Desktop 尚无稳定的触控支持，
+    // 因此桌面端继续使用 MOUSE 分支，不启用进度条触摸取消状态机。
+    val touchSeekState = rememberPlayerTouchSeekState(
+        enabled = gestureFamily == GestureFamily.TOUCH,
+        controllerState = playerControllerState,
+        indicatorState = indicatorState,
+    )
 
     AniTheme(darkModeOverride = DarkMode.DARK) {
         val progressSliderColors = MediaProgressSliderDefaults.colors()
@@ -307,7 +319,6 @@ internal fun EpisodeVideoImpl(
                 }
 
                 val indicatorTasker = rememberUiMonoTasker()
-                val indicatorState = rememberGestureIndicatorState()
                 LockableVideoGestureHost(
                     playerControllerState,
                     swipeSeekerState,
@@ -376,6 +387,7 @@ internal fun EpisodeVideoImpl(
                     }
                 }
             },
+            touchSeekState = touchSeekState,
             framePreviewOverlay = {
                 if (!expanded) {
                     ProgressSliderCenteredPreviewFrame(
@@ -445,6 +457,7 @@ internal fun EpisodeVideoImpl(
                             showPreviewTimeTextOnThumb = expanded,
                             framePreview = framePreview,
                             showFramePreviewInPopup = expanded,
+                            touchSeekState = touchSeekState,
                         )
                     },
                     danmakuEditor = danmakuEditor,
@@ -494,12 +507,59 @@ internal fun EpisodeVideoImpl(
                         )
                     },
                     expanded = expanded,
+                    sliderOnly = playerControllerState.visibility == ControllerVisibility.InlineSliderOnly,
                 )
             },
             detachedProgressSlider = detachedProgressSlider,
             floatingBottomEnd = { fullscreenSwitchButton() },
             rhsSheet = { sideSheets(sheetsController) },
             leftBottomTips = leftBottomTips,
+        )
+    }
+}
+
+/**
+ * 将进度条的通用触摸状态机接入播放器 UI：拖动期间保留 inline progress slider，
+ * 手指进入取消区域时持续显示取消提示。非触屏分支返回 `null`，不改变原有交互。
+ */
+@Composable
+private fun rememberPlayerTouchSeekState(
+    enabled: Boolean,
+    controllerState: PlayerControllerState,
+    indicatorState: GestureIndicatorState,
+): TouchSeekState? {
+    if (!enabled) return null
+
+    return remember(controllerState, indicatorState) {
+        // requester 和 indicator ticket 跨状态迁移保持不变，确保每次请求都由同一实例撤销。
+        val controllerRequester = Any()
+        var indicatorTicket: Int? = null
+        fun stopCancellationIndicator() {
+            indicatorTicket?.let(indicatorState::stopSeekCancellation)
+            indicatorTicket = null
+        }
+        TouchSeekState(
+            isInCancelArea = SwipeSeekerConfig.Default::isInCancelArea,
+            onStateChanged = { state ->
+                when (state) {
+                    // 手势结束：恢复控制器的正常显隐，并关闭可能存在的取消提示。
+                    TouchSeekState.State.Idle -> {
+                        controllerState.cancelRequestInlineProgressSlider(controllerRequester)
+                        stopCancellationIndicator()
+                    }
+
+                    // 正常拖动：保留 bottom bar 内正在接收触摸事件的原进度条。
+                    TouchSeekState.State.Seeking -> {
+                        controllerState.setRequestInlineProgressSlider(controllerRequester)
+                        stopCancellationIndicator()
+                    }
+
+                    // 进入取消区域：进度条保持原位，只将中央指示器切换为取消提示。
+                    TouchSeekState.State.Cancelling -> {
+                        indicatorTicket = indicatorState.startSeekCancellation()
+                    }
+                }
+            },
         )
     }
 }

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -156,6 +157,15 @@ class EpisodeVideoControllerTest {
             rhsBar = false,
             gestureLock = false,
             detachedSlider = true,
+        )
+
+        private val PREVIEW_INLINE_SLIDER = ControllerVisibility(
+            topBar = false,
+            bottomBar = true,
+            floatingBottomEnd = false,
+            rhsBar = false,
+            gestureLock = false,
+            detachedSlider = false,
         )
     }
 
@@ -1117,7 +1127,7 @@ class EpisodeVideoControllerTest {
      * @see GestureFamily.swipeToSeek
      */
     @Test
-    fun `touch - swipeToSeek shows detached slider`() = runAniComposeUiTest {
+    fun `touch - swipeToSeek shows detached slider when controller is hidden`() = runAniComposeUiTest {
         setContent {
             Player(GestureFamily.TOUCH)
         }
@@ -1157,7 +1167,7 @@ class EpisodeVideoControllerTest {
      * @see GestureFamily.swipeToSeek
      */
     @Test
-    fun `touch - swipe when controller is already fully visible`() = runAniComposeUiTest {
+    fun `touch - swipe hides visible controls without moving slider`() = runAniComposeUiTest {
         setContent {
             Player(GestureFamily.TOUCH)
         }
@@ -1173,6 +1183,7 @@ class EpisodeVideoControllerTest {
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
             detachedProgressSlider.assertDoesNotExist()
         }
+        val progressSliderBoundsBeforeDrag = progressSlider.fetchSemanticsNode().boundsInRoot
 
         runOnUiThread {
             root.performTouchInput {
@@ -1181,9 +1192,18 @@ class EpisodeVideoControllerTest {
             }
         }
         runOnIdle {
+            mainClock.advanceTimeBy(1000L)
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { previewPopup.exists() }
+            // Top controls remain laid out but are drawn transparently, preserving the top scrim.
+            topBar.assertExists()
             detachedProgressSlider.assertDoesNotExist()
-            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            progressSlider.assertExists()
+            assertEquals(
+                progressSliderBoundsBeforeDrag,
+                progressSlider.fetchSemanticsNode().boundsInRoot,
+            )
+            onNodeWithTag(TAG_PROGRESS_SLIDER_PREVIEW_FRAME, useUnmergedTree = true).assertDoesNotExist()
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
         }
 
         runOnUiThread {
@@ -1192,6 +1212,7 @@ class EpisodeVideoControllerTest {
             }
         }
         runOnIdle {
+            mainClock.advanceTimeBy(1000L)
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { previewPopup.doesNotExist() }
             detachedProgressSlider.assertDoesNotExist()
             assertEquals(NORMAL_VISIBLE, controllerState.visibility)
@@ -1255,10 +1276,11 @@ class EpisodeVideoControllerTest {
             moveBy(Offset(centerX, 0f))
         }
         waitForIdle() // does nothing because autoAdvance is false
-        mainClock.advanceTimeByFrame() // renders the next frame (i.e. update derivedStateOf and Text)
-        mediaProgressIndicatorText.assertTextEquals("00:47 / 01:40")
+        mainClock.advanceTimeBy(1000L)
+        previewPopup.assertExists()
+        onAllNodesWithText("00:47", useUnmergedTree = true).onFirst().assertExists()
         runOnUiThread {
-            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            assertEquals(PREVIEW_INLINE_SLIDER, controllerState.visibility)
         }
 
         // 松开手指
@@ -1289,6 +1311,7 @@ class EpisodeVideoControllerTest {
                 waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
                 detachedProgressSlider.assertDoesNotExist()
             }
+            val progressSliderBoundsBeforeDrag = progressSlider.fetchSemanticsNode().boundsInRoot
 
             runOnUiThread {
                 progressSlider.performTouchInput {
@@ -1297,8 +1320,20 @@ class EpisodeVideoControllerTest {
                 }
             }
             runOnIdle {
-                waitUntil(timeoutMillis = WAIT_TIMEOUT) { onNodeWithText("00:48 / 01:40").exists() }
-                assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+                mainClock.advanceTimeBy(1000L)
+                waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                    controllerState.visibility == ControllerVisibility.InlineSliderOnly
+                }
+                topBar.assertExists()
+                // Other controller content stays composed so the slider keeps the same layout,
+                // but PlayerControllerBar draws it transparently while dragging.
+                mediaProgressIndicatorText.assertExists()
+                progressSlider.assertExists()
+                assertEquals(
+                    progressSliderBoundsBeforeDrag,
+                    progressSlider.fetchSemanticsNode().boundsInRoot,
+                )
+                assertEquals(true, progressSliderState.isPreviewing)
             }
 
             // 松开手指
@@ -1320,6 +1355,96 @@ class EpisodeVideoControllerTest {
                 assertEquals(NORMAL_VISIBLE, controllerState.visibility)
             }
         }
+
+    @Test
+    fun `touch - progress slider drag can be cancelled`() = runAniComposeUiTest {
+        setContent {
+            Player(GestureFamily.TOUCH)
+        }
+        waitForIdle()
+        val root = onAllNodes(isRoot()).onFirst()
+
+        mainClock.autoAdvance = false
+        root.performClick()
+        mainClock.advanceTimeBy(1000L)
+        waitForIdle()
+
+        val playerBounds = player.fetchSemanticsNode().boundsInRoot
+        val sliderBounds = progressSlider.fetchSemanticsNode().boundsInRoot
+        progressSlider.performTouchInput {
+            down(centerLeft)
+            moveTo(Offset(width * 0.75f, centerY))
+        }
+        runOnIdle {
+            assertEquals(true, progressSliderState.isPreviewing)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(playerBounds.topLeft + Offset(1f, 1f) - sliderBounds.topLeft)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").exists()
+            }
+            assertEquals(false, progressSliderState.isPreviewing)
+            assertEquals(ControllerVisibility.InlineSliderOnly, controllerState.visibility)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(Offset(width * 0.6f, centerY))
+        }
+        runOnIdle {
+            mainClock.advanceTimeBy(1000L)
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").doesNotExist()
+            }
+            assertEquals(true, progressSliderState.isPreviewing)
+        }
+
+        progressSlider.performTouchInput {
+            moveTo(playerBounds.topLeft + Offset(1f, 1f) - sliderBounds.topLeft)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").exists()
+            }
+        }
+
+        progressSlider.performTouchInput {
+            up()
+        }
+        runOnIdle {
+            mainClock.advanceTimeBy(1000L)
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) {
+                onNodeWithText("Release to cancel").doesNotExist()
+            }
+            assertEquals(0L, currentPositionMillis)
+            assertEquals(false, progressSliderState.isPreviewing)
+        }
+    }
+
+    @Test
+    fun `mouse - previewing progress slider keeps full controller visible`() = runAniComposeUiTest {
+        setContent {
+            Player(GestureFamily.MOUSE)
+        }
+        waitForIdle()
+
+        runOnUiThread {
+            controllerState.toggleFullVisible(true)
+            progressSliderState.previewPositionRatio(0.5f)
+        }
+        runOnIdle {
+            waitUntil(timeoutMillis = WAIT_TIMEOUT) { topBar.exists() }
+            assertEquals(NORMAL_VISIBLE, controllerState.visibility)
+            mediaProgressIndicatorText.assertExists()
+            progressSlider.assertExists()
+        }
+
+        runOnUiThread {
+            progressSliderState.cancelPreview()
+        }
+    }
 
     /**
      * @see GestureFamily.swipeToSeek

--- a/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/PlayerControllerState.kt
@@ -153,6 +153,9 @@ data class ControllerVisibility(
             detachedSlider = false,
         )
 
+        /**
+         * 控制器原本隐藏时的 seek 指示状态：只展示固定在播放器底部的独立进度条。
+         */
         @Stable
         val DetachedSliderOnly = ControllerVisibility(
             topBar = false,
@@ -161,6 +164,20 @@ data class ControllerVisibility(
             rhsBar = false,
             gestureLock = false,
             detachedSlider = true,
+        )
+
+        /**
+         * 已有底栏交互时的 seek 状态：保留底栏原进度条及其布局，其他控制器元素仅在视觉上隐藏。
+         * 直接拖动进度条必须使用此状态，避免替换正在接收触摸事件的组件。
+         */
+        @Stable
+        val InlineSliderOnly = ControllerVisibility(
+            topBar = false,
+            bottomBar = true,
+            floatingBottomEnd = false,
+            rhsBar = false,
+            gestureLock = false,
+            detachedSlider = false,
         )
     }
 }
@@ -177,12 +194,16 @@ class PlayerControllerState(
 
     private var fullVisible by mutableStateOf(initialVisibility == ControllerVisibility.Visible)
     private val hasProgressBarRequester by derivedStateOf { progressBarRequesters.isNotEmpty() }
+    private val hasInlineProgressSliderRequester by derivedStateOf {
+        inlineProgressSliderRequesters.isNotEmpty()
+    }
 
     /**
      * 当前 UI 应当显示的状态
      */
     val visibility: ControllerVisibility by derivedStateOf {
         // 根据 hasProgressBarRequester, alwaysOn 和 fullVisible 计算正确的 `ControllerVisibility`
+        if (hasInlineProgressSliderRequester) return@derivedStateOf ControllerVisibility.InlineSliderOnly
         if (alwaysOn) return@derivedStateOf ControllerVisibility.Visible
         if (fullVisible) return@derivedStateOf ControllerVisibility.Visible
         if (hasProgressBarRequester) return@derivedStateOf ControllerVisibility.DetachedSliderOnly
@@ -229,12 +250,40 @@ class PlayerControllerState(
 
     private val progressBarRequesters = SnapshotStateList<Any>()
 
+    private val inlineProgressSliderRequesters = SnapshotStateList<Any>()
+
     /**
-     * 请求显示进度条
-     * 当目前没有显示进度条时, 将显示独立的进度条.
-     * 若目前已经有进度条, 则会保持该状态, 防止自动关闭.
+     * 请求只显示底部控制栏内已有的 inline progress slider.
      *
-     * @param requester 是谁希望请求显示进度条. 在 [cancelRequestProgressBarVisible] 时需要传入相同实例. 同一时刻有任一 requester 则会让进度条一直显示.
+     * 该进度条属于 bottom bar；进入此模式后仍保留整个 bottom bar 的布局，
+     * 只是将进度条以外的控制器元素隐藏。因此正在接收触摸事件的进度条不会被替换。
+     * 适用于直接拖动进度条，或控制器可见时开始的屏幕横滑。
+     *
+     * [setRequestProgressBar] 请求的则是 bottom bar 之外的另一个 detached progress slider，
+     * 用于控制器隐藏时的屏幕横滑，不能代替正在接收触摸事件的 inline progress slider.
+     *
+     * @param requester 请求方；取消时必须将同一实例传给 [cancelRequestInlineProgressSlider].
+     */
+    fun setRequestInlineProgressSlider(requester: Any) {
+        if (requester in inlineProgressSliderRequesters) return
+        inlineProgressSliderRequesters.add(requester)
+    }
+
+    fun cancelRequestInlineProgressSlider(requester: Any) {
+        inlineProgressSliderRequesters.remove(requester)
+    }
+
+    /**
+     * 请求在控制器隐藏时显示独立的 detached progress slider.
+     *
+     * 该进度条位于 bottom bar 之外，是专门用于指示屏幕横滑 seek 的另一个组件；
+     * 它不会保留或复用 bottom bar 内的 inline progress slider.
+     * 适用于控制器隐藏时开始的屏幕横滑。
+     *
+     * 如果控制器当前完整显示，则完整控制器优先；控制器隐藏后，只要本请求仍存在，
+     * 就会显示 detached progress slider，而不是让进度指示一并消失。
+     *
+     * @param requester 请求方；取消时必须将同一实例传给 [cancelRequestProgressBarVisible].
      */
     fun setRequestProgressBar(requester: Any) {
         if (requester in progressBarRequesters) return

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -40,9 +40,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
@@ -50,6 +54,7 @@ import me.him188.ani.app.ui.foundation.layout.desktopTitleBar
 import me.him188.ani.app.ui.foundation.theme.slightlyWeaken
 import me.him188.ani.app.videoplayer.ui.gesture.PlayerGestureHost
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerBar
+import me.him188.ani.app.videoplayer.ui.progress.TouchSeekState
 import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
 
 /**
@@ -100,7 +105,9 @@ fun VideoScaffold(
     centerOverlay: @Composable BoxScope.() -> Unit = {},
     framePreviewOverlay: @Composable BoxScope.() -> Unit = {},
     playerStatsOverlay: @Composable BoxScope.() -> Unit = {},
+    touchSeekState: TouchSeekState? = null,
 ) {
+    val inlineSliderOnly = controllerState.visibility == ControllerVisibility.InlineSliderOnly
     val controllerVisibility = controllerState.visibility
         .withGestureLocked(gestureLocked)
         .withExpanded(expanded)
@@ -113,6 +120,9 @@ fun VideoScaffold(
     ) { // 16:9 box
         Box(
             Modifier
+                .onGloballyPositioned {
+                    touchSeekState?.containerCoordinates = it
+                }
                 .then(
                     if (!maintainAspectRatio) {
                         Modifier.fillMaxSize()
@@ -161,7 +171,7 @@ fun VideoScaffold(
                 Column(Modifier.fillMaxSize().background(Color.Transparent)) {
                     // 顶部控制栏: 返回键, 标题, 设置
                     me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility(
-                        visible = controllerVisibility.topBar,
+                        visible = controllerVisibility.topBar || inlineSliderOnly,
                         enter = enterTransition,
                         exit = exitTransition,
                     ) {
@@ -181,6 +191,7 @@ fun VideoScaffold(
 
                             Column(
                                 Modifier
+                                    .keepLayoutWhenHidden(inlineSliderOnly)
                                     .hoverToRequestAlwaysOn(alwaysOnRequester)
                                     .fillMaxWidth(),
                             ) {
@@ -206,6 +217,7 @@ fun VideoScaffold(
 
                             Box(
                                 Modifier.matchParentSize()
+                                    .keepLayoutWhenHidden(inlineSliderOnly)
                                     .windowInsetsPadding(contentWindowInsets.only(WindowInsetsSides.Top))
                                     .padding(top = 8.dp),
                                 contentAlignment = Alignment.TopCenter,
@@ -360,6 +372,19 @@ fun VideoScaffold(
             }
         }
     }
+}
+
+internal fun Modifier.keepLayoutWhenHidden(hidden: Boolean): Modifier {
+    if (!hidden) return this
+    return alpha(0f)
+        .clearAndSetSemantics { }
+        .pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                }
+            }
+        }
 }
 
 

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.BrightnessHigh
 import androidx.compose.material.icons.rounded.BrightnessLow
 import androidx.compose.material.icons.rounded.BrightnessMedium
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
@@ -50,6 +51,7 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -79,6 +81,7 @@ import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.isSystemInFullscreen
+import me.him188.ani.app.ui.lang.*
 import me.him188.ani.app.utils.fixToString
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
@@ -93,10 +96,10 @@ import me.him188.ani.app.videoplayer.ui.gesture.GestureIndicatorState.State.VOLU
 import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
 import me.him188.ani.app.videoplayer.ui.playerFocusHost
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
-import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.utils.platform.Platform
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.features.AudioLevelController
+import org.jetbrains.compose.resources.stringResource
 import kotlin.math.absoluteValue
 import kotlin.time.Duration.Companion.seconds
 
@@ -124,6 +127,7 @@ class GestureIndicatorState {
     internal var state: State? by mutableStateOf(null)
     internal var progressValue: Float by mutableFloatStateOf(0f)
     internal var deltaSeconds: Int by mutableIntStateOf(0)
+    internal var seekCancelled: Boolean by mutableStateOf(false)
     private var counter: Int = 0
 
     private inline fun startShow(
@@ -194,9 +198,24 @@ class GestureIndicatorState {
     suspend fun showSeeking(
         deltaSeconds: Int,
     ) {
-        show(SEEKING, setup = { this.deltaSeconds = deltaSeconds }) {
+        show(SEEKING, setup = {
+            this.deltaSeconds = deltaSeconds
+            seekCancelled = false
+        }) {
             delay(SHORT)
         }
+    }
+
+    @UiThread
+    fun startSeekCancellation(): Int {
+        return startShow(SEEKING) {
+            seekCancelled = true
+        }
+    }
+
+    @UiThread
+    fun stopSeekCancellation(ticket: Int) {
+        stopShow(ticket)
     }
 
     @UiThread
@@ -236,15 +255,17 @@ class GestureIndicatorState {
 @Composable
 fun GestureIndicator(
     state: GestureIndicatorState,
+    swipeSeekerState: SwipeSeekerState? = null,
 ) {
     val shape = MaterialTheme.shapes.small
     val colors = MaterialTheme.colorScheme
+    val activeSwipeSeekerState = swipeSeekerState?.takeIf { it.isSeeking }
     var lastDelta by remember(state) {
         mutableIntStateOf(state.deltaSeconds)
     }
 
     AniAnimatedVisibility(
-        visible = state.visible,
+        visible = state.visible || activeSwipeSeekerState != null,
         enter = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
         exit = fadeOut(tween(durationMillis = 500)),
         label = "SeekPositionIndicator",
@@ -280,7 +301,7 @@ fun GestureIndicator(
                         }
                     }
 
-                    when (state.state) {
+                    when (if (activeSwipeSeekerState != null) SEEKING else state.state) {
                         RESUMED_ONCE -> {
                             Icon(
                                 Icons.Rounded.PlayArrow, null,
@@ -293,7 +314,8 @@ fun GestureIndicator(
                         }
 
                         SEEKING -> {
-                            val deltaDuration = state.deltaSeconds
+                            val deltaDuration = activeSwipeSeekerState?.deltaSeconds ?: state.deltaSeconds
+                            val seekCancelled = activeSwipeSeekerState?.isCancelled ?: state.seekCancelled
                             // 记忆变为 0 之前的 delta, 这样在快进/快退结束后, 会显示上一次的 delta, 而不是显示 0
                             val duration = if (deltaDuration == 0) {
                                 lastDelta
@@ -304,17 +326,20 @@ fun GestureIndicator(
                             }
 
                             Icon(
-                                if (duration > 0) {
-                                    Icons.Rounded.FastForward
-                                } else {
-                                    Icons.Rounded.FastRewind
+                                when {
+                                    seekCancelled -> Icons.Rounded.Close
+                                    duration > 0 -> Icons.Rounded.FastForward
+                                    else -> Icons.Rounded.FastRewind
                                 },
-                                null,
-                                Modifier.size(iconSize),
+                                contentDescription = null,
+                                modifier = Modifier.size(iconSize),
                             )
-                            val text = renderTime(duration.absoluteValue)
                             Text(
-                                text,
+                                text = if (seekCancelled) {
+                                    stringResource(Lang.video_player_release_to_cancel)
+                                } else {
+                                    renderTime(duration.absoluteValue)
+                                },
                                 maxLines = 1,
                             )
                         }
@@ -413,6 +438,78 @@ enum class GestureFamily(
 val VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION = 3.seconds
 val VIDEO_GESTURE_TOUCH_SHOW_CONTROLLER_DURATION = 3.seconds
 
+/**
+ * 将屏幕横滑 seek 的状态迁移映射到控制器显隐和进度预览。
+ * [SwipeSeekerState] 负责识别手势，本类只响应开始、取消区域变化和结束事件。
+ */
+private class SwipeSeekInteraction(
+    private val controllerState: PlayerControllerState,
+    private val seekerState: SwipeSeekerState,
+    private val progressSliderState: PlayerProgressSliderState,
+) {
+    fun onStarted() {
+        if (controllerState.visibility.bottomBar) {
+            controllerState.setRequestInlineProgressSlider(this)
+        } else {
+            controllerState.setRequestProgressBar(this)
+        }
+    }
+
+    fun onCancellationChanged(cancelled: Boolean) {
+        if (cancelled) {
+            progressSliderState.cancelPreview()
+        } else {
+            updatePreview()
+        }
+    }
+
+    fun updatePreview() {
+        if (seekerState.isCancelled) {
+            progressSliderState.cancelPreview()
+            return
+        }
+        if (progressSliderState.totalDurationMillis == 0L) return
+
+        val previewPositionMillis =
+            progressSliderState.currentPositionMillis + seekerState.deltaSeconds.times(1000)
+        val offsetRatio = previewPositionMillis.toFloat() / progressSliderState.totalDurationMillis
+        progressSliderState.previewPositionRatio(offsetRatio.coerceIn(0f, 1f))
+    }
+
+    fun onStopped(cancelled: Boolean) {
+        cancelControllerRequest()
+        if (cancelled) {
+            progressSliderState.cancelPreview()
+        } else {
+            progressSliderState.finishPreview()
+        }
+    }
+
+    fun dispose() {
+        cancelControllerRequest()
+    }
+
+    private fun cancelControllerRequest() {
+        controllerState.cancelRequestInlineProgressSlider(this)
+        controllerState.cancelRequestProgressBarVisible(this)
+    }
+}
+
+@Composable
+private fun rememberSwipeSeekInteraction(
+    controllerState: PlayerControllerState,
+    seekerState: SwipeSeekerState,
+    progressSliderState: PlayerProgressSliderState,
+): SwipeSeekInteraction {
+    val interaction = remember(controllerState, seekerState, progressSliderState) {
+        SwipeSeekInteraction(controllerState, seekerState, progressSliderState)
+    }
+    DisposableEffect(interaction) {
+        onDispose(interaction::dispose)
+    }
+    return interaction
+}
+
 @Composable
 fun PlayerGestureHost(
     controllerState: PlayerControllerState,
@@ -441,12 +538,7 @@ fun PlayerGestureHost(
                 .systemGesturesPadding()
                 .padding(top = 16.dp),
         ) {
-            LaunchedEffect(seekerState.deltaSeconds) {
-                if (seekerState.isSeeking) {
-                    indicatorState.showSeeking(seekerState.deltaSeconds)
-                }
-            }
-            GestureIndicator(indicatorState)
+            GestureIndicator(indicatorState, swipeSeekerState = seekerState)
         }
         val maxHeight = maxHeight
         val adjustingVolumeOrBrightness =
@@ -564,32 +656,27 @@ fun PlayerGestureHost(
             keyboardModifier
                 .combineClickableWithFamilyGesture()
                 .ifThen(family.swipeToSeek && enableSwipeToSeek) {
-                    val swipeToSeekRequester = rememberAlwaysOnRequester(controllerState, "swipeToSeek")
+                    val swipeSeekInteraction = rememberSwipeSeekInteraction(
+                        controllerState,
+                        seekerState,
+                        progressSliderState,
+                    )
                     swipeToSeek(
                         seekerState,
                         Orientation.Horizontal,
                         //调节音量/亮度时禁用水平seek
                         enabled = !adjustingVolumeOrBrightness,
                         onDragStarted = {
-                            if (controllerState.visibility.bottomBar) {
-                                swipeToSeekRequester.request()
-                            }
-                            controllerState.setRequestProgressBar(swipeToSeekRequester)
+                            swipeSeekInteraction.onStarted()
                         },
-                        onDragStopped = {
-                            if (controllerState.visibility.bottomBar) {
-                                swipeToSeekRequester.cancelRequest()
-                            }
-                            controllerState.cancelRequestProgressBarVisible(swipeToSeekRequester)
-                            progressSliderState.finishPreview()
+                        onDragStopped = { _, cancelled ->
+                            swipeSeekInteraction.onStopped(cancelled)
+                        },
+                        onCancellationChanged = { cancelled ->
+                            swipeSeekInteraction.onCancellationChanged(cancelled)
                         },
                     ) {
-                        progressSliderState.run {
-                            if (totalDurationMillis == 0L) return@run
-                            val offsetRatio =
-                                (currentPositionMillis + seekerState.deltaSeconds.times(1000)).toFloat() / totalDurationMillis
-                            previewPositionRatio(offsetRatio.coerceIn(0f, 1f))
-                        }
+                        swipeSeekInteraction.updatePreview()
                     }
                 }
                 .onPointerEventMultiplatform(PointerEventType.Move) { event ->

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
@@ -20,13 +20,19 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CoroutineScope
+import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import kotlin.math.roundToInt
 
 
@@ -58,9 +64,40 @@ data class SwipeSeekerConfig(
     // 用户不能从最左边开始滑. 因此稍微留了点余量.
     // 实测差不多可以滑到 87 秒, 看三秒 op 让他知道他完了 op
     val maxDragSeconds: Int = 97,
+    /**
+     * 屏幕顶部作为取消区域的高度占比.
+     */
+    val cancelAreaHeightRatio: Float = 0.25f,
+    /**
+     * 屏幕左右两侧各自作为取消区域的宽度占比.
+     */
+    val cancelAreaWidthRatio: Float = 0.25f,
 ) {
     companion object {
         val Default = SwipeSeekerConfig()
+    }
+}
+
+fun SwipeSeekerConfig.isInCancelArea(position: Offset, containerSize: IntSize): Boolean {
+    if (!position.isSpecified || containerSize.width <= 0 || containerSize.height <= 0) return false
+
+    val inTopArea = position.y <= containerSize.height * cancelAreaHeightRatio
+    val inLeftArea = position.x <= containerSize.width * cancelAreaWidthRatio
+    val inRightArea = position.x >= containerSize.width * (1f - cancelAreaWidthRatio)
+    return inTopArea && (inLeftArea || inRightArea)
+}
+
+// draggable 继续负责识别单轴 seek；这里只观察二维位置，并在进入或离开取消区域时通知上层。
+private fun Modifier.trackSwipeSeekCancellation(
+    seekerState: SwipeSeekerState,
+    onCancellationChanged: (Boolean) -> Unit,
+): Modifier = onPointerEventMultiplatform(
+    PointerEventType.Move,
+    pass = PointerEventPass.Initial,
+) { event ->
+    val change = event.changes.firstOrNull() ?: return@onPointerEventMultiplatform
+    if (seekerState.updateCancellation(change.position, size)) {
+        onCancellationChanged(seekerState.isCancelled)
     }
 }
 
@@ -81,22 +118,49 @@ class SwipeSeekerState(
      */
     private var seekDelta: Float by mutableFloatStateOf(Float.NaN)
 
+    /**
+     * 当前滑动是否已进入取消区域.
+     */
+    var isCancelled: Boolean by mutableStateOf(false)
+        private set
+
+    private var lastPointerPosition: Offset = Offset.Unspecified
+    private var lastPointerContainerSize: IntSize = IntSize.Zero
+
     @UiThread
-    private fun onSwipeStarted() {
+    internal fun onSwipeStarted() {
         seekDelta = 0f
+        isCancelled = isInCancelArea(lastPointerPosition, lastPointerContainerSize)
     }
 
     @UiThread
-    private fun onSwipeStopped() {
+    internal fun onSwipeStopped() {
         if (seekDelta.isNaN()) return
-        onSeek(deltaSeconds)
+        if (!isCancelled) {
+            onSeek(deltaSeconds)
+        }
         seekDelta = Float.NaN
+        isCancelled = false
     }
 
     @UiThread
-    private fun onSwipeOffset(offsetPx: Float) {
+    internal fun onSwipeOffset(offsetPx: Float) {
         seekDelta += offsetPx
     }
+
+    @UiThread
+    internal fun updateCancellation(position: Offset, containerSize: IntSize): Boolean {
+        val wasCancelled = isCancelled
+        lastPointerPosition = position
+        lastPointerContainerSize = containerSize
+        if (isSeeking) {
+            isCancelled = isInCancelArea(position, containerSize)
+        }
+        return isCancelled != wasCancelled
+    }
+
+    private fun isInCancelArea(position: Offset, containerSize: IntSize): Boolean =
+        swipeSeekerConfig.isInCancelArea(position, containerSize)
 
     /**
      * 是否正在快进, 即用户是否正在滑动屏幕
@@ -133,7 +197,8 @@ class SwipeSeekerState(
             interactionSource: MutableInteractionSource? = null,
             reverseDirection: Boolean = false,
             onDragStarted: suspend CoroutineScope.(startedPosition: Offset) -> Unit = {},
-            onDragStopped: suspend CoroutineScope.(velocity: Float) -> Unit = {},
+            onDragStopped: suspend CoroutineScope.(velocity: Float, cancelled: Boolean) -> Unit = { _, _ -> },
+            onCancellationChanged: (cancelled: Boolean) -> Unit = {},
             onDelta: (Float) -> Unit = {},
         ): Modifier {
             return composed(
@@ -153,13 +218,14 @@ class SwipeSeekerState(
                         onDragStarted(it)
                     },
                     onDragStopped = {
+                        val cancelled = seekerState.isCancelled
                         seekerState.onSwipeStopped()
-                        onDragStopped(it)
+                        onDragStopped(it, cancelled)
                     },
                     enabled = enabled,
                     interactionSource = interactionSource,
                     reverseDirection = reverseDirection,
-                )
+                ).trackSwipeSeekCancellation(seekerState, onCancellationChanged)
             }
         }
     }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
@@ -57,7 +57,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -157,6 +161,13 @@ class PlayerProgressSliderState(
         onPreviewFinished((ratio * totalDurationMillis).roundToLong())
         previewPositionRatio = Float.NaN
     }
+
+    /**
+     * Stops previewing without seeking to the previewed position.
+     */
+    fun cancelPreview() {
+        previewPositionRatio = Float.NaN
+    }
 }
 
 private class Data(
@@ -253,6 +264,63 @@ class MediaProgressSliderColors(
 )
 
 /**
+ * 直接拖动进度条时的触摸手势状态机, 不参与鼠标交互.
+ *
+ * 状态只按以下路径迁移:
+ * ```
+ * Idle --start--> Seeking
+ * Seeking --move into cancel area--> Cancelling
+ * Cancelling --move out--> Seeking
+ * Seeking / Cancelling --stop--> Idle
+ * ```
+ * [move] 根据手指是否位于取消区域，在 [State.Seeking] 和 [State.Cancelling] 之间切换；
+ * [stop] 返回松手时是否处于取消状态，供进度条决定提交或放弃 seek.
+ * [onStateChanged] 只在状态实际变化时调用，控制器显隐和取消提示统一在这里响应.
+ */
+@Stable
+class TouchSeekState(
+    val isInCancelArea: (position: Offset, containerSize: IntSize) -> Boolean,
+    val onStateChanged: (State) -> Unit,
+) {
+    enum class State {
+        Idle,
+        Seeking,
+        Cancelling,
+    }
+
+    var state: State = State.Idle
+        private set
+
+    internal var containerCoordinates: LayoutCoordinates? = null
+
+    internal fun start() {
+        transitionTo(State.Seeking)
+    }
+
+    internal fun move(sliderCoordinates: LayoutCoordinates, position: Offset): Boolean {
+        val containerCoordinates = containerCoordinates ?: return false
+        val cancelling = isInCancelArea(
+            containerCoordinates.localPositionOf(sliderCoordinates, position),
+            containerCoordinates.size,
+        )
+        return transitionTo(if (cancelling) State.Cancelling else State.Seeking)
+    }
+
+    internal fun stop(): Boolean {
+        val cancelled = state == State.Cancelling
+        transitionTo(State.Idle)
+        return cancelled
+    }
+
+    private fun transitionTo(newState: State): Boolean {
+        if (state == newState) return false
+        state = newState
+        onStateChanged(newState)
+        return true
+    }
+}
+
+/**
  * 视频播放器的进度条, 支持拖动调整播放位置, 支持显示缓冲进度.
  */
 @Composable
@@ -264,6 +332,7 @@ fun MediaProgressSlider(
     showPreviewTimeTextOnThumb: Boolean = true,
     framePreview: MediaProgressFramePreviewState? = null,
     showFramePreviewInPopup: Boolean = true,
+    touchSeekState: TouchSeekState? = null,
 //    drawThumb: @Composable DrawScope.() -> Unit = {
 //        drawCircle(
 //            MaterialTheme.colorScheme.primary,
@@ -384,6 +453,9 @@ fun MediaProgressSlider(
         var mousePosX by rememberSaveable { mutableStateOf(0f) }
         var thumbWidth by rememberSaveable { mutableIntStateOf(0) }
         var sliderWidth by rememberSaveable { mutableIntStateOf(0) }
+        var sliderCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+        var latestTouchPreviewRatio by remember { mutableFloatStateOf(Float.NaN) }
+        var handlingTouchInput by remember { mutableStateOf(false) }
 
         fun renderPreviewTime(previewTimeMillis: Long): String {
             state.chapters.find {
@@ -488,7 +560,15 @@ fun MediaProgressSlider(
         Slider(
             value = state.displayPositionRatio,
             valueRange = 0f..1f,
-            onValueChange = { state.previewPositionRatio(it) },
+            onValueChange = {
+                if (handlingTouchInput && touchSeekState?.state == TouchSeekState.State.Idle) {
+                    touchSeekState.start()
+                }
+                latestTouchPreviewRatio = it
+                if (touchSeekState?.state != TouchSeekState.State.Cancelling) {
+                    state.previewPositionRatio(it)
+                }
+            },
             interactionSource = interactionSource,
             thumb = {
                 Canvas(Modifier.width(12.dp).height(24.dp)) {
@@ -538,16 +618,50 @@ fun MediaProgressSlider(
                 )
             },
             onValueChangeFinished = {
-                state.finishPreview()
+                val cancelled = handlingTouchInput && touchSeekState?.stop() == true
+                handlingTouchInput = false
+                if (cancelled) {
+                    state.cancelPreview()
+                } else {
+                    state.finishPreview()
+                }
             },
             enabled = enabled,
             modifier = Modifier.fillMaxWidth().height(24.dp)
+                .onGloballyPositioned {
+                    sliderCoordinates = it
+                }
                 .onSizeChanged {
                     sliderWidth = it.width
                 }
                 .hoverable(interactionSource = hoverInteraction)
-                .onPointerEventMultiplatform(PointerEventType.Move) {
-                    mousePosX = it.changes.firstOrNull()?.position?.x ?: return@onPointerEventMultiplatform
+                .onPointerEventMultiplatform(
+                    PointerEventType.Press,
+                    pass = PointerEventPass.Initial,
+                ) { event ->
+                    handlingTouchInput = event.changes.firstOrNull()?.type == PointerType.Touch
+                }
+                .onPointerEventMultiplatform(
+                    PointerEventType.Move,
+                    pass = PointerEventPass.Initial,
+                ) { event ->
+                    val change = event.changes.firstOrNull() ?: return@onPointerEventMultiplatform
+                    mousePosX = change.position.x
+
+                    val touchSeekState = touchSeekState ?: return@onPointerEventMultiplatform
+                    if (!handlingTouchInput || touchSeekState.state == TouchSeekState.State.Idle) {
+                        return@onPointerEventMultiplatform
+                    }
+                    val coordinates = sliderCoordinates ?: return@onPointerEventMultiplatform
+                    if (!touchSeekState.move(coordinates, change.position)) {
+                        return@onPointerEventMultiplatform
+                    }
+
+                    if (touchSeekState.state == TouchSeekState.State.Cancelling) {
+                        state.cancelPreview()
+                    } else if (!latestTouchPreviewRatio.isNaN()) {
+                        state.previewPositionRatio(latestTouchPreviewRatio)
+                    }
                 },
         )
     }

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -104,6 +104,7 @@ import me.him188.ani.app.ui.foundation.theme.stronglyWeaken
 import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
 import me.him188.ani.app.videoplayer.ui.PlayerControllerState
 import me.him188.ani.app.videoplayer.ui.VideoAspectRatioControllerState
+import me.him188.ani.app.videoplayer.ui.keepLayoutWhenHidden
 import me.him188.ani.app.videoplayer.ui.renderAspectRatioMode
 import me.him188.ani.app.videoplayer.ui.top.needWorkaroundForFocusManager
 import kotlin.math.roundToInt
@@ -616,6 +617,7 @@ object PlayerControllerDefaults {
         showPreviewTimeTextOnThumb: Boolean = true,
         framePreview: MediaProgressFramePreviewState? = null,
         showFramePreviewInPopup: Boolean = true,
+        touchSeekState: TouchSeekState? = null,
     ) {
         val cacheProgressInfo by cacheProgressInfoFlow.collectAsStateWithLifecycle(null)
         MediaProgressSlider(
@@ -624,6 +626,7 @@ object PlayerControllerDefaults {
             showPreviewTimeTextOnThumb = showPreviewTimeTextOnThumb,
             framePreview = framePreview,
             showFramePreviewInPopup = showFramePreviewInPopup,
+            touchSeekState = touchSeekState,
             modifier = modifier,
         )
     }
@@ -669,6 +672,7 @@ object PlayerControllerDefaults {
  * @param expanded Whether the controller bar is expanded.
  * If `true`, the [progressIndicator] and [progressSlider] will be shown on a separate row above. The bottom row will contain a [danmakuEditor].
  * If `false`, the entire bar will be only one row. [danmakuEditor] will be ignored.
+ * @param sliderOnly Whether to keep only [progressSlider] visible without replacing its composition.
  */
 @Composable
 fun PlayerControllerBar(
@@ -678,6 +682,7 @@ fun PlayerControllerBar(
     danmakuEditor: @Composable RowScope.() -> Unit,
     endActions: @Composable RowScope.() -> Unit,
     expanded: Boolean,
+    sliderOnly: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -692,6 +697,7 @@ fun PlayerControllerBar(
             ProvideTextStyle(MaterialTheme.typography.labelMedium) {
                 Row(
                     Modifier
+                        .keepLayoutWhenHidden(sliderOnly)
                         .padding(start = if (expanded) 8.dp else 4.dp)
                         .padding(vertical = if (expanded) 4.dp else 2.dp),
                 ) {
@@ -714,13 +720,14 @@ fun PlayerControllerBar(
         ) {
             // 播放 / 暂停按钮
             Row(
+                Modifier.keepLayoutWhenHidden(sliderOnly),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 startActions()
             }
 
             Row(
-                Modifier.weight(1f),
+                Modifier.weight(1f).keepLayoutWhenHidden(sliderOnly && expanded),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (expanded) {
@@ -733,6 +740,7 @@ fun PlayerControllerBar(
             }
 
             Row(
+                Modifier.keepLayoutWhenHidden(sliderOnly),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 endActions()

--- a/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/PlayerControllerStateTest.kt
@@ -65,6 +65,18 @@ class PlayerControllerStateTest {
     }
 
     @Test
+    fun `inline slider request keeps bottom bar while hiding other controls`() {
+        val state = PlayerControllerState(ControllerVisibility.Visible)
+        val requester = Any()
+
+        state.setRequestInlineProgressSlider(requester)
+        assertEquals(ControllerVisibility.InlineSliderOnly, state.visibility)
+
+        state.cancelRequestInlineProgressSlider(requester)
+        assertEquals(ControllerVisibility.Visible, state.visibility)
+    }
+
+    @Test
     fun `visibility when nothing`() {
         val state = createStateRequested(false, false, false)
         assertEquals(ControllerVisibility.Invisible, state.visibility)

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GestureIndicatorStateTest {
+    @Test
+    fun `seek cancellation remains visible until stopped`() {
+        val state = GestureIndicatorState()
+
+        val ticket = state.startSeekCancellation()
+        assertTrue(state.visible)
+        assertTrue(state.seekCancelled)
+
+        state.stopSeekCancellation(ticket)
+        assertFalse(state.visible)
+    }
+
+    @Test
+    fun `showing regular seek clears cancellation state`() = runTest {
+        val state = GestureIndicatorState()
+        state.startSeekCancellation()
+
+        state.showSeeking(deltaSeconds = 10)
+
+        assertFalse(state.seekCancelled)
+    }
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SwipeSeekerStateTest {
+    private val containerSize = IntSize(width = 1000, height = 600)
+
+    @Test
+    fun `releasing in top corner cancels seek`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+        state.updateCancellation(Offset(100f, 100f), containerSize)
+
+        assertTrue(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(emptyList(), seeks)
+        assertFalse(state.isSeeking)
+        assertFalse(state.isCancelled)
+    }
+
+    @Test
+    fun `pointer entering cancel area before drag recognition is retained`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.updateCancellation(Offset(100f, 100f), containerSize)
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+
+        assertTrue(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(emptyList(), seeks)
+    }
+
+    @Test
+    fun `moving out of top corner resumes seek`() {
+        val seeks = mutableListOf<Int>()
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+
+        state.onSwipeStarted()
+        state.onSwipeOffset(500f)
+        state.updateCancellation(Offset(900f, 100f), containerSize)
+        assertTrue(state.isCancelled)
+
+        state.updateCancellation(Offset(500f, 300f), containerSize)
+        assertFalse(state.isCancelled)
+        state.onSwipeStopped()
+        assertEquals(listOf(49), seeks)
+    }
+
+    @Test
+    fun `top center is outside cancel area`() {
+        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = {})
+
+        state.onSwipeStarted()
+        state.updateCancellation(Offset(500f, 100f), containerSize)
+
+        assertFalse(state.isCancelled)
+    }
+
+    @Test
+    fun `invalid cancel area input is outside cancel area`() {
+        val config = SwipeSeekerConfig.Default
+
+        assertFalse(config.isInCancelArea(Offset.Unspecified, containerSize))
+        assertFalse(config.isInCancelArea(Offset.Zero, IntSize.Zero))
+        assertFalse(config.isInCancelArea(Offset.Zero, IntSize(width = -1, height = 600)))
+        assertFalse(config.isInCancelArea(Offset.Zero, IntSize(width = 1000, height = -1)))
+    }
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PlayerProgressSliderStateTest {
+    @Test
+    fun `cancel preview does not finish seek`() {
+        val finishedPositions = mutableListOf<Long>()
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { 10_000L },
+            totalDurationMillis = { 100_000L },
+            chapters = { emptyList() },
+            onPreview = {},
+            onPreviewFinished = finishedPositions::add,
+        )
+
+        state.previewPositionRatio(0.5f)
+        state.cancelPreview()
+
+        assertFalse(state.isPreviewing)
+        assertEquals(emptyList(), finishedPositions)
+        assertEquals(0.1f, state.displayPositionRatio)
+    }
+}

--- a/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
+++ b/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.gesture
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SwipeToSeekTest {
+    @Test
+    fun `release in top corner cancels seek`() = runAniComposeUiTest {
+        val seeks = mutableListOf<Int>()
+        setContent {
+            BoxWithConstraints(Modifier.fillMaxSize()) {
+                val state = rememberSwipeSeekerState(constraints.maxWidth, onSeek = seeks::add)
+                Box(
+                    Modifier.fillMaxSize()
+                        .testTag("swipeTarget")
+                        .swipeToSeek(state, Orientation.Horizontal),
+                )
+            }
+        }
+
+        onNodeWithTag("swipeTarget").performTouchInput {
+            down(center)
+            moveTo(Offset(width * 0.4f, height * 0.5f))
+            moveTo(Offset(width * 0.1f, height * 0.1f))
+            up()
+        }
+
+        assertEquals(emptyList(), seeks)
+    }
+}


### PR DESCRIPTION
## 主要改动

优化 Android 端的播放进度调整交互，并实现 #2510 提出的取消操作。

- 屏幕横向滑动和直接拖动底部进度条使用一致的取消交互。
- 手指移入左上角或右上角取消区域后，持续显示“松开手指取消”。
- 移出取消区域后恢复进度预览；在取消区域内松手不会改变播放进度。
- 控制器已隐藏时，滑动会在播放器底部显示独立进度条。
- 控制器已显示或直接拖动进度条时，保留原进度条及其布局，仅在视觉上隐藏其他控制器元素。
- 隐藏控制器元素时保留上下渐变遮罩，避免进度条位移或闪动。
- 相关逻辑仅对 `GestureFamily.TOUCH` 生效，不改变 mouse/desktop 行为。

取消区域为播放器顶部 25% 高度内、左右各 25% 宽度的区域。

## 演示

### 控制器已显示

保留底部控制栏中的原进度条，拖动期间隐藏其他控制器元素。

<img width="960" height="436" alt="控制器已显示时的进度拖动与取消交互" src="https://github.com/user-attachments/assets/f61f70e2-8a60-49b8-80da-85c89f7a33da" />

### 控制器已隐藏

滑动时在播放器底部显示独立进度条。

<img width="720" height="328" alt="控制器已隐藏时的进度拖动与取消交互" src="https://github.com/user-attachments/assets/b90a2adb-a673-4b78-bf6d-afcc7fb3b24e" />

## 测试

- `:app:shared:desktopTest --tests '*EpisodeVideoControllerTest*'`
- `:app:shared:video-player:desktopTest`
- `:app:shared:video-player:testAndroidHostTest`
- `:app:shared:video-player:compileAndroidMain`
- `:app:shared:compileAndroidMain`

Closes #2510
