### PR TITLE
修复自动换源后从头播放的问题

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.domain.player.extension
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -45,6 +46,9 @@ class RememberPlayProgressExtension(
     private val latestInfoBundleMutex = Mutex()
     private val latestInfoBundles = mutableMapOf<Int, SubjectEpisodeInfoBundle>()
 
+    @Volatile
+    private var lastKnownPlaybackPosition: PlaybackPosition? = null
+
     override fun onStart(episodeSession: EpisodeSession, backgroundTaskScope: ExtensionBackgroundTaskScope) {
         val mediaLoaded = CompletableDeferred<Unit>()
         backgroundTaskScope.launch("MediaLoadedListener") {
@@ -59,6 +63,21 @@ class RememberPlayProgressExtension(
             episodeSession.infoBundleFlow.filterNotNull().collect { info ->
                 latestInfoBundleMutex.withLock {
                     latestInfoBundles[info.episodeId] = info
+                }
+            }
+        }
+
+        backgroundTaskScope.launch("PlaybackPositionCache") {
+            combine(
+                context.player.currentPositionMillis,
+                context.player.mediaProperties
+            ) { positionMillis, mediaProperties ->
+                mediaProperties?.durationMillis
+                    ?.takeIf { it > 0L }
+                    ?.let { PlaybackPosition(positionMillis, it) }
+            }.filterNotNull().collect { position ->
+                if (position.isValid) {
+                    lastKnownPlaybackPosition = position
                 }
             }
         }
@@ -153,22 +172,21 @@ class RememberPlayProgressExtension(
     ) {
         val player = context.player
         val playbackState = player.playbackState.value
-        val videoDurationMillis = player.mediaProperties.value?.durationMillis
-
-        if (videoDurationMillis == null || videoDurationMillis <= 0L) {
-            return
-        }
-
-        when (playbackState) {
+        val position = when (playbackState) {
             PlaybackState.DESTROYED,
             PlaybackState.CREATED,
-            PlaybackState.READY,
-            PlaybackState.ERROR -> return
+            PlaybackState.READY -> return
+
+            // 播放器出错后可能无法再提供有效位置，但自动换源仍需使用最近位置恢复本集播放。
+            PlaybackState.ERROR -> lastKnownPlaybackPosition ?: return
 
             PlaybackState.FINISHED,
             PlaybackState.PAUSED,
             PlaybackState.PLAYING,
             PlaybackState.PAUSED_BUFFERING -> {
+                val videoDurationMillis = player.mediaProperties.value?.durationMillis
+                    ?.takeIf { it > 0L }
+                    ?: return
                 val currentPositionMillis = withContext(Dispatchers.Main.immediate) {
                     try {
                         player.getCurrentPositionMillis()
@@ -183,24 +201,28 @@ class RememberPlayProgressExtension(
                     return
                 }
 
-                if (videoDurationMillis - currentPositionMillis < 5000 || currentPositionMillis > videoDurationMillis) {
-                    playProgressRepository.remove(episodeId)
-                } else {
-                    val info = latestInfoBundle(episodeId, episodeSession)
-                    playProgressRepository.saveOrUpdate(
-                        episodeId = episodeId,
-                        positionMillis = currentPositionMillis,
-                        subjectId = info?.subjectId,
-                        episodeSort = info?.episodeInfo?.sort?.number,
-                        subjectName = info?.subjectInfo?.displayName,
-                        subjectImageUrl = info?.subjectInfo?.imageLarge,
-                        episodeName = info?.episodeInfo?.displayName,
-                        durationMillis = videoDurationMillis,
-                    )
-                }
-                return
+                PlaybackPosition(currentPositionMillis, videoDurationMillis)
             }
         }
+
+        if (playbackState != PlaybackState.ERROR &&
+            (position.durationMillis - position.positionMillis < 5000 || position.positionMillis > position.durationMillis)
+        ) {
+            playProgressRepository.remove(episodeId)
+            return
+        }
+
+        val info = latestInfoBundle(episodeId, episodeSession)
+        playProgressRepository.saveOrUpdate(
+            episodeId = episodeId,
+            positionMillis = position.positionMillis,
+            subjectId = info?.subjectId,
+            episodeSort = info?.episodeInfo?.sort?.number,
+            subjectName = info?.subjectInfo?.displayName,
+            subjectImageUrl = info?.subjectInfo?.imageLarge,
+            episodeName = info?.episodeInfo?.displayName,
+            durationMillis = position.durationMillis,
+        )
     }
 
     private suspend fun latestInfoBundle(
@@ -219,5 +241,13 @@ class RememberPlayProgressExtension(
             RememberPlayProgressExtension(context, koin)
 
         private val logger = logger<RememberPlayProgressExtension>()
+    }
+
+    private data class PlaybackPosition(
+        val positionMillis: Long,
+        val durationMillis: Long,
+    ) {
+        val isValid: Boolean
+            get() = positionMillis > 0L && positionMillis <= durationMillis
     }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
@@ -485,6 +485,26 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
     }
 
     @Test
+    fun `switching source after player error restores cached progress`() = runTest {
+        val (testScope, suite, state) = createCase()
+        advanceUntilIdle()
+
+        loadSelectedMedia(suite, state)
+        suite.player.seekTo(1000)
+        suite.player.playbackState.value = PlaybackState.PLAYING
+        advanceUntilIdle()
+
+        suite.player.playbackState.value = PlaybackState.ERROR
+        advanceUntilIdle()
+
+        loadSelectedMedia(suite, state, mediaIndex = 1)
+
+        assertSingleSavedHistoryList(1000)
+        assertEquals(1000, suite.player.currentPositionMillis.value)
+        testScope.cancel()
+    }
+
+    @Test
     fun `player finished when duration is zero does not remove history`() = runTest {
         val (testScope, suite, state) = createCase()
         advanceUntilIdle()


### PR DESCRIPTION
## 背景与问题

部分在线数据源会在正片中插入广告。广告结束处可能因 HLS 时间轴、分片或编码切换导致底层播放器进入 `ERROR` 状态。

在默认开启“播放出错时自动切换视频源”且优先使用在线源的情况下，`SwitchMediaOnPlayerErrorExtension` 会在短暂延迟后选择下一个在线资源。资源切换会重新加载播放器，因此进度条归零本身是预期的重载表现；问题在于重载前没有保存可恢复的断点，导致新资源从第 0 秒开始播放。

## 根因

`RememberPlayProgressExtension` 原先只在暂停、播放结束和资源选择前保存断点。但自动换源发生时，资源选择事件到达前播放器已经处于 `ERROR`：

1. 旧播放器因广告边界异常进入 `ERROR`；
2. 自动换源逻辑选择下一个在线资源；
3. 资源选择前的断点保存逻辑对 `ERROR` 直接返回；
4. `PlayerSession.loadMedia` 停止旧播放器并加载新资源；
5. 新资源没有刚才的断点可恢复，因而从头播放。

## 修改内容

### `RememberPlayProgressExtension`

- 新增 `PlaybackPositionCache`：组合监听播放器的当前位置和媒体属性，仅缓存“位置大于 0、时长有效、位置不超过时长”的最后一个有效快照。
- 新增线程可见的 `lastKnownPlaybackPosition`，保存位置与时长，避免播放器进入 `ERROR` 后无法再读取当前位置。
- 在 `ERROR` 状态下发生资源切换时，改用该快照写入播放历史；新资源加载并进入播放状态后仍沿用既有恢复逻辑执行 seek。
- 正常播放、暂停和结束场景仍直接读取当前播放器位置；原有“距离结尾不足 5 秒或位置超过时长时移除断点”的规则保持不变，并且不会用于错误状态，避免错误发生在结尾附近时错误地清空断点。

### 回归测试

在 `RememberPlayProgressExtensionTest` 中新增用例，模拟：

1. 第一个资源播放到 1000 ms；
2. 播放器进入 `ERROR`；
3. 选择第二个资源；
4. 断言播放历史保存为 1000 ms，且第二个资源恢复至 1000 ms。

该用例覆盖自动换源依赖的同一“错误状态下资源选择”交接点。

## 预期效果

- 广告边界仍可能让原在线资源报错并触发自动换源；本 PR 不尝试猜测或修改第三方 HLS 广告流。
- 自动换源后，用户会回到广告前的最近有效正片位置，而不是从头开始。
- 不影响手动切源、暂停保存、正常播放结束和接近结尾时的既有断点行为。

## 验证

- `./gradlew.bat :app:shared:app-data:desktopTest --tests "me.him188.ani.app.domain.player.extension.RememberPlayProgressExtensionTest"`
