### PR TITLE
Fix macOS Anitorrent library extraction directory

### DIFF
--- a/torrent/anitorrent/src/desktopTest/kotlin/AnitorrentLibraryLoaderTest.kt
+++ b/torrent/anitorrent/src/desktopTest/kotlin/AnitorrentLibraryLoaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -9,17 +9,55 @@
 
 package me.him188.ani.app.torrent.anitorrent
 
+import me.him188.ani.utils.platform.Arch
+import me.him188.ani.utils.platform.Platform
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
+import java.nio.file.Files
+import java.nio.file.Paths
 import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class AnitorrentLibraryLoaderTest {
     @Test
-    @DisabledOnOs(OS.LINUX)
-    fun `can load in debug mode`() { // 注意, 这个 test 无法测试打包之后的
+    @EnabledOnOs(OS.WINDOWS)
+    fun `can load in debug mode on Windows`() { // 注意, 这个 test 无法测试打包之后的
         assertDoesNotThrow {
             AnitorrentLibraryLoader.loadLibraries()
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    fun `can load in debug mode when the working directory is macOS root`() {
+        val originalWorkingDirectory = System.getProperty("user.dir")
+        try {
+            System.setProperty("user.dir", "/")
+            assertDoesNotThrow {
+                AnitorrentLibraryLoader.loadLibraries()
+            }
+        } finally {
+            System.setProperty("user.dir", originalWorkingDirectory)
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    fun `uses a writable temp directory instead of the working directory on macOS`() {
+        val workingDirectory = Paths.get("/")
+        val tempDirectory = AnitorrentLibraryLoader.getTempDirForPlatform(
+            Platform.MacOS(Arch.AARCH64),
+            workingDirectory,
+        )
+
+        try {
+            assertNotEquals(workingDirectory, tempDirectory)
+            assertTrue(tempDirectory.startsWith(Paths.get(System.getProperty("java.io.tmpdir"))))
+            assertTrue(Files.isWritable(tempDirectory))
+        } finally {
+            tempDirectory.toFile().deleteRecursively()
         }
     }
 }

--- a/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
+++ b/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
@@ -12,7 +12,6 @@ package me.him188.ani.app.torrent.anitorrent
 import me.him188.ani.app.torrent.api.TorrentLibraryLoader
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
-import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.Arch
 import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatform
@@ -96,16 +95,7 @@ object AnitorrentLibraryLoader : TorrentLibraryLoader {
         if (targetPlatform !is Platform.MacOS) return workingDirectory
 
         return Files.createTempDirectory("animeko-anitorrent-").apply {
-            Runtime.getRuntime().addShutdownHook(
-                Thread(
-                    {
-                        if (!toFile().deleteRecursively()) {
-                            logger.warn { "Failed to delete temporary anitorrent library directory $this" }
-                        }
-                    },
-                    "anitorrent-library-cleanup",
-                ),
-            )
+            toFile().deleteOnExit()
         }
     }
 
@@ -141,6 +131,9 @@ object AnitorrentLibraryLoader : TorrentLibraryLoader {
         tempDir: Path
     ) {
         extractLibraryFromResources(name, tempDir)?.let {
+            if (platform is Platform.MacOS) {
+                it.toFile().deleteOnExit()
+            }
             System.load(it.absolutePathString())
         } ?: throw UnsatisfiedLinkError("Failed to extract library $name from resources (possibly no such resource)")
     }

--- a/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
+++ b/torrent/anitorrent/src/jvmMain/kotlin/AnitorrentLibraryLoader.kt
@@ -12,12 +12,14 @@ package me.him188.ani.app.torrent.anitorrent
 import me.him188.ani.app.torrent.api.TorrentLibraryLoader
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.Arch
 import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatform
 import me.him188.ani.utils.platform.isAndroid
 import org.openani.anitorrent.binding.anitorrentJNI
 import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
@@ -87,23 +89,24 @@ object AnitorrentLibraryLoader : TorrentLibraryLoader {
         }
     }
 
-    private fun getTempDirForPlatform(): Path {
-        return Paths.get(System.getProperty("user.dir")) // macos 也得输出到当前目录, 因为 link path 只包含一些系统路径和 .
-//        return if (platform is Platform.Windows) {
-//            Paths.get(System.getProperty("user.dir"))
-//        } else {
-//            Files.createTempDirectory("libanitorrent${Random.nextInt().absoluteValue}").apply {
-//                Runtime.getRuntime().addShutdownHook(
-//                    Thread {
-//                        try {
-//                            deleteRecursively()
-//                        } catch (e: IOException) {
-//                            logger.error(e) { "Failed to delete temp directory $this" }
-//                        }
-//                    },
-//                )
-//            }
-//        }
+    internal fun getTempDirForPlatform(
+        targetPlatform: Platform.Desktop = platform as Platform.Desktop,
+        workingDirectory: Path = Paths.get(System.getProperty("user.dir")),
+    ): Path {
+        if (targetPlatform !is Platform.MacOS) return workingDirectory
+
+        return Files.createTempDirectory("animeko-anitorrent-").apply {
+            Runtime.getRuntime().addShutdownHook(
+                Thread(
+                    {
+                        if (!toFile().deleteRecursively()) {
+                            logger.warn { "Failed to delete temporary anitorrent library directory $this" }
+                        }
+                    },
+                    "anitorrent-library-cleanup",
+                ),
+            )
+        }
     }
 
 


### PR DESCRIPTION
Closes #3165

## Summary

- extract the fallback macOS `libanitorrent.dylib` into a unique writable system temp directory instead of `user.dir`
- remove the temporary native-library directory during JVM shutdown while preserving the existing extraction behavior on other desktop platforms
- add macOS regression coverage for a packaged-style `user.dir=/` launch and for writable temp-directory selection

## Verification

- `./gradlew :torrent:anitorrent:desktopTest --stacktrace`
- `./gradlew :app:shared:compileKotlinDesktop`
- built and launched the packaged macOS `Ani.app` with the repo `desktop-ui-verify` skill
- confirmed the real packaged process had `user.dir: /`, extracted to `/var/folders/.../T/animeko-anitorrent-*`, then logged `Loading anitorrent library: success (from resources)`, `Anitorrent is loaded`, and `Loaded libraries for AnitorrentEngine`
- visually inspected the launched 1440x900 desktop window and confirmed the temporary extraction directory was removed after app shutdown

No UI code changed, so no UI screenshot is applicable.