### PR TITLE
feat(desktop): support native Windows touch input

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -228,8 +228,9 @@ internal fun EpisodeVideoImpl(
         }
     }
     val indicatorState = rememberGestureIndicatorState()
-    // commonMain 中的 TOUCH 仅表示移动端触屏交互。CMP Desktop 尚无稳定的触控支持，
-    // 因此桌面端继续使用 MOUSE 分支，不启用进度条触摸取消状态机。
+    // 桌面设备可能同时支持鼠标和触摸；当前 GestureFamily 不能按单次输入来源分流，
+    // 因此桌面端仍使用 MOUSE 分支。后续实现来源级分流时再支持桌面触摸手势。
+    // TODO: 根据触控能力与平台特性建立设备抽象，并据此选择手势策略。
     val touchSeekState = rememberPlayerTouchSeekState(
         enabled = gestureFamily == GestureFamily.TOUCH,
         controllerState = playerControllerState,

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/ComposeSceneTouchBridge.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/ComposeSceneTouchBridge.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package me.him188.ani.app.platform.window
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.scene.ComposeScenePointer
+import me.him188.ani.utils.logging.error
+import me.him188.ani.utils.logging.logger
+import java.awt.Component
+import java.awt.EventQueue
+import java.awt.Point
+import java.awt.Window
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+private val logger = logger("ComposeSceneTouchBridge")
+
+/**
+ * Injects native Windows touch events into [ComposeScene].
+ *
+ * Compose Desktop does not expose a supported API for this injection, so this bridge resolves its
+ * internal scene and methods through reflection once at creation time. If that lookup fails after a
+ * Compose Desktop change, [create] returns null and the caller keeps the default AWT mouse path.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class ComposeSceneTouchBridge private constructor(
+    private val scene: ComposeScene,
+    private val mediator: Any,
+    private val contentComponent: Component,
+    private val sceneBoundsMethod: Method,
+    private val sendPointerEventMethod: Method,
+) : AutoCloseable {
+    private var closed = false
+    private var sceneBoundsFallbackLogged = false
+
+    fun send(event: WindowsTouchEvent) {
+        if (closed) return
+        runOnEventDispatchThread {
+            check(!closed) { "ComposeSceneTouchBridge is closed" }
+            check(contentComponent.isDisplayable) { "Compose content is no longer displayable" }
+
+            val position = windowsScreenPositionToScenePosition(
+                screenX = event.pointer.screenX,
+                screenY = event.pointer.screenY,
+                contentLocationOnScreen = contentComponent.locationOnScreen,
+                density = scene.density.density,
+                sceneBoundsInPx = sceneBoundsInPxOrZero(),
+            )
+            val pointer = ComposeScenePointer(
+                id = PointerId(event.pointer.id),
+                position = position,
+                pressed = event.type != WindowsTouchEventType.RELEASE,
+                type = PointerType.Touch,
+                pressure = 1f,
+            )
+            sendPointerEventMethod.invoke(
+                scene,
+                event.type.toComposePointerEventType(),
+                listOf(pointer),
+                0,
+                0,
+                Offset.Zero.packedValue,
+                event.pointer.eventTimeMillis,
+                null,
+                null,
+            )
+        }
+    }
+
+    private fun sceneBoundsInPxOrZero(): Rect {
+        return (sceneBoundsMethod.invoke(mediator) as? Rect) ?: Rect(
+            left = 0f,
+            top = 0f,
+            right = 0f,
+            bottom = 0f,
+        ).also {
+            if (!sceneBoundsFallbackLogged) {
+                sceneBoundsFallbackLogged = true
+                logger.warn("CMP scene bounds are not initialized; using zero scene offset for native touch")
+            }
+        }
+    }
+
+    fun cancel() {
+        if (closed) return
+        runOnEventDispatchThread {
+            if (!closed) scene.cancelPointerInput()
+        }
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+    }
+
+    private fun runOnEventDispatchThread(block: () -> Unit) {
+        if (EventQueue.isDispatchThread()) {
+            block()
+        } else {
+            EventQueue.invokeLater {
+                runCatching(block).onFailure { error ->
+                    logger.error(error) { "ComposeScene touch event dispatch failed" }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun create(window: Window): ComposeSceneTouchBridge? {
+            val composeWindow = window as? ComposeWindow ?: return null
+            return runCatching {
+                val composePanel = ComposeWindow::class.java
+                    .getDeclaredField("composePanel")
+                    .accessibleField()
+                    .get(composeWindow)
+                val composeContainer = composePanel.javaClass
+                    .getDeclaredField("_composeContainer")
+                    .accessibleField()
+                    .get(composePanel)
+                    ?: error("Compose container is not initialized")
+                val mediator = composeContainer.javaClass
+                    .getDeclaredField("mediator")
+                    .accessibleField()
+                    .get(composeContainer)
+                val scene = findScene(mediator)
+                val sceneBoundsMethod = mediator.javaClass
+                    .getDeclaredMethod("getSceneBoundsInPx")
+                    .accessibleMethod()
+                val sendPointerEventMethod = findSendPointerEventMethod(scene)
+                val contentComponent = composeContainer.javaClass
+                    .getDeclaredMethod("getContentComponent")
+                    .accessibleMethod()
+                    .invoke(composeContainer) as? Component
+                    ?: error("Compose content component is not initialized")
+
+                ComposeSceneTouchBridge(
+                    scene = scene,
+                    mediator = mediator,
+                    contentComponent = contentComponent,
+                    sceneBoundsMethod = sceneBoundsMethod,
+                    sendPointerEventMethod = sendPointerEventMethod,
+                )
+            }.onFailure { error ->
+                logger.warn("CMP ComposeScene touch bridge unavailable; keeping default mouse input", error)
+            }.getOrNull()
+        }
+
+        private fun findScene(mediator: Any): ComposeScene {
+            val mediatorClass = mediator.javaClass
+            val accessorName = "access${'$'}getScene"
+            runCatching {
+                val accessor = mediatorClass
+                    .getDeclaredMethod(accessorName, mediatorClass)
+                    .accessibleMethod()
+                accessor.invoke(null, mediator) as? ComposeScene
+                    ?: error("CMP scene accessor returned an unexpected value")
+            }.getOrNull()?.let { return it }
+
+            val sceneDelegate = mediatorClass
+                .getDeclaredField("scene${'$'}delegate")
+                .accessibleField()
+                .get(mediator)
+            return (sceneDelegate as? Lazy<*>)?.value as? ComposeScene
+                ?: error("CMP scene delegate returned an unexpected value")
+        }
+
+        private fun findSendPointerEventMethod(scene: ComposeScene): Method {
+            val methods = (scene.javaClass.methods.asSequence() + ComposeScene::class.java.methods.asSequence())
+                .filter { method ->
+                    method.name.startsWith("sendPointerEvent-") &&
+                        method.parameterTypes.size == 8 &&
+                        method.parameterTypes[1] == List::class.java
+                }
+                .distinctBy { method -> method.name }
+                .toList()
+            check(methods.size == 1) {
+                "Expected exactly one CMP list sendPointerEvent overload, found ${methods.size}"
+            }
+            return methods.single().accessibleMethod()
+        }
+    }
+}
+
+/**
+ * Converts Win32 screen-pixel coordinates to [ComposeScene]-local coordinates.
+ *
+ * [contentLocationOnScreen] locates the AWT host in screen space; [sceneBoundsInPx] accounts for
+ * the scene's offset inside that host.
+ */
+internal fun windowsScreenPositionToScenePosition(
+    screenX: Int,
+    screenY: Int,
+    contentLocationOnScreen: Point,
+    density: Float,
+    sceneBoundsInPx: Rect,
+): Offset {
+    return Offset(
+        screenX - contentLocationOnScreen.x * density - sceneBoundsInPx.left,
+        screenY - contentLocationOnScreen.y * density - sceneBoundsInPx.top,
+    )
+}
+
+private fun WindowsTouchEventType.toComposePointerEventType(): Int = when (this) {
+    WindowsTouchEventType.PRESS -> PointerEventType.Press.value
+    WindowsTouchEventType.MOVE -> PointerEventType.Move.value
+    WindowsTouchEventType.RELEASE -> PointerEventType.Release.value
+}
+
+private fun Field.accessibleField(): Field = apply { trySetAccessible() }
+
+private fun Method.accessibleMethod(): Method = apply { trySetAccessible() }

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsPointerInput.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsPointerInput.kt
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform.window
+
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.platform.win32.WinDef.POINT
+import com.sun.jna.platform.win32.WinDef.WPARAM
+import me.him188.ani.utils.logging.error
+import me.him188.ani.utils.logging.logger
+import java.awt.EventQueue
+
+private val logger = logger("WindowsPointerInput")
+
+internal const val WINDOWS_NATIVE_TOUCH_DEBUG_PROPERTY = "ani.windows.nativeTouch.debug"
+
+internal const val PT_TOUCH: Int = 0x00000002
+
+internal const val WM_POINTERUPDATE: Int = 0x0245
+internal const val WM_POINTERDOWN: Int = 0x0246
+internal const val WM_POINTERUP: Int = 0x0247
+internal const val WM_POINTERCAPTURECHANGED: Int = 0x024C
+
+internal const val POINTER_FLAG_INCONTACT: Int = 0x00000004
+internal const val POINTER_FLAG_CANCELED: Int = 0x00008000
+
+internal object WindowsNativeTouchDebug {
+    private var lastUpdateLogNanos = 0L
+
+    val enabled: Boolean
+        get() = System.getProperty(WINDOWS_NATIVE_TOUCH_DEBUG_PROPERTY).toBoolean()
+
+    fun logHook(
+        hookName: String,
+        hookedWindow: HWND,
+        topLevelWindow: HWND?,
+        skiaLayerWindow: HWND?,
+        contentWindow: HWND?,
+    ) {
+        if (!enabled) return
+        logger.info(
+            "Windows touch hook=$hookName " +
+                "hooked=${hookedWindow.debugHandle()}, " +
+                "topLevel=${topLevelWindow.debugHandle()}, " +
+                "skiaLayer=${skiaLayerWindow.debugHandle()}, " +
+                "content=${contentWindow.debugHandle()}"
+        )
+    }
+
+    fun logPointerMessage(
+        hookName: String,
+        uMsg: Int,
+        callbackWindow: HWND?,
+        wParam: WPARAM,
+        pointerInfo: POINTER_INFO?,
+    ) {
+        if (!enabled || uMsg == WM_POINTERUPDATE && !shouldLogUpdate()) return
+        val pointer = pointerInfo
+        logger.info(
+            "Windows touch message hook=$hookName message=${uMsg.debugName()} " +
+                "callback=${callbackWindow.debugHandle()}, " +
+                "wParam=0x${wParam.toLong().toString(16)}, " +
+                "pointerId=${pointer?.pointerId}, " +
+                "type=${pointer?.pointerType}, " +
+                "flags=0x${pointer?.pointerFlags?.toString(16)}, " +
+                "time=${pointer?.dwTime?.toLong()?.and(0xFFFFFFFFL)}, " +
+                "screen=${pointer?.ptPixelLocation?.x},${pointer?.ptPixelLocation?.y}, " +
+                "target=${pointer?.hwndTarget.debugHandle()}, " +
+                "edt=${EventQueue.isDispatchThread()}"
+        )
+    }
+
+    private fun shouldLogUpdate(): Boolean {
+        val now = System.nanoTime()
+        if (now - lastUpdateLogNanos < 100_000_000L) return false
+        lastUpdateLogNanos = now
+        return true
+    }
+}
+
+internal enum class WindowsPointerMessage {
+    DOWN,
+    UPDATE,
+    UP,
+}
+
+internal enum class WindowsTouchEventType {
+    PRESS,
+    MOVE,
+    RELEASE,
+}
+
+internal data class WindowsPointerData(
+    val id: Long,
+    val pointerType: Int,
+    val flags: Int,
+    val screenX: Int,
+    val screenY: Int,
+    val eventTimeMillis: Long = 0L,
+) {
+    val isInContact: Boolean get() = flags and POINTER_FLAG_INCONTACT != 0
+    val isCanceled: Boolean get() = flags and POINTER_FLAG_CANCELED != 0
+}
+
+internal data class WindowsTouchEvent(
+    val type: WindowsTouchEventType,
+    val pointer: WindowsPointerData,
+)
+
+internal sealed interface WindowsPointerDispatch {
+    data object Pass : WindowsPointerDispatch
+    data object Consume : WindowsPointerDispatch
+    data object Cancel : WindowsPointerDispatch
+    data class Send(val event: WindowsTouchEvent) : WindowsPointerDispatch
+}
+
+internal enum class WindowsPointerSequenceState {
+    IDLE,
+    PRIMARY_ACTIVE,
+    DRAINING,
+}
+
+/**
+ * Owns one complete native touch sequence for the bridge.
+ *
+ * Once the primary contact is sent to Compose, every related native message must be consumed until
+ * the sequence ends or is cancelled; otherwise Windows can also deliver the same interaction through
+ * its default mouse path.
+ *
+ * This is a single-touch MVP. Desktop interactions are currently predominantly single-touch; pinch
+ * gestures such as image zoom are intentionally out of scope. Secondary pointers are tracked only so
+ * their native messages can be consumed consistently until the sequence drains, never promoted.
+ */
+internal class WindowsPointerSequenceStateMachine {
+    var state: WindowsPointerSequenceState = WindowsPointerSequenceState.IDLE
+        private set
+
+    var primaryPointerId: Long? = null
+        private set
+
+    private val suppressedPointerIds = mutableSetOf<Long>()
+
+    fun handle(message: WindowsPointerMessage, pointer: WindowsPointerData): WindowsPointerDispatch {
+        if (pointer.pointerType != PT_TOUCH) return WindowsPointerDispatch.Pass
+
+        if (pointer.isCanceled) {
+            return if (owns(pointer.id)) cancelAndDispatch() else WindowsPointerDispatch.Pass
+        }
+
+        return when (state) {
+            WindowsPointerSequenceState.IDLE -> handleIdle(message, pointer)
+            WindowsPointerSequenceState.PRIMARY_ACTIVE -> handlePrimaryActive(message, pointer)
+            WindowsPointerSequenceState.DRAINING -> handleDraining(message, pointer)
+        }
+    }
+
+    fun handleCaptureChanged(): WindowsPointerDispatch {
+        return if (isActive) cancelAndDispatch() else WindowsPointerDispatch.Pass
+    }
+
+    fun handleReadFailure(pointerId: Long): WindowsPointerDispatch {
+        return if (owns(pointerId)) cancelAndDispatch() else WindowsPointerDispatch.Pass
+    }
+
+    fun cancel(): Boolean {
+        if (!isActive) return false
+        clear()
+        return true
+    }
+
+    fun owns(pointerId: Long): Boolean {
+        return primaryPointerId == pointerId || pointerId in suppressedPointerIds
+    }
+
+    private val isActive: Boolean
+        get() = state != WindowsPointerSequenceState.IDLE
+
+    private fun handleIdle(
+        message: WindowsPointerMessage,
+        pointer: WindowsPointerData,
+    ): WindowsPointerDispatch {
+        if (message != WindowsPointerMessage.DOWN) return WindowsPointerDispatch.Pass
+
+        primaryPointerId = pointer.id
+        state = WindowsPointerSequenceState.PRIMARY_ACTIVE
+        return WindowsPointerDispatch.Send(WindowsTouchEvent(WindowsTouchEventType.PRESS, pointer))
+    }
+
+    private fun handlePrimaryActive(
+        message: WindowsPointerMessage,
+        pointer: WindowsPointerData,
+    ): WindowsPointerDispatch {
+        val primaryId = primaryPointerId
+        if (pointer.id == primaryId) {
+            return when (message) {
+                WindowsPointerMessage.DOWN -> WindowsPointerDispatch.Consume
+                WindowsPointerMessage.UPDATE -> {
+                    if (pointer.isInContact) {
+                        WindowsPointerDispatch.Send(WindowsTouchEvent(WindowsTouchEventType.MOVE, pointer))
+                    } else {
+                        cancelAndDispatch()
+                    }
+                }
+
+                WindowsPointerMessage.UP -> {
+                    primaryPointerId = null
+                    state = if (suppressedPointerIds.isEmpty()) {
+                        WindowsPointerSequenceState.IDLE
+                    } else {
+                        WindowsPointerSequenceState.DRAINING
+                    }
+                    WindowsPointerDispatch.Send(WindowsTouchEvent(WindowsTouchEventType.RELEASE, pointer))
+                }
+            }
+        }
+
+        return when (message) {
+            WindowsPointerMessage.DOWN -> {
+                suppressedPointerIds += pointer.id
+                WindowsPointerDispatch.Consume
+            }
+
+            WindowsPointerMessage.UPDATE,
+            WindowsPointerMessage.UP,
+                -> {
+                if (pointer.id !in suppressedPointerIds) {
+                    WindowsPointerDispatch.Pass
+                } else {
+                    if (message == WindowsPointerMessage.UP) {
+                        suppressedPointerIds -= pointer.id
+                        if (suppressedPointerIds.isEmpty()) {
+                            state = WindowsPointerSequenceState.IDLE
+                        }
+                    }
+                    WindowsPointerDispatch.Consume
+                }
+            }
+        }
+    }
+
+    private fun handleDraining(
+        message: WindowsPointerMessage,
+        pointer: WindowsPointerData,
+    ): WindowsPointerDispatch {
+        return when (message) {
+            WindowsPointerMessage.DOWN -> {
+                suppressedPointerIds += pointer.id
+                WindowsPointerDispatch.Consume
+            }
+
+            WindowsPointerMessage.UPDATE -> {
+                if (pointer.id in suppressedPointerIds) WindowsPointerDispatch.Consume
+                else WindowsPointerDispatch.Pass
+            }
+
+            WindowsPointerMessage.UP -> {
+                if (pointer.id !in suppressedPointerIds) {
+                    WindowsPointerDispatch.Pass
+                } else {
+                    suppressedPointerIds -= pointer.id
+                    if (suppressedPointerIds.isEmpty()) {
+                        state = WindowsPointerSequenceState.IDLE
+                    }
+                    WindowsPointerDispatch.Consume
+                }
+            }
+        }
+    }
+
+    private fun cancelAndDispatch(): WindowsPointerDispatch {
+        clear()
+        return WindowsPointerDispatch.Cancel
+    }
+
+    private fun clear() {
+        primaryPointerId = null
+        suppressedPointerIds.clear()
+        state = WindowsPointerSequenceState.IDLE
+    }
+}
+
+/** A copy of the Win32 POINTER_INFO structure that is safe to read synchronously. */
+@Suppress("SpellCheckingInspection")
+internal class POINTER_INFO : Structure() {
+    @JvmField var pointerType: Int = 0
+    @JvmField var pointerId: Int = 0
+    @JvmField var frameId: Int = 0
+    @JvmField var pointerFlags: Int = 0
+    @JvmField var sourceDevice: Pointer? = null
+    @JvmField var hwndTarget: HWND? = null
+    @JvmField var ptPixelLocation: POINT = POINT()
+    @JvmField var ptHimetricLocation: POINT = POINT()
+    @JvmField var ptPixelLocationRaw: POINT = POINT()
+    @JvmField var ptHimetricLocationRaw: POINT = POINT()
+    @JvmField var dwTime: Int = 0
+    @JvmField var historyCount: Int = 0
+    @JvmField var inputData: Int = 0
+    @JvmField var dwKeyStates: Int = 0
+    @JvmField var performanceCount: Long = 0
+    @JvmField var buttonChangeType: Int = 0
+
+    override fun getFieldOrder(): List<String> = listOf(
+        "pointerType",
+        "pointerId",
+        "frameId",
+        "pointerFlags",
+        "sourceDevice",
+        "hwndTarget",
+        "ptPixelLocation",
+        "ptHimetricLocation",
+        "ptPixelLocationRaw",
+        "ptHimetricLocationRaw",
+        "dwTime",
+        "historyCount",
+        "inputData",
+        "dwKeyStates",
+        "performanceCount",
+        "buttonChangeType",
+    )
+
+    fun toPointerData(pointerId: Long): WindowsPointerData = WindowsPointerData(
+        id = pointerId,
+        pointerType = pointerType,
+        flags = pointerFlags,
+        screenX = ptPixelLocation.x,
+        screenY = ptPixelLocation.y,
+        eventTimeMillis = dwTime.toLong() and 0xFFFFFFFFL,
+    )
+}
+
+internal class WindowsPointerInputHandler(
+    private val readPointerInfo: (pointerId: Int, pointerInfo: POINTER_INFO) -> Boolean,
+    private val dispatch: (WindowsTouchEvent) -> Unit,
+    private val cancel: () -> Unit,
+    private val debugHookName: String = "unknown",
+) : AutoCloseable {
+    private val sequence = WindowsPointerSequenceStateMachine()
+    private var closed = false
+    private var disabled = false
+
+    fun handleMessage(uMsg: Int, wParam: WPARAM, callbackWindow: HWND? = null): Boolean {
+        if (closed || disabled) return false
+        if (uMsg == WM_POINTERCAPTURECHANGED) {
+            WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, null)
+        }
+
+        val pointerId = if (uMsg == WM_POINTERDOWN || uMsg == WM_POINTERUPDATE || uMsg == WM_POINTERUP) {
+            pointerIdFromWParam(wParam)
+        } else {
+            null
+        }
+        val ownedBeforeHandling = pointerId?.let(sequence::owns)
+            ?: (uMsg == WM_POINTERCAPTURECHANGED && sequence.state != WindowsPointerSequenceState.IDLE)
+
+        return try {
+            when (uMsg) {
+                WM_POINTERCAPTURECHANGED -> apply(sequence.handleCaptureChanged())
+                WM_POINTERDOWN,
+                WM_POINTERUPDATE,
+                WM_POINTERUP,
+                    -> handlePointerMessage(uMsg, wParam, callbackWindow)
+
+                else -> false
+            }
+        } catch (error: Throwable) {
+            logger.error(error) { "Windows pointer input bridge failed; disabling native touch" }
+            sequence.cancel()
+            runCatching(cancel)
+            disabled = true
+            // Keep consuming an already owned sequence even if cancellation or
+            // scene injection itself failed. This prevents the same touch from
+            // being synthesized as a second mouse sequence after a bridge error.
+            ownedBeforeHandling
+        }
+    }
+
+    private fun handlePointerMessage(uMsg: Int, wParam: WPARAM, callbackWindow: HWND?): Boolean {
+        val pointerId = pointerIdFromWParam(wParam)
+        val pointerInfo = POINTER_INFO()
+        if (!readPointerInfo(pointerId.toInt(), pointerInfo)) {
+            WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, null)
+            return apply(sequence.handleReadFailure(pointerId))
+        }
+        WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, pointerInfo)
+
+        val message = when (uMsg) {
+            WM_POINTERDOWN -> WindowsPointerMessage.DOWN
+            WM_POINTERUPDATE -> WindowsPointerMessage.UPDATE
+            WM_POINTERUP -> WindowsPointerMessage.UP
+            else -> error("Unsupported pointer message: $uMsg")
+        }
+        return apply(sequence.handle(message, pointerInfo.toPointerData(pointerId)))
+    }
+
+    private fun apply(dispatchResult: WindowsPointerDispatch): Boolean {
+        return when (dispatchResult) {
+            WindowsPointerDispatch.Pass -> false
+            WindowsPointerDispatch.Consume -> true
+            WindowsPointerDispatch.Cancel -> {
+                cancel()
+                true
+            }
+
+            is WindowsPointerDispatch.Send -> {
+                dispatch(dispatchResult.event)
+                true
+            }
+        }
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        if (sequence.cancel()) {
+            runCatching(cancel)
+        }
+    }
+}
+
+internal fun pointerIdFromWParam(wParam: WPARAM): Long = wParam.toLong() and 0xFFFF
+
+private fun Int.debugName(): String = when (this) {
+    WM_POINTERUPDATE -> "WM_POINTERUPDATE"
+    WM_POINTERDOWN -> "WM_POINTERDOWN"
+    WM_POINTERUP -> "WM_POINTERUP"
+    WM_POINTERCAPTURECHANGED -> "WM_POINTERCAPTURECHANGED"
+    else -> "0x${toString(16)}"
+}
+
+private fun HWND?.debugHandle(): String = this?.toString() ?: "null"

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
@@ -94,6 +94,7 @@ fun HandleWindowsWindowProc() {
 internal open class BasicWindowProc(
     private val user32: ExtendedUser32,
     window: Window,
+    installTouchBridge: Boolean = true,
 ) : WindowProc, AutoCloseable {
     protected val windowHandle: HWND = HWND(
         (window as? ComposeWindow)
@@ -105,18 +106,58 @@ internal open class BasicWindowProc(
     val accentColor: StateFlow<Color> = _accentColor.asStateFlow()
 
     private val defaultWindowProc =
-        user32.SetWindowLongPtr(
+        user32.installWindowProc(
             windowHandle,
-            WinUser.GWL_WNDPROC,
             CallbackReference.getFunctionPointer(this),
         )
+
+    private val touchBridge = if (installTouchBridge) ComposeSceneTouchBridge.create(window) else null
+    private val touchInputHandler = touchBridge?.let { bridge ->
+        WindowsPointerInputHandler(
+            readPointerInfo = user32::GetPointerInfo,
+            dispatch = bridge::send,
+            cancel = bridge::cancel,
+            debugHookName = "BasicWindowProc",
+        )
+    }
+
+    init {
+        WindowsNativeTouchDebug.logHook(
+            hookName = "BasicWindowProc",
+            hookedWindow = windowHandle,
+            topLevelWindow = windowHandle,
+            skiaLayerWindow = null,
+            contentWindow = null,
+        )
+    }
 
     override fun callback(
         hwnd: HWND,
         uMsg: Int,
         wParam: WinDef.WPARAM,
+        lParam: WinDef.LPARAM,
+    ): LRESULT {
+        return try {
+            callbackInternal(hwnd, uMsg, wParam, lParam)
+        } catch (error: Throwable) {
+            logger.error(error) { "Windows BasicWindowProc callback failed" }
+            runCatching { callDefWindowProc(hwnd, uMsg, wParam, lParam) }
+                .getOrElse { fallbackError ->
+                    logger.error(fallbackError) { "Windows BasicWindowProc fallback failed" }
+                    LRESULT(0)
+                }
+        }
+    }
+
+    private fun callbackInternal(
+        hwnd: HWND,
+        uMsg: Int,
+        wParam: WinDef.WPARAM,
         lParam: WinDef.LPARAM
     ): LRESULT {
+        if (touchInputHandler?.handleMessage(uMsg, wParam, hwnd) == true) {
+            return LRESULT(0)
+        }
         if (uMsg == WM_SETTINGCHANGE) {
             val changedKey = Pointer(lParam.toLong()).getWideString(0)
             // Theme changed for color and darkTheme
@@ -153,7 +194,9 @@ internal open class BasicWindowProc(
     }
 
     override fun close() {
-        user32.SetWindowLongPtr(windowHandle, WinUser.GWL_WNDPROC, defaultWindowProc)
+        touchInputHandler?.close()
+        touchBridge?.close()
+        user32.restoreWindowProc(windowHandle, defaultWindowProc)
     }
 }
 
@@ -161,7 +204,7 @@ internal class ExtendedTitleBarWindowProc(
     window: Window,
     private val user32: ExtendedUser32,
     dwmapi: Dwmapi
-) : BasicWindowProc(user32, window) {
+) : BasicWindowProc(user32, window, installTouchBridge = false) {
 
     private var childHitTestOwner: WindowsWindowHitTestOwner? = null
 
@@ -174,7 +217,7 @@ internal class ExtendedTitleBarWindowProc(
     private var hitTestResult = WindowsWindowHitResult.CLIENT
 
     private val skiaLayerWindowProc: SkiaLayerHitTestWindowProc? =
-        window.findSkiaLayer()?.let { SkiaLayerHitTestWindowProc(it, user32, ::hitTest) }
+        window.findSkiaLayer()?.let { SkiaLayerHitTestWindowProc(it, user32, ::hitTest, window) }
 
     private var isMaximized: Boolean = user32.isWindowInMaximized(windowHandle)
     private var dpi: UINT = UINT(0)
@@ -517,16 +560,39 @@ internal class SkiaLayerHitTestWindowProc(
     skiaLayer: SkiaLayer,
     private val user32: ExtendedUser32,
     private val hitTest: (lParam: WinDef.LPARAM) -> WindowsWindowHitResult,
+    window: Window,
 ) : WindowProc, AutoCloseable {
+    private val topLevelWindowHandle = HWND(
+        (window as? ComposeWindow)
+            ?.let { Pointer(it.windowHandle) }
+            ?: Native.getWindowPointer(window),
+    )
     private val windowHandle = HWND(Pointer(skiaLayer.windowHandle))
     internal val contentHandle = HWND(skiaLayer.canvas.let(Native::getComponentPointer))
 
     private val defaultWindowProc =
-        user32.SetWindowLongPtr(contentHandle, WinUser.GWL_WNDPROC, CallbackReference.getFunctionPointer(this))
+        user32.installWindowProc(contentHandle, CallbackReference.getFunctionPointer(this))
+
+    private val touchBridge = ComposeSceneTouchBridge.create(window)
+    private val touchInputHandler = touchBridge?.let { bridge ->
+        WindowsPointerInputHandler(
+            readPointerInfo = user32::GetPointerInfo,
+            dispatch = bridge::send,
+            cancel = bridge::cancel,
+            debugHookName = "SkiaLayerHitTestWindowProc",
+        )
+    }
 
     private var hitResult = WindowsWindowHitResult.CLIENT
 
     init {
+        WindowsNativeTouchDebug.logHook(
+            hookName = "SkiaLayerHitTestWindowProc",
+            hookedWindow = contentHandle,
+            topLevelWindow = topLevelWindowHandle,
+            skiaLayerWindow = windowHandle,
+            contentWindow = contentHandle,
+        )
         val buildNumber = WindowsWindowUtils.instance.windowsBuildNumber() ?: 22000
         skiaLayer.transparency = buildNumber < 22000
     }
@@ -537,6 +603,27 @@ internal class SkiaLayerHitTestWindowProc(
         wParam: WinDef.WPARAM,
         lParam: WinDef.LPARAM,
     ): LRESULT {
+        return try {
+            callbackInternal(hwnd, uMsg, wParam, lParam)
+        } catch (error: Throwable) {
+            logger.error(error) { "Windows SkiaLayer WindowProc callback failed" }
+            runCatching { user32.CallWindowProc(defaultWindowProc, hwnd, uMsg, wParam, lParam) ?: LRESULT(0) }
+                .getOrElse { fallbackError ->
+                    logger.error(fallbackError) { "Windows SkiaLayer WindowProc fallback failed" }
+                    LRESULT(0)
+                }
+        }
+    }
+
+    private fun callbackInternal(
+        hwnd: HWND,
+        uMsg: Int,
+        wParam: WinDef.WPARAM,
+        lParam: WinDef.LPARAM,
+    ): LRESULT {
+        if (touchInputHandler?.handleMessage(uMsg, wParam, hwnd) == true) {
+            return LRESULT(0)
+        }
         return when (uMsg) {
 
             WM_NCHITTEST -> {
@@ -581,7 +668,24 @@ internal class SkiaLayerHitTestWindowProc(
     }
 
     override fun close() {
-        user32.SetWindowLongPtr(contentHandle, WinUser.GWL_WNDPROC, defaultWindowProc)
+        touchInputHandler?.close()
+        touchBridge?.close()
+        user32.restoreWindowProc(contentHandle, defaultWindowProc)
+    }
+}
+
+private fun ExtendedUser32.installWindowProc(windowHandle: HWND, callback: Pointer): Pointer {
+    return SetWindowLongPtr(windowHandle, WinUser.GWL_WNDPROC, callback).also { previous ->
+        check(previous != null) {
+            "SetWindowLongPtr failed for $windowHandle, lastError=${Native.getLastError()}"
+        }
+    }
+}
+
+private fun ExtendedUser32.restoreWindowProc(windowHandle: HWND, previousWindowProc: Pointer) {
+    val restored = SetWindowLongPtr(windowHandle, WinUser.GWL_WNDPROC, previousWindowProc)
+    if (restored == null) {
+        logger.error("恢复 Windows WndProc 失败: hwnd=$windowHandle, lastError=${Native.getLastError()}")
     }
 }
 

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
@@ -323,6 +323,8 @@ internal interface Dwmapi : StdCallLibrary {
 }
 
 internal interface ExtendedUser32 : User32 {
+    fun GetPointerInfo(pointerId: Int, pointerInfo: POINTER_INFO): Boolean
+
     /**
      * Is the window zoomed (maximised) or not?
      *

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/ComposeSceneTouchBridgeTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/ComposeSceneTouchBridgeTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+
+package me.him188.ani.app.platform.window
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.scene.ComposeScene
+import java.awt.Point
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposeSceneTouchBridgeTest {
+    @Test
+    fun `screen physical pixels are converted using content origin density and scene bounds`() {
+        assertEquals(
+            Offset(104f, 76f),
+            windowsScreenPositionToScenePosition(
+                screenX = 500,
+                screenY = 400,
+                contentLocationOnScreen = Point(200, 150),
+                density = 1.5f,
+                sceneBoundsInPx = Rect(left = 96f, top = 99f, right = 1200f, bottom = 800f),
+            ),
+        )
+    }
+
+    @Test
+    fun `current CMP exposes one list pointer event overload`() {
+        val methods = ComposeScene::class.java.methods.filter { method ->
+            method.name.startsWith("sendPointerEvent-") &&
+                method.parameterTypes.size == 8 &&
+                method.parameterTypes[1] == List::class.java
+        }
+
+        assertEquals(1, methods.size)
+        assertEquals(Int::class.javaPrimitiveType, methods.single().parameterTypes[0])
+        assertEquals(Long::class.javaPrimitiveType, methods.single().parameterTypes[4])
+        assertEquals(Long::class.javaPrimitiveType, methods.single().parameterTypes[5])
+    }
+}

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsPointerInputTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsPointerInputTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform.window
+
+import com.sun.jna.platform.win32.WinDef.WPARAM
+import com.sun.jna.platform.win32.WinDef.POINT
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowsPointerInputTest {
+    @Test
+    fun `primary pointer has stable press move release lifecycle`() {
+        val state = WindowsPointerSequenceStateMachine()
+        val pointer = pointer(id = 7, x = 100, y = 200)
+
+        assertEquals(WindowsTouchEventType.PRESS, state.handle(WindowsPointerMessage.DOWN, pointer).eventType())
+        assertEquals(WindowsPointerSequenceState.PRIMARY_ACTIVE, state.state)
+        assertEquals(7L, state.primaryPointerId)
+
+        val move = state.handle(
+            WindowsPointerMessage.UPDATE,
+            pointer.copy(screenX = 120, screenY = 220),
+        )
+        assertEquals(WindowsTouchEventType.MOVE, move.eventType())
+        assertEquals(7L, state.primaryPointerId)
+
+        val release = state.handle(
+            WindowsPointerMessage.UP,
+            pointer.copy(screenX = 130, screenY = 230, flags = 0),
+        )
+        assertEquals(WindowsTouchEventType.RELEASE, release.eventType())
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+        assertEquals(null, state.primaryPointerId)
+    }
+
+    @Test
+    fun `secondary pointers are consumed but never promoted`() {
+        val state = WindowsPointerSequenceStateMachine()
+        val primary = pointer(id = 1, x = 0, y = 0)
+        val secondary = pointer(id = 2, x = 10, y = 10)
+
+        state.handle(WindowsPointerMessage.DOWN, primary)
+        assertEquals(WindowsPointerDispatch.Consume, state.handle(WindowsPointerMessage.DOWN, secondary))
+        assertEquals(WindowsPointerDispatch.Consume, state.handle(WindowsPointerMessage.UPDATE, secondary))
+
+        assertEquals(
+            WindowsTouchEventType.RELEASE,
+            state.handle(WindowsPointerMessage.UP, primary).eventType(),
+        )
+        assertEquals(WindowsPointerSequenceState.DRAINING, state.state)
+        assertEquals(null, state.primaryPointerId)
+
+        assertEquals(WindowsPointerDispatch.Consume, state.handle(WindowsPointerMessage.UP, secondary))
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+        assertEquals(WindowsPointerDispatch.Pass, state.handle(WindowsPointerMessage.UPDATE, secondary))
+    }
+
+    @Test
+    fun `unknown touch messages are not taken over while idle`() {
+        val state = WindowsPointerSequenceStateMachine()
+        val pointer = pointer(id = 3, x = 0, y = 0)
+
+        assertEquals(WindowsPointerDispatch.Pass, state.handle(WindowsPointerMessage.UPDATE, pointer))
+        assertEquals(WindowsPointerDispatch.Pass, state.handle(WindowsPointerMessage.UP, pointer))
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+    }
+
+    @Test
+    fun `cancel clears primary and suppressed pointers`() {
+        val state = WindowsPointerSequenceStateMachine()
+        state.handle(WindowsPointerMessage.DOWN, pointer(id = 1, x = 0, y = 0))
+        state.handle(WindowsPointerMessage.DOWN, pointer(id = 2, x = 0, y = 0))
+
+        assertEquals(WindowsPointerDispatch.Cancel, state.handleCaptureChanged())
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+        assertFalse(state.owns(1))
+        assertFalse(state.owns(2))
+        assertEquals(WindowsPointerDispatch.Pass, state.handleCaptureChanged())
+    }
+
+    @Test
+    fun `canceled update cancels an owned sequence`() {
+        val state = WindowsPointerSequenceStateMachine()
+        state.handle(WindowsPointerMessage.DOWN, pointer(id = 1, x = 0, y = 0))
+
+        assertEquals(
+            WindowsPointerDispatch.Cancel,
+            state.handle(WindowsPointerMessage.UPDATE, pointer(id = 1, x = 2, y = 2, flags = POINTER_FLAG_CANCELED)),
+        )
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+    }
+
+    @Test
+    fun `non-contact primary update cancels instead of producing a move`() {
+        val state = WindowsPointerSequenceStateMachine()
+        state.handle(WindowsPointerMessage.DOWN, pointer(id = 1, x = 0, y = 0))
+
+        assertEquals(
+            WindowsPointerDispatch.Cancel,
+            state.handle(WindowsPointerMessage.UPDATE, pointer(id = 1, x = 2, y = 2, flags = 0)),
+        )
+        assertEquals(WindowsPointerSequenceState.IDLE, state.state)
+    }
+
+    @Test
+    fun `pointer id is limited to the low word of wParam`() {
+        assertEquals(0x1234L, pointerIdFromWParam(WPARAM(0xABCD1234L)))
+    }
+
+    @Test
+    fun `pointer data preserves the unsigned native event time`() {
+        val info = POINTER_INFO().apply {
+            pointerType = PT_TOUCH
+            pointerFlags = POINTER_FLAG_INCONTACT
+            ptPixelLocation = POINT(100, 200)
+            dwTime = -1
+        }
+
+        assertEquals(0xFFFFFFFFL, info.toPointerData(pointerId = 7).eventTimeMillis)
+    }
+
+    @Test
+    fun `non-touch pointers are passed through`() {
+        val state = WindowsPointerSequenceStateMachine()
+        assertEquals(
+            WindowsPointerDispatch.Pass,
+            state.handle(WindowsPointerMessage.DOWN, pointer(id = 1, x = 0, y = 0, pointerType = 1)),
+        )
+    }
+
+    @Test
+    fun `read failure does not take over a new sequence`() {
+        var cancelCount = 0
+        val handler = WindowsPointerInputHandler(
+            readPointerInfo = { _, _ -> false },
+            dispatch = {},
+            cancel = { cancelCount++ },
+        )
+
+        assertFalse(handler.handleMessage(WM_POINTERDOWN, WPARAM(1)))
+        assertEquals(0, cancelCount)
+    }
+
+    @Test
+    fun `read failure cancels and consumes an owned sequence`() {
+        var readCount = 0
+        var cancelCount = 0
+        val handler = WindowsPointerInputHandler(
+            readPointerInfo = { _, info ->
+                readCount++
+                if (readCount == 1) {
+                    info.pointerType = PT_TOUCH
+                    info.pointerFlags = POINTER_FLAG_INCONTACT
+                    true
+                } else {
+                    false
+                }
+            },
+            dispatch = {},
+            cancel = { cancelCount++ },
+        )
+
+        assertTrue(handler.handleMessage(WM_POINTERDOWN, WPARAM(1)))
+        assertTrue(handler.handleMessage(WM_POINTERUPDATE, WPARAM(1)))
+        assertEquals(1, cancelCount)
+
+        assertFalse(handler.handleMessage(WM_POINTERUPDATE, WPARAM(1)))
+    }
+
+    @Test
+    fun `dispatch failure disables bridge and falls back for a new sequence`() {
+        var cancelCount = 0
+        val handler = WindowsPointerInputHandler(
+            readPointerInfo = { _, info ->
+                info.pointerType = PT_TOUCH
+                info.pointerFlags = POINTER_FLAG_INCONTACT
+                true
+            },
+            dispatch = { error("injected dispatch failure") },
+            cancel = { cancelCount++ },
+        )
+
+        // No sequence was successfully taken over, so the native message may
+        // fall back to the original procedure after the fatal bridge failure.
+        assertFalse(handler.handleMessage(WM_POINTERDOWN, WPARAM(1)))
+        assertEquals(1, cancelCount)
+        assertFalse(handler.handleMessage(WM_POINTERDOWN, WPARAM(2)))
+    }
+
+    @Test
+    fun `close cancels an active sequence exactly once`() {
+        var cancelCount = 0
+        val handler = WindowsPointerInputHandler(
+            readPointerInfo = { _, info ->
+                info.pointerType = PT_TOUCH
+                info.pointerFlags = POINTER_FLAG_INCONTACT
+                true
+            },
+            dispatch = {},
+            cancel = { cancelCount++ },
+        )
+
+        assertTrue(handler.handleMessage(WM_POINTERDOWN, WPARAM(1)))
+        handler.close()
+        handler.close()
+
+        assertEquals(1, cancelCount)
+        assertFalse(handler.handleMessage(WM_POINTERUP, WPARAM(1)))
+    }
+
+    private fun pointer(
+        id: Long,
+        x: Int,
+        y: Int,
+        flags: Int = POINTER_FLAG_INCONTACT,
+        pointerType: Int = PT_TOUCH,
+    ) = WindowsPointerData(id, pointerType, flags, x, y)
+
+    private fun WindowsPointerDispatch.eventType(): WindowsTouchEventType {
+        assertTrue(this is WindowsPointerDispatch.Send)
+        return this.event.type
+    }
+}


### PR DESCRIPTION
## 概述

为 Windows 的 `WM_POINTER*` 输入增加原生触控桥，将 `PT_TOUCH` 指针以 `PointerType.Touch` 注入 Compose Desktop。

## 变更

- 在现有 Windows `WindowProc` 中接管触控指针消息。
- 读取 `GetPointerInfo`，将首指的按下、移动、抬起转换为 Compose 指针事件。
- 触控序列接管后持续消费其消息，避免同一次触控再走默认鼠标路径。
- 触控桥无法创建或运行失败时，保留原有 AWT 鼠标输入路径。
- 增加指针序列、取消、异常回退、坐标转换和 Compose 内部 API 兼容性测试。

## 范围

当前实现是单指 MVP：桌面端主要交互可使用触控；多指手势（如图片缩放）暂不支持。

桌面播放器仍保持现有 `MOUSE` 手势语义。后续需要根据实际输入来源、触控能力和平台特性设计统一的设备/手势策略。

## 验证

- 已在 Windows on ARM 二合一设备上实机验证。
- 新增 `WindowsPointerInputTest` 与 `ComposeSceneTouchBridgeTest`，覆盖状态机、异常回退、坐标换算及 Compose 内部 `sendPointerEvent` 重载约束。

Closes #1732