### PR TITLE
Add opt-in WebView media URL scanning

### DIFF
--- a/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.domain.media.resolver
 import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
@@ -20,9 +21,7 @@ import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -155,6 +154,8 @@ class AndroidWebViewVideoExtractor(
         return withContext(Dispatchers.Main) {
             val deferred = CompletableDeferred<WebResource>()
             val loadedNestedUrls = ConcurrentSkipListSet<String>()
+            val domMediaUrlCollector = DomMediaUrlCollector()
+            val inlineScriptUrlCollector = InlineScriptUrlCollector()
 
             runCatching {
                 for (string in config.cookies) {
@@ -168,6 +169,7 @@ class AndroidWebViewVideoExtractor(
              * @return if the url has been consumed
              */
             fun handleUrl(webView: WebView, url: String): Boolean {
+                if (!deferred.isActive) return false
                 val matched = resourceMatcher(url)
                 when (matched) {
                     Instruction.Continue -> return false
@@ -179,6 +181,7 @@ class AndroidWebViewVideoExtractor(
                     Instruction.LoadPage -> {
                         logger.info { "WebView loading nested page: $url" }
                         launch(Dispatchers.Main) {
+                            if (!deferred.isActive) return@launch
                             if (webView.url == url) return@launch // avoid infinite loop
                             if (!loadedNestedUrls.add(url)) return@launch
                             logger.info { "WebView navigating to new url: $url" }
@@ -191,7 +194,15 @@ class AndroidWebViewVideoExtractor(
             }
 
             loadedNestedUrls.add(pageUrl)
-            createWebView(context, deferred, ::handleUrl).loadUrl(pageUrl)
+            val webView = createWebView(
+                context = context,
+                pageUrl = pageUrl,
+                config = config,
+                deferred = deferred,
+                domMediaUrlCollector = domMediaUrlCollector,
+                inlineScriptUrlCollector = inlineScriptUrlCollector,
+                handleUrl = ::handleUrl,
+            )
 
             //            webView.webChromeClient = object : WebChromeClient() {
             //                override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
@@ -208,6 +219,7 @@ class AndroidWebViewVideoExtractor(
             //            }
 
             try {
+                webView.loadUrl(pageUrl)
                 withTimeoutOrNull(timeoutMillis) {
                     deferred.await()
                 }
@@ -216,28 +228,87 @@ class AndroidWebViewVideoExtractor(
                     deferred.cancel()
                 }
                 throw e
+            } finally {
+                if (deferred.isActive) {
+                    deferred.cancel()
+                }
+                if (config.scanDomMediaUrls) {
+                    webView.evaluateJavascript(stopDomMediaUrlScannerScript(), null)
+                    webView.removeJavascriptInterface(DOM_MEDIA_URL_JAVASCRIPT_INTERFACE)
+                }
+                if (config.scanInlineScriptUrls) {
+                    webView.evaluateJavascript(stopInlineScriptUrlScannerScript(), null)
+                    webView.removeJavascriptInterface(INLINE_SCRIPT_URL_JAVASCRIPT_INTERFACE)
+                }
+                webView.stopLoading()
+                webView.webViewClient = WebViewClient()
+                webView.destroy()
             }
         }
 //        }
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    @OptIn(DelicateCoroutinesApi::class)
     private fun createWebView(
         context: Context,
+        pageUrl: String,
+        config: WebViewConfig,
         deferred: CompletableDeferred<WebResource>,
+        domMediaUrlCollector: DomMediaUrlCollector,
+        inlineScriptUrlCollector: InlineScriptUrlCollector,
         handleUrl: (WebView, String) -> Boolean,
     ): WebView = WebView(context).apply {
         val webView = this
-        deferred.invokeOnCompletion {
-            GlobalScope.launch(Dispatchers.Main.immediate) {
-                webView.destroy()
-            }
+        if (config.scanDomMediaUrls) {
+            addJavascriptInterface(
+                DomMediaUrlJavascriptInterface { rawUrl ->
+                    webView.post {
+                        if (!deferred.isActive) return@post
+                        val baseUrl = webView.url ?: pageUrl
+                        val absoluteUrl = domMediaUrlCollector.collect(baseUrl, rawUrl) ?: return@post
+                        handleUrl(webView, absoluteUrl)
+                    }
+                },
+                DOM_MEDIA_URL_JAVASCRIPT_INTERFACE,
+            )
+        }
+        if (config.scanInlineScriptUrls) {
+            addJavascriptInterface(
+                InlineScriptUrlJavascriptInterface { rawUrl ->
+                    webView.post {
+                        if (!deferred.isActive) return@post
+                        val baseUrl = webView.url ?: pageUrl
+                        val absoluteUrl = inlineScriptUrlCollector.collect(baseUrl, rawUrl) ?: return@post
+                        handleUrl(webView, absoluteUrl)
+                    }
+                },
+                INLINE_SCRIPT_URL_JAVASCRIPT_INTERFACE,
+            )
         }
         webView.settings.javaScriptEnabled = true
         webView.settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         webView.settings.domStorageEnabled = true
         webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView, url: String) {
+                super.onPageFinished(view, url)
+                if (config.scanDomMediaUrls && deferred.isActive) {
+                    view.evaluateJavascript(
+                        domMediaUrlScannerScript(
+                            "window.$DOM_MEDIA_URL_JAVASCRIPT_INTERFACE.report(url);",
+                        ),
+                        null,
+                    )
+                }
+                if (config.scanInlineScriptUrls && deferred.isActive) {
+                    view.evaluateJavascript(
+                        inlineScriptUrlScannerScript(
+                            "window.$INLINE_SCRIPT_URL_JAVASCRIPT_INTERFACE.report(url);",
+                        ),
+                        null,
+                    )
+                }
+            }
+
             override fun shouldInterceptRequest(
                 view: WebView,
                 request: WebResourceRequest
@@ -263,6 +334,24 @@ class AndroidWebViewVideoExtractor(
                 }
                 super.onLoadResource(view, url)
             }
+        }
+    }
+
+    private class DomMediaUrlJavascriptInterface(
+        private val onUrl: (String) -> Unit,
+    ) {
+        @JavascriptInterface
+        fun report(url: String) {
+            onUrl(url)
+        }
+    }
+
+    private class InlineScriptUrlJavascriptInterface(
+        private val onUrl: (String) -> Unit,
+    ) {
+        @JavascriptInterface
+        fun report(url: String) {
+            onUrl(url)
         }
     }
 }

--- a/app/shared/app-data/src/appleMain/kotlin/domain/media/resolver/MediaResolver.apple.kt
+++ b/app/shared/app-data/src/appleMain/kotlin/domain/media/resolver/MediaResolver.apple.kt
@@ -150,11 +150,18 @@ class IosWebViewVideoExtractor(
         resourceMatcher: (String) -> WebViewVideoExtractor.Instruction
     ): WebResource? = withContext(Dispatchers.Main) {
         initWebView()
+        configureUserScripts(config)
 
         // Create a new handler for each request to avoid re-entrancy issues
         val handler = Handler(pageUrl, config, resourceMatcher)
         currentHandler = handler
-        handler.run()
+        try {
+            handler.run()
+        } finally {
+            if (currentHandler === handler) {
+                currentHandler = null
+            }
+        }
     }
 
     // Must be on Main thread
@@ -175,68 +182,23 @@ class IosWebViewVideoExtractor(
                         try {
                             val body = didReceiveScriptMessage.body.toString()
                             logger.info { "JS -> Native: $body" }
-                            currentHandler?.handleInterceptedUrl(body)
+                            if (body.startsWith(DOM_MEDIA_URL_MESSAGE_PREFIX)) {
+                                currentHandler?.handleDomMediaUrl(
+                                    body.removePrefix(DOM_MEDIA_URL_MESSAGE_PREFIX),
+                                )
+                            } else if (body.startsWith(INLINE_SCRIPT_URL_MESSAGE_PREFIX)) {
+                                currentHandler?.handleInlineScriptUrl(
+                                    body.removePrefix(INLINE_SCRIPT_URL_MESSAGE_PREFIX),
+                                )
+                            } else {
+                                currentHandler?.handleInterceptedUrl(body)
+                            }
                         } catch (e: Throwable) {
                             logger.warn(e) { "Error in script message handler" }
                         }
                     }
                 },
                 name = "AniIntercept",
-            )
-
-            // Insert a small test to ensure the script actually runs
-            val injectionScript = """
-            console.log("[AniIntercept] Script injected at documentStart.");
-            (function() {
-                function reportUrl(value) {
-                    try {
-                        let url;
-                        if (typeof value === 'string') {
-                            url = value;
-                        } else if (typeof Request !== 'undefined' && value instanceof Request) {
-                            url = value.url;
-                        } else if (typeof URL !== 'undefined' && value instanceof URL) {
-                            url = value.href;
-                        } else {
-                            url = String(value);
-                        }
-                        window.webkit.messageHandlers.AniIntercept.postMessage(url);
-                    } catch (error) {
-                        console.warn("[AniIntercept] Failed to report URL:", error);
-                    }
-                }
-
-                const oldFetch = window.fetch;
-                window.fetch = function() {
-                    const url = arguments[0];
-                    console.log("[AniIntercept] fetch called:", url);
-                    reportUrl(url);
-                    return oldFetch.apply(this, arguments);
-                };
-
-                const oldOpen = XMLHttpRequest.prototype.open;
-                XMLHttpRequest.prototype.open = function(method, url) {
-                    console.log("[AniIntercept] XHR open:", url);
-                    reportUrl(url);
-                    return oldOpen.apply(this, arguments);
-                };
-
-                const origSetSrc = HTMLMediaElement.prototype.setAttribute;
-                HTMLMediaElement.prototype.setAttribute = function(name, value) {
-                    if (name === 'src') {
-                        reportUrl(value);
-                    }
-                    return origSetSrc.apply(this, arguments);
-                };
-            })();
-        """.trimIndent()
-
-            addUserScript(
-                WKUserScript(
-                    source = injectionScript,
-                    injectionTime = WKUserScriptInjectionTime.WKUserScriptInjectionTimeAtDocumentStart,
-                    forMainFrameOnly = false,
-                ),
             )
         }
 
@@ -257,6 +219,92 @@ class IosWebViewVideoExtractor(
         )
     }
 
+    @OptIn(ExperimentalForeignApi::class)
+    private fun configureUserScripts(config: WebViewConfig) {
+        aniInterceptContentController.removeAllUserScripts()
+        aniInterceptContentController.addUserScript(
+            WKUserScript(
+                source = """
+                    console.log("[AniIntercept] Script injected at documentStart.");
+                    (function() {
+                        function reportUrl(value) {
+                            try {
+                                let url;
+                                if (typeof value === 'string') {
+                                    url = value;
+                                } else if (typeof Request !== 'undefined' && value instanceof Request) {
+                                    url = value.url;
+                                } else if (typeof URL !== 'undefined' && value instanceof URL) {
+                                    url = value.href;
+                                } else {
+                                    url = String(value);
+                                }
+                                window.webkit.messageHandlers.AniIntercept.postMessage(url);
+                            } catch (error) {
+                                console.warn("[AniIntercept] Failed to report URL:", error);
+                            }
+                        }
+
+                        const oldFetch = window.fetch;
+                        window.fetch = function() {
+                            const url = arguments[0];
+                            console.log("[AniIntercept] fetch called:", url);
+                            reportUrl(url);
+                            return oldFetch.apply(this, arguments);
+                        };
+
+                        const oldOpen = XMLHttpRequest.prototype.open;
+                        XMLHttpRequest.prototype.open = function(method, url) {
+                            console.log("[AniIntercept] XHR open:", url);
+                            reportUrl(url);
+                            return oldOpen.apply(this, arguments);
+                        };
+
+                        const origSetSrc = HTMLMediaElement.prototype.setAttribute;
+                        HTMLMediaElement.prototype.setAttribute = function(name, value) {
+                            if (name === 'src') {
+                                reportUrl(value);
+                            }
+                            return origSetSrc.apply(this, arguments);
+                        };
+                    })();
+                """.trimIndent(),
+                injectionTime = WKUserScriptInjectionTime.WKUserScriptInjectionTimeAtDocumentStart,
+                forMainFrameOnly = false,
+            ),
+        )
+        if (config.scanDomMediaUrls) {
+            aniInterceptContentController.addUserScript(
+                WKUserScript(
+                    source = domMediaUrlScannerScript(
+                        """
+                            window.webkit.messageHandlers.AniIntercept.postMessage(
+                                "$DOM_MEDIA_URL_MESSAGE_PREFIX" + url
+                            );
+                        """.trimIndent(),
+                    ),
+                    injectionTime = WKUserScriptInjectionTime.WKUserScriptInjectionTimeAtDocumentStart,
+                    forMainFrameOnly = false,
+                ),
+            )
+        }
+        if (config.scanInlineScriptUrls) {
+            aniInterceptContentController.addUserScript(
+                WKUserScript(
+                    source = inlineScriptUrlScannerScript(
+                        """
+                            window.webkit.messageHandlers.AniIntercept.postMessage(
+                                "$INLINE_SCRIPT_URL_MESSAGE_PREFIX" + url
+                            );
+                        """.trimIndent(),
+                    ),
+                    injectionTime = WKUserScriptInjectionTime.WKUserScriptInjectionTimeAtDocumentStart,
+                    forMainFrameOnly = false,
+                ),
+            )
+        }
+    }
+
     @OptIn(DelicateCoroutinesApi::class)
     private inner class Handler(
         private val pageUrl: String,
@@ -264,6 +312,8 @@ class IosWebViewVideoExtractor(
         private val resourceMatcher: (String) -> WebViewVideoExtractor.Instruction,
     ) {
         private val deferred = CompletableDeferred<WebResource>()
+        private val domMediaUrlCollector = DomMediaUrlCollector()
+        private val inlineScriptUrlCollector = InlineScriptUrlCollector()
 
         suspend fun run(): WebResource? {
             logger.info { "Starting webview for $pageUrl" }
@@ -288,10 +338,25 @@ class IosWebViewVideoExtractor(
                 return result
             } finally {
                 logger.info { "Cleaning up webview" }
+                if (deferred.isActive) {
+                    deferred.cancel()
+                }
+                if (config.scanDomMediaUrls) {
+                    webView.evaluateJavaScript(
+                        stopDomMediaUrlScannerScript(),
+                        completionHandler = null,
+                    )
+                }
+                if (config.scanInlineScriptUrls) {
+                    webView.evaluateJavaScript(
+                        stopInlineScriptUrlScannerScript(),
+                        completionHandler = null,
+                    )
+                }
+                aniInterceptContentController.removeAllUserScripts()
                 webView.stopLoading()
                 webView.loadHTMLString("", baseURL = null)
                 webView.navigationDelegate = null
-                // Remove the injected script so subsequent calls can re-inject if needed.
             }
         }
 
@@ -304,6 +369,26 @@ class IosWebViewVideoExtractor(
                 logger.warn(e) { "Failed to handle intercepted URL: $url" }
                 null
             }
+        }
+
+        fun handleDomMediaUrl(rawUrl: String): WKNavigationActionPolicy? {
+            if (!config.scanDomMediaUrls || deferred.isCompleted) {
+                return WKNavigationActionPolicy.WKNavigationActionPolicyAllow
+            }
+            val currentWebViewUrl = webView.URL?.absoluteString ?: pageUrl
+            val absoluteUrl = domMediaUrlCollector.collect(currentWebViewUrl, rawUrl)
+                ?: return WKNavigationActionPolicy.WKNavigationActionPolicyAllow
+            return handleInterceptedUrl(absoluteUrl)
+        }
+
+        fun handleInlineScriptUrl(rawUrl: String): WKNavigationActionPolicy? {
+            if (!config.scanInlineScriptUrls || deferred.isCompleted) {
+                return WKNavigationActionPolicy.WKNavigationActionPolicyAllow
+            }
+            val currentWebViewUrl = webView.URL?.absoluteString ?: pageUrl
+            val absoluteUrl = inlineScriptUrlCollector.collect(currentWebViewUrl, rawUrl)
+                ?: return WKNavigationActionPolicy.WKNavigationActionPolicyAllow
+            return handleInterceptedUrl(absoluteUrl)
         }
 
         // Shared logic for any new request we want to evaluate

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/resolver/WebViewVideoExtractor.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/resolver/WebViewVideoExtractor.kt
@@ -14,6 +14,7 @@ import me.him188.ani.app.data.models.preference.VideoResolverSettings
 import me.him188.ani.app.domain.media.resolver.WebViewVideoExtractor.Instruction
 import me.him188.ani.app.platform.Context
 import me.him188.ani.datasources.api.matcher.WebViewConfig
+import me.him188.ani.utils.ktor.UrlHelpers
 import me.him188.ani.utils.platform.annotations.TestOnly
 
 interface WebViewVideoExtractor {
@@ -46,6 +47,345 @@ interface WebViewVideoExtractor {
 data class WebResource(
     val url: String
 )
+
+internal const val DOM_MEDIA_URL_MESSAGE_PREFIX = "__ani_dom_media_url__:"
+internal const val DOM_MEDIA_URL_JAVASCRIPT_INTERFACE = "AniDomMediaUrlScanner"
+internal const val INLINE_SCRIPT_URL_MESSAGE_PREFIX = "__ani_inline_script_url__:"
+internal const val INLINE_SCRIPT_URL_JAVASCRIPT_INTERFACE = "AniInlineScriptUrlScanner"
+
+internal const val INLINE_SCRIPT_URL_MAX_SCRIPT_LENGTH = 256 * 1024
+internal const val INLINE_SCRIPT_URL_MAX_SCRIPT_SCANS = 512
+internal const val INLINE_SCRIPT_URL_MAX_CANDIDATES_PER_SCRIPT = 64
+internal const val INLINE_SCRIPT_URL_MAX_CANDIDATES = 256
+internal const val INLINE_SCRIPT_URL_MAX_LENGTH = 4 * 1024
+
+/**
+ * Converts DOM attribute values to absolute URLs and suppresses repeats for one extraction.
+ *
+ * DOM implementations normally expose an absolute value through an element's `src` property,
+ * but normalizing again here also covers platform bridges that report the raw attribute value.
+ */
+internal class DomMediaUrlCollector {
+    private val seenUrls = mutableSetOf<String>()
+
+    fun collect(baseUrl: String, rawUrl: String): String? {
+        val normalized = rawUrl.trim().takeIf { it.isNotEmpty() } ?: return null
+        val absoluteUrl = UrlHelpers.computeAbsoluteUrlOrNull(baseUrl, normalized) ?: return null
+        return absoluteUrl.takeIf(seenUrls::add)
+    }
+}
+
+/**
+ * Normalizes URL candidates found in inline scripts and bounds matcher invocations per extraction.
+ *
+ * The page-side scanner already limits the amount of script text and candidate count it processes.
+ * These checks form a second boundary at the native bridge, where input must still be treated as
+ * untrusted.
+ */
+internal class InlineScriptUrlCollector(
+    private val maxCandidates: Int = INLINE_SCRIPT_URL_MAX_CANDIDATES,
+    private val maxUrlLength: Int = INLINE_SCRIPT_URL_MAX_LENGTH,
+) {
+    init {
+        require(maxCandidates > 0)
+        require(maxUrlLength > 0)
+    }
+
+    private val seenUrls = mutableSetOf<String>()
+
+    fun collect(baseUrl: String, rawUrl: String): String? {
+        if (seenUrls.size >= maxCandidates) return null
+        if (rawUrl.length.toLong() > maxUrlLength.toLong() * 2) return null
+
+        val normalized = rawUrl
+            .trim()
+            .replace("\\/", "/")
+            .trimEnd(',', ';', ')', ']', '}', '\\')
+        if (normalized.isEmpty() || normalized.length > maxUrlLength) return null
+        if (
+            !normalized.startsWith("http://", ignoreCase = true) &&
+            !normalized.startsWith("https://", ignoreCase = true)
+        ) {
+            return null
+        }
+
+        val absoluteUrl = UrlHelpers.computeAbsoluteUrlOrNull(baseUrl, normalized) ?: return null
+        if (absoluteUrl.length > maxUrlLength) return null
+        return absoluteUrl.takeIf(seenUrls::add)
+    }
+}
+
+/**
+ * Installs a per-document scanner for media and iframe `src` attributes.
+ *
+ * [reportUrlStatement] is JavaScript that can use the local `url` variable to bridge the value
+ * back to the platform implementation.
+ */
+internal fun domMediaUrlScannerScript(reportUrlStatement: String): String = """
+    (function() {
+        const scannerKey = "__aniDomMediaUrlScanner";
+        const previousScanner = window[scannerKey];
+        if (previousScanner && typeof previousScanner.stop === "function") {
+            previousScanner.stop();
+        }
+
+        const selector = "iframe[src],video[src],source[src],audio[src]";
+        const seenUrls = new Set();
+        let observer = null;
+        let stopped = false;
+
+        function reportElement(element) {
+            if (stopped || !element || typeof element.matches !== "function" || !element.matches(selector)) {
+                return;
+            }
+            const url = element.src;
+            if (!url || seenUrls.has(url)) {
+                return;
+            }
+            seenUrls.add(url);
+            try {
+                $reportUrlStatement
+            } catch (error) {
+                console.warn("[AniDomMediaUrlScanner] Failed to report URL:", error);
+            }
+        }
+
+        function scan(root) {
+            if (!root) {
+                return;
+            }
+            reportElement(root);
+            if (typeof root.querySelectorAll === "function") {
+                root.querySelectorAll(selector).forEach(reportElement);
+            }
+        }
+
+        function start() {
+            if (stopped) {
+                return;
+            }
+            scan(document);
+            if (!document.documentElement) {
+                return;
+            }
+            observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.type === "attributes") {
+                        reportElement(mutation.target);
+                    } else {
+                        mutation.addedNodes.forEach(scan);
+                    }
+                });
+            });
+            observer.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ["src"]
+            });
+        }
+
+        function onReady() {
+            start();
+        }
+
+        window[scannerKey] = {
+            stop: function() {
+                stopped = true;
+                document.removeEventListener("DOMContentLoaded", onReady);
+                if (observer) {
+                    observer.disconnect();
+                    observer = null;
+                }
+            }
+        };
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", onReady, { once: true });
+        } else {
+            start();
+        }
+    })();
+""".trimIndent()
+
+internal fun stopDomMediaUrlScannerScript(): String = """
+    (function() {
+        const scannerKey = "__aniDomMediaUrlScanner";
+        const scanner = window[scannerKey];
+        if (scanner && typeof scanner.stop === "function") {
+            scanner.stop();
+        }
+        delete window[scannerKey];
+    })();
+""".trimIndent()
+
+/**
+ * Installs a bounded per-document observer for URL candidates in inline `script` text.
+ *
+ * The script never evaluates the text or reads external script responses. It only reports strings
+ * that already look like absolute HTTP(S) URLs. [reportUrlStatement] may use the local `url`
+ * variable to bridge a candidate back to the platform implementation.
+ */
+internal fun inlineScriptUrlScannerScript(reportUrlStatement: String): String = """
+    (function() {
+        const scannerKey = "__aniInlineScriptUrlScanner";
+        const previousScanner = window[scannerKey];
+        if (previousScanner && typeof previousScanner.stop === "function") {
+            previousScanner.stop();
+        }
+
+        const selector = "script:not([src])";
+        const maxScriptLength = $INLINE_SCRIPT_URL_MAX_SCRIPT_LENGTH;
+        const maxScriptScans = $INLINE_SCRIPT_URL_MAX_SCRIPT_SCANS;
+        const maxCandidatesPerScript = $INLINE_SCRIPT_URL_MAX_CANDIDATES_PER_SCRIPT;
+        const maxCandidates = $INLINE_SCRIPT_URL_MAX_CANDIDATES;
+        const maxCandidateLength = ${INLINE_SCRIPT_URL_MAX_LENGTH * 2};
+        const urlPattern = /https?:\\?\/\\?\/[^\s"'<>`]+/gi;
+        const seenUrls = new Set();
+        const lastFingerprints = new WeakMap();
+        let scannedScriptCount = 0;
+        let reportedCandidateCount = 0;
+        let observer = null;
+        let stopped = false;
+
+        function stop() {
+            stopped = true;
+            document.removeEventListener("DOMContentLoaded", onReady);
+            if (observer) {
+                observer.disconnect();
+                observer = null;
+            }
+        }
+
+        function reportCandidate(rawUrl) {
+            if (stopped || !rawUrl || rawUrl.length > maxCandidateLength) {
+                return;
+            }
+            const normalizedUrl = rawUrl.replace(/\\\//g, "/");
+            if (seenUrls.has(normalizedUrl)) {
+                return;
+            }
+            seenUrls.add(normalizedUrl);
+            reportedCandidateCount += 1;
+            const url = rawUrl;
+            try {
+                $reportUrlStatement
+            } catch (error) {
+                console.warn("[AniInlineScriptUrlScanner] Failed to report URL:", error);
+            }
+            if (reportedCandidateCount >= maxCandidates) {
+                stop();
+            }
+        }
+
+        function fingerprint(text) {
+            let hash = 2166136261;
+            for (let index = 0; index < text.length; index += 1) {
+                hash ^= text.charCodeAt(index);
+                hash = Math.imul(hash, 16777619);
+            }
+            return text.length + ":" + (hash >>> 0);
+        }
+
+        function scanScript(script) {
+            if (
+                stopped ||
+                !script ||
+                typeof script.matches !== "function" ||
+                !script.matches(selector)
+            ) {
+                return;
+            }
+            if (scannedScriptCount >= maxScriptScans) {
+                stop();
+                return;
+            }
+
+            const text = (script.textContent || "").slice(0, maxScriptLength);
+            const currentFingerprint = fingerprint(text);
+            if (lastFingerprints.get(script) === currentFingerprint) {
+                return;
+            }
+            lastFingerprints.set(script, currentFingerprint);
+            scannedScriptCount += 1;
+
+            urlPattern.lastIndex = 0;
+            let candidateCount = 0;
+            let match;
+            while (!stopped && candidateCount < maxCandidatesPerScript && (match = urlPattern.exec(text)) !== null) {
+                candidateCount += 1;
+                reportCandidate(match[0]);
+            }
+            if (scannedScriptCount >= maxScriptScans) {
+                stop();
+            }
+        }
+
+        function scan(root) {
+            if (stopped || !root) {
+                return;
+            }
+            if (root.nodeType === Node.TEXT_NODE) {
+                const ownerScript = root.parentElement && root.parentElement.closest(selector);
+                scanScript(ownerScript);
+                return;
+            }
+            scanScript(root);
+            if (typeof root.querySelectorAll === "function") {
+                root.querySelectorAll(selector).forEach(scanScript);
+            }
+        }
+
+        function start() {
+            if (stopped) {
+                return;
+            }
+            scan(document);
+            if (stopped || !document.documentElement) {
+                return;
+            }
+            observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.type === "characterData" || mutation.type === "attributes") {
+                        scan(mutation.target);
+                    } else {
+                        scanScript(mutation.target);
+                        mutation.addedNodes.forEach(scan);
+                    }
+                });
+            });
+            observer.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+                characterData: true,
+                attributes: true,
+                attributeFilter: ["src"]
+            });
+        }
+
+        function onReady() {
+            start();
+        }
+
+        window[scannerKey] = { stop: stop };
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", onReady, { once: true });
+        } else {
+            start();
+        }
+    })();
+""".trimIndent()
+
+internal fun stopInlineScriptUrlScannerScript(): String = """
+    (function() {
+        const scannerKey = "__aniInlineScriptUrlScanner";
+        const scanner = window[scannerKey];
+        if (scanner && typeof scanner.stop === "function") {
+            scanner.stop();
+        }
+        delete window[scannerKey];
+    })();
+""".trimIndent()
 
 expect fun WebViewVideoExtractor(
     proxyConfig: ProxyConfig?,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSource.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSource.kt
@@ -435,12 +435,18 @@ class SelectorMediaSource(
                     mediaSourceId = mediaSourceId,
                     pageUrl = searchConfig.searchUrl,
                 )
+                val scanDomMediaUrls = config.scanDomMediaUrls ||
+                        arguments.searchConfig.matchVideo.scanDomMediaUrls
+                val scanInlineScriptUrls = config.scanInlineScriptUrls ||
+                        arguments.searchConfig.matchVideo.scanInlineScriptUrls
                 return config.copy(
                     cookies = mergeCookies(
                         config.cookies,
                         configuredCookies,
                         captchaCookies,
                     ),
+                    scanDomMediaUrls = scanDomMediaUrls,
+                    scanInlineScriptUrls = scanInlineScriptUrls,
                 )
             }
         }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorSearchConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorSearchConfig.kt
@@ -114,6 +114,8 @@ data class SelectorSearchConfig(
     @Serializable
     @Suppress("RegExpRedundantEscape")
     data class MatchVideoConfig(
+        val scanDomMediaUrls: Boolean = false,
+        val scanInlineScriptUrls: Boolean = false,
         val enableNestedUrl: Boolean = true,
         @param:Language("regexp")
         val matchNestedUrl: String = """^.+(m3u8|vip|xigua\.php).+\?""",

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/resolver/DomMediaUrlCollectorTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/resolver/DomMediaUrlCollectorTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.resolver
+
+import me.him188.ani.datasources.api.matcher.WebViewConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class DomMediaUrlCollectorTest {
+    @Test
+    fun `web view config keeps DOM scanning disabled by default`() {
+        assertFalse(WebViewConfig().scanDomMediaUrls)
+    }
+
+    @Test
+    fun `resolves relative DOM URL against document URL`() {
+        val collector = DomMediaUrlCollector()
+
+        assertEquals(
+            "https://example.com/player/media/video.m3u8",
+            collector.collect(
+                baseUrl = "https://example.com/player/index.html",
+                rawUrl = "media/video.m3u8",
+            ),
+        )
+    }
+
+    @Test
+    fun `deduplicates equivalent absolute and relative DOM URLs`() {
+        val collector = DomMediaUrlCollector()
+
+        assertEquals(
+            "https://example.com/player/video.mp4",
+            collector.collect("https://example.com/player/index.html", "video.mp4"),
+        )
+        assertNull(
+            collector.collect(
+                "https://example.com/another-page.html",
+                "https://example.com/player/video.mp4",
+            ),
+        )
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/resolver/InlineScriptUrlCollectorTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/resolver/InlineScriptUrlCollectorTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.resolver
+
+import me.him188.ani.datasources.api.matcher.WebViewConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InlineScriptUrlCollectorTest {
+    @Test
+    fun `web view config keeps inline script scanning disabled by default`() {
+        assertFalse(WebViewConfig().scanInlineScriptUrls)
+    }
+
+    @Test
+    fun `normalizes escaped slash URL and makes it absolute`() {
+        val collector = InlineScriptUrlCollector()
+
+        assertEquals(
+            "https://media.example.com/video/index.m3u8",
+            collector.collect(
+                baseUrl = "https://example.com/player/index.html",
+                rawUrl = "https:\\/\\/media.example.com\\/video\\/index.m3u8",
+            ),
+        )
+    }
+
+    @Test
+    fun `deduplicates escaped and plain forms`() {
+        val collector = InlineScriptUrlCollector()
+
+        assertEquals(
+            "https://media.example.com/video.mp4",
+            collector.collect("https://example.com", "https:\\/\\/media.example.com\\/video.mp4"),
+        )
+        assertNull(
+            collector.collect("https://example.com", "https://media.example.com/video.mp4"),
+        )
+    }
+
+    @Test
+    fun `bounds candidate count and URL length`() {
+        val collector = InlineScriptUrlCollector(maxCandidates = 2, maxUrlLength = 64)
+
+        assertEquals(
+            "https://example.com/1.m3u8",
+            collector.collect("https://example.com", "https://example.com/1.m3u8"),
+        )
+        assertEquals(
+            "https://example.com/2.m3u8",
+            collector.collect("https://example.com", "https://example.com/2.m3u8"),
+        )
+        assertNull(collector.collect("https://example.com", "https://example.com/3.m3u8"))
+
+        val lengthLimited = InlineScriptUrlCollector(maxCandidates = 2, maxUrlLength = 32)
+        assertNull(
+            lengthLimited.collect(
+                "https://example.com",
+                "https://example.com/" + "x".repeat(64) + ".m3u8",
+            ),
+        )
+    }
+
+    @Test
+    fun `scanner script observes initial and rewritten inline scripts with limits`() {
+        val script = inlineScriptUrlScannerScript("bridge.report(url);")
+
+        assertTrue("script:not([src])" in script)
+        assertTrue("new MutationObserver" in script)
+        assertTrue("characterData: true" in script)
+        assertTrue("bridge.report(url);" in script)
+        assertTrue("const maxScriptLength = $INLINE_SCRIPT_URL_MAX_SCRIPT_LENGTH;" in script)
+        assertTrue("const maxScriptScans = $INLINE_SCRIPT_URL_MAX_SCRIPT_SCANS;" in script)
+        assertTrue("const maxCandidates = $INLINE_SCRIPT_URL_MAX_CANDIDATES;" in script)
+        assertTrue("__aniInlineScriptUrlScanner" in stopInlineScriptUrlScannerScript())
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorMediaSourceMatcherCaptchaTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorMediaSourceMatcherCaptchaTest.kt
@@ -22,6 +22,7 @@ import me.him188.ani.datasources.api.source.serializeArguments
 import me.him188.ani.utils.ktor.asScopedHttpClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SelectorMediaSourceMatcherCaptchaTest {
     @Test
@@ -39,6 +40,8 @@ class SelectorMediaSourceMatcherCaptchaTest {
                             searchUrl = "https://www.example.com/search/{keyword}",
                             matchVideo = SelectorSearchConfig.MatchVideoConfig(
                                 cookies = "quality=1080\nsession=static",
+                                scanDomMediaUrls = true,
+                                scanInlineScriptUrls = true,
                             ),
                         ),
                     ),
@@ -81,6 +84,8 @@ class SelectorMediaSourceMatcherCaptchaTest {
             ),
             patched.cookies.associateBy { it.substringBefore("=") },
         )
+        assertTrue(patched.scanDomMediaUrls)
+        assertTrue(patched.scanInlineScriptUrls)
     }
 
     private class FakeWebCaptchaCoordinator(

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorSearchConfigMatchVideoTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorSearchConfigMatchVideoTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.web
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SelectorSearchConfigMatchVideoTest {
+    @Test
+    fun `old JSON defaults optional scanners to disabled`() {
+        val decoded = Json.decodeFromString<SelectorSearchConfig>("""{"matchVideo":{}}""")
+
+        assertFalse(decoded.matchVideo.scanDomMediaUrls)
+        assertFalse(decoded.matchVideo.scanInlineScriptUrls)
+    }
+
+    @Test
+    fun `DOM scanning survives JSON round trip`() {
+        val original = SelectorSearchConfig.MatchVideoConfig(scanDomMediaUrls = true)
+
+        val encoded = Json.encodeToString(original)
+        val decoded = Json.decodeFromString<SelectorSearchConfig.MatchVideoConfig>(encoded)
+
+        assertTrue("\"scanDomMediaUrls\":true" in encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `inline script scanning survives JSON round trip`() {
+        val original = SelectorSearchConfig.MatchVideoConfig(scanInlineScriptUrls = true)
+
+        val encoded = Json.encodeToString(original)
+        val decoded = Json.decodeFromString<SelectorSearchConfig.MatchVideoConfig>(encoded)
+
+        assertTrue("\"scanInlineScriptUrls\":true" in encoded)
+        assertEquals(original, decoded)
+    }
+}

--- a/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/domain/media/resolver/DesktopWebMediaResolver.kt
@@ -48,6 +48,7 @@ import org.cef.browser.CefFrame
 import org.cef.browser.CefRendering
 import org.cef.browser.CefRequestContext
 import org.cef.handler.CefDisplayHandlerAdapter
+import org.cef.handler.CefLoadHandlerAdapter
 import org.cef.handler.CefResourceRequestHandlerAdapter
 import org.cef.network.CefCookie
 import org.cef.network.CefCookieManager
@@ -153,6 +154,38 @@ class CefVideoExtractor(
         var client: org.cef.CefClient? = null
         var browser: CefBrowser? = null
         val deferred = CompletableDeferred<WebResource>()
+        val domMediaUrlCollector = DomMediaUrlCollector()
+        val inlineScriptUrlCollector = InlineScriptUrlCollector()
+        val lastUrl = object {
+            // browser.url is not updated immediately, so we need to keep track of the current url.
+            var value: String? by atomic(null)
+        }
+
+        /**
+         * @return `true` to intercept the request that supplied [url].
+         */
+        fun handleUrl(browser: CefBrowser, url: String): Boolean = synchronized(deferred) {
+            if (!deferred.isActive) return false
+            return when (resourceMatcher(url)) {
+                Instruction.Continue -> false
+                Instruction.FoundResource -> {
+                    deferred.complete(WebResource(url))
+                    logger.info { "Found video stream resource: $url" }
+                    true
+                }
+
+                Instruction.LoadPage -> {
+                    if (browser.url == url || lastUrl.value == url) return false // don't recurse
+                    logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
+                    lastUrl.value = url
+                    val escapedUrl = json.encodeToString(String.serializer(), url)
+                    AniCefApp.runOnCefContext {
+                        browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
+                    }
+                    true
+                }
+            }
+        }
 
         try {
             val createdClient = AniCefApp.suspendCoroutineOnCefContext {
@@ -164,10 +197,6 @@ class CefVideoExtractor(
             client = createdClient
 
             val createdBrowser = AniCefApp.suspendCoroutineOnCefContext {
-                val lastUrl = object {
-                    // browser.url is not updated immediately, so we need to keep track of the current url.
-                    var value: String? by atomic(null)
-                }
                 createdClient.createBrowser(
                     pageUrl,
                     CefRendering.DEFAULT,
@@ -180,41 +209,11 @@ class CefVideoExtractor(
                                 request: CefRequest?
                             ): Boolean {
                                 if (request != null && browser != null) {
-                                    if (handleUrl(request, browser)) {
+                                    if (handleUrl(browser, request.url)) {
                                         return true
                                     }
                                 }
                                 return super.onBeforeResourceLoad(browser, frame, request)
-                            }
-
-                            /**
-                             * @return `true` to intercept
-                             */
-                            private fun handleUrl(
-                                request: CefRequest,
-                                browser: CefBrowser
-                            ): Boolean = synchronized(this) {
-                                val url = request.url
-                                val matched = resourceMatcher(url)
-                                when (matched) {
-                                    Instruction.Continue -> return false
-                                    Instruction.FoundResource -> {
-                                        deferred.complete(WebResource(url))
-                                        logger.info { "Found video stream resource: $url" }
-                                        return true
-                                    }
-
-                                    Instruction.LoadPage -> {
-                                        if (browser.url == url || lastUrl.value == url) return false // don't recurse
-                                        logger.info { "CEF loading nested page: $url, lastUrl=${lastUrl.value}" }
-                                        lastUrl.value = url
-                                        val escapedUrl = json.encodeToString(String.serializer(), url)
-                                        AniCefApp.runOnCefContext {
-                                            browser.executeJavaScript("window.location.href=$escapedUrl;", "", 1)
-                                        }
-                                        return true
-                                    }
-                                }
                             }
                         }
                     },
@@ -224,6 +223,37 @@ class CefVideoExtractor(
 
             AniCefApp.suspendCoroutineOnCefContext {
                 createdBrowser.setCloseAllowed()
+                if (config.scanDomMediaUrls || config.scanInlineScriptUrls) {
+                    createdClient.addLoadHandler(
+                        object : CefLoadHandlerAdapter() {
+                            override fun onLoadEnd(
+                                browser: CefBrowser?,
+                                frame: CefFrame?,
+                                httpStatusCode: Int,
+                            ) {
+                                if (frame == null || !deferred.isActive) return
+                                if (config.scanDomMediaUrls) {
+                                    frame.executeJavaScript(
+                                        domMediaUrlScannerScript(
+                                            "console.log(\"$DOM_MEDIA_URL_MESSAGE_PREFIX\" + url);",
+                                        ),
+                                        frame.url,
+                                        1,
+                                    )
+                                }
+                                if (config.scanInlineScriptUrls) {
+                                    frame.executeJavaScript(
+                                        inlineScriptUrlScannerScript(
+                                            "console.log(\"$INLINE_SCRIPT_URL_MESSAGE_PREFIX\" + url);",
+                                        ),
+                                        frame.url,
+                                        1,
+                                    )
+                                }
+                            }
+                        },
+                    )
+                }
                 createdClient.addDisplayHandler(
                     object : CefDisplayHandlerAdapter() {
                         override fun onConsoleMessage(
@@ -233,6 +263,37 @@ class CefVideoExtractor(
                             source: String?,
                             line: Int
                         ): Boolean {
+                            if (
+                                config.scanDomMediaUrls &&
+                                browser != null &&
+                                message?.startsWith(DOM_MEDIA_URL_MESSAGE_PREFIX) == true
+                            ) {
+                                val rawUrl = message.removePrefix(DOM_MEDIA_URL_MESSAGE_PREFIX)
+                                val baseUrl = source?.takeIf { it.isNotBlank() }
+                                    ?: browser.url?.takeIf { it.isNotBlank() }
+                                    ?: pageUrl
+                                val absoluteUrl = synchronized(domMediaUrlCollector) {
+                                    domMediaUrlCollector.collect(baseUrl, rawUrl)
+                                }
+                                if (absoluteUrl != null) {
+                                    handleUrl(browser, absoluteUrl)
+                                }
+                            } else if (
+                                config.scanInlineScriptUrls &&
+                                browser != null &&
+                                message?.startsWith(INLINE_SCRIPT_URL_MESSAGE_PREFIX) == true
+                            ) {
+                                val rawUrl = message.removePrefix(INLINE_SCRIPT_URL_MESSAGE_PREFIX)
+                                val baseUrl = source?.takeIf { it.isNotBlank() }
+                                    ?: browser.url?.takeIf { it.isNotBlank() }
+                                    ?: pageUrl
+                                val absoluteUrl = synchronized(inlineScriptUrlCollector) {
+                                    inlineScriptUrlCollector.collect(baseUrl, rawUrl)
+                                }
+                                if (absoluteUrl != null) {
+                                    handleUrl(browser, absoluteUrl)
+                                }
+                            }
                             logger.info { "CEF client console: ${message?.replace("\n", "\\n")} ($source:$line)" }
                             return super.onConsoleMessage(browser, level, message, source, line)
                         }
@@ -265,6 +326,27 @@ class CefVideoExtractor(
             null
         } finally {
             withContext(NonCancellable) {
+                if (deferred.isActive) {
+                    deferred.cancel()
+                }
+                if (config.scanDomMediaUrls && browser != null) {
+                    AniCefApp.suspendCoroutineOnCefContext {
+                        browser.executeJavaScript(
+                            stopDomMediaUrlScannerScript(),
+                            browser.url ?: pageUrl,
+                            1,
+                        )
+                    }
+                }
+                if (config.scanInlineScriptUrls && browser != null) {
+                    AniCefApp.suspendCoroutineOnCefContext {
+                        browser.executeJavaScript(
+                            stopInlineScriptUrlScannerScript(),
+                            browser.url ?: pageUrl,
+                            1,
+                        )
+                    }
+                }
                 AniCefApp.closeBrowserAndDisposeClient(browser, client)
             }
             logger.info { "CEF client is disposed." }

--- a/datasource/api/src/commonMain/kotlin/matcher/WebVideoMatcher.kt
+++ b/datasource/api/src/commonMain/kotlin/matcher/WebVideoMatcher.kt
@@ -37,6 +37,8 @@ fun interface WebVideoMatcher { // SPI service load
 
 data class WebViewConfig(
     val cookies: List<String> = emptyList(),
+    val scanDomMediaUrls: Boolean = false,
+    val scanInlineScriptUrls: Boolean = false,
 ) {
     companion object {
         val Empty = WebViewConfig()

--- a/tools/datasource-test-mcp/build.gradle.kts
+++ b/tools/datasource-test-mcp/build.gradle.kts
@@ -50,6 +50,12 @@ dependencies {
     implementation(libs.vlcj)
     implementation(compose.desktop.currentOs)
 
+    when (val triple = getOsTriple()) {
+        "windows-x64" -> runtimeOnly(libs.mediamp.mpv.runtime.windows.x64)
+        "macos-arm64" -> runtimeOnly(libs.mediamp.mpv.runtime.macos.arm64)
+        else -> {}
+    }
+
     runtimeOnly(libs.slf4j.simple)
 
     testImplementation(kotlin("test"))

--- a/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/Main.kt
+++ b/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/Main.kt
@@ -89,7 +89,7 @@ fun main(args: Array<String>) {
             probe = probe,
             analyzer = MpvVideoAnalyzer(),
             adAnalyzer = M3u8AdAnalyzer(client),
-        )
+        ).apply { initialize() }
         val sourceTestService = SourceTestService(
             httpClient = client,
             registry = DataSourceRegistry(scopedClient),

--- a/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorEngineService.kt
+++ b/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorEngineService.kt
@@ -690,7 +690,11 @@ class SelectorWebVideoMatcher(
     override fun patchConfig(config: WebViewConfig): WebViewConfig {
         val configuredCookies = matchVideoConfig.cookies.lines().filter { it.isNotBlank() }
         // 复用 SelectorMediaSource.matcher 的合并实现: 按 cookie 名去重, 后面的覆盖前面的
-        return config.copy(cookies = SelectorMediaSource.mergeCookies(config.cookies, configuredCookies))
+        return config.copy(
+            cookies = SelectorMediaSource.mergeCookies(config.cookies, configuredCookies),
+            scanDomMediaUrls = config.scanDomMediaUrls || matchVideoConfig.scanDomMediaUrls,
+            scanInlineScriptUrls = config.scanInlineScriptUrls || matchVideoConfig.scanInlineScriptUrls,
+        )
     }
 }
 

--- a/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/video/VideoService.kt
+++ b/tools/datasource-test-mcp/src/main/kotlin/me/him188/ani/tools/datasourcetestmcp/video/VideoService.kt
@@ -10,6 +10,13 @@
 package me.him188.ani.tools.datasourcetestmcp.video
 
 import kotlinx.coroutines.withTimeout
+import me.him188.ani.utils.logging.debug
+import me.him188.ani.utils.logging.error
+import me.him188.ani.utils.logging.info
+import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.trace
+import me.him188.ani.utils.logging.warn
+import org.openani.mediamp.mpv.MPVHandle
 
 /**
  * 视频能力: HTTP 可达性探测 + Animeko 播放器 (VLC) 真实播放测试.
@@ -19,6 +26,28 @@ class VideoService(
     private val analyzer: MpvVideoAnalyzer,
     private val adAnalyzer: M3u8AdAnalyzer,
 ) {
+    private val logger = logger<VideoService>()
+
+    fun initialize() {
+        MPVHandle.useDefaultRuntimeLibraryDirectory()
+        // mpv_log_level in https://github.com/mpv-player/mpv/blob/master/include/mpv/client.h
+        MPVHandle.setLogHandler {
+            val prefix = it.prefix.padStart(9, ' ')
+            val handle = "0x${it.instanceHandle.toHexString().trimStart('0')}"
+            if (it.level in 1..20) {
+                logger.error { "[$prefix@$handle] ${it.line}" }
+            } else if (it.level <= 30) {
+                logger.warn { "[$prefix@$handle] ${it.line}" }
+            } else if (it.level <= 40) {
+                logger.info { "[$prefix@$handle] ${it.line}" }
+            } else if (it.level <= 50) {
+                logger.debug { "[$prefix@$handle] ${it.line}" }
+            } else {
+                logger.trace { "[$prefix@$handle] ${it.line}" }
+            }
+        }
+    }
+
     suspend fun probeVideo(input: ProbeVideoInput): ProbeVideoResult {
         val totalStart = System.currentTimeMillis()
         val httpProbeStart = System.currentTimeMillis()

--- a/tools/datasource-test-mcp/src/main/resources/selector-engine-docs.md
+++ b/tools/datasource-test-mcp/src/main/resources/selector-engine-docs.md
@@ -118,6 +118,12 @@ MCP 工具对应关系:
 
 匹配成功后,视频请求会附带 `addHeadersToVideo` 配置的 `User-Agent` / `Referer`;
 WebView 加载播放页时会注入 `cookies`(每行一个 `name=value`)。
+`scanDomMediaUrls=true` 时还会在每个文档初次就绪和后续 DOM 变更时扫描
+`iframe[src]` / `video[src]` / `source[src]` / `audio[src]`,将去重后的绝对 URL 交给相同的
+`matchNestedUrl` / `matchVideoUrl` 逻辑。该字段默认为 `false`,旧配置的行为不变。
+`scanInlineScriptUrls=true` 时会额外扫描内联 `script` 文本中的 HTTP(S) URL 候选（包括
+`https:\/\/` 形式），并把解转义、去重后的有界候选交给同一 matcher。扫描器不会执行脚本文本、
+读取外链脚本响应或点击页面；该字段同样默认为 `false`。
 
 MCP 工具:
 

--- a/tools/datasource-test-mcp/src/test/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorWebVideoMatcherTest.kt
+++ b/tools/datasource-test-mcp/src/test/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorWebVideoMatcherTest.kt
@@ -16,6 +16,8 @@ import me.him188.ani.datasources.api.matcher.WebViewConfig
 import me.him188.ani.utils.xml.Document
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * [SelectorWebVideoMatcher.patchConfig] 的 cookie 合并必须与 App 内
@@ -30,9 +32,17 @@ class SelectorWebVideoMatcherTest {
             throw UnsupportedOperationException()
     }
 
-    private fun matcher(cookies: String) = SelectorWebVideoMatcher(
+    private fun matcher(
+        cookies: String = "",
+        scanDomMediaUrls: Boolean = false,
+        scanInlineScriptUrls: Boolean = false,
+    ) = SelectorWebVideoMatcher(
         engine,
-        SelectorSearchConfig.MatchVideoConfig(cookies = cookies),
+        SelectorSearchConfig.MatchVideoConfig(
+            cookies = cookies,
+            scanDomMediaUrls = scanDomMediaUrls,
+            scanInlineScriptUrls = scanInlineScriptUrls,
+        ),
     )
 
     @Test
@@ -63,5 +73,43 @@ class SelectorWebVideoMatcherTest {
             WebViewConfig(cookies = listOf(" quality=720 ")),
         )
         assertEquals(listOf("quality=1080"), result.cookies)
+    }
+
+    @Test
+    fun `DOM scanning config is merged with OR semantics`() {
+        assertTrue(
+            matcher(scanDomMediaUrls = true)
+                .patchConfig(WebViewConfig(scanDomMediaUrls = false))
+                .scanDomMediaUrls,
+        )
+        assertTrue(
+            matcher(scanDomMediaUrls = false)
+                .patchConfig(WebViewConfig(scanDomMediaUrls = true))
+                .scanDomMediaUrls,
+        )
+        assertFalse(
+            matcher(scanDomMediaUrls = false)
+                .patchConfig(WebViewConfig(scanDomMediaUrls = false))
+                .scanDomMediaUrls,
+        )
+    }
+
+    @Test
+    fun `inline script scanning config is merged with OR semantics`() {
+        assertTrue(
+            matcher(scanInlineScriptUrls = true)
+                .patchConfig(WebViewConfig(scanInlineScriptUrls = false))
+                .scanInlineScriptUrls,
+        )
+        assertTrue(
+            matcher(scanInlineScriptUrls = false)
+                .patchConfig(WebViewConfig(scanInlineScriptUrls = true))
+                .scanInlineScriptUrls,
+        )
+        assertFalse(
+            matcher(scanInlineScriptUrls = false)
+                .patchConfig(WebViewConfig(scanInlineScriptUrls = false))
+                .scanInlineScriptUrls,
+        )
     }
 }


### PR DESCRIPTION
## Summary

- add opt-in DOM scanning for `iframe`, `video`, `source`, and `audio` URLs across the Android, Desktop, and Apple WebView resolvers
- add bounded, deduplicated inline-script HTTP(S) URL discovery and feed candidates through the existing web video matcher
- propagate both scanner flags through `WebViewConfig` and Selector `matchVideo` configuration with backward-compatible disabled defaults and OR merge semantics
- update datasource-test-mcp coverage, embedded configuration guidance, mpv runtime packaging, and mpv initialization/logging

## Why

Some selector sources expose their final media URL only in a rendered iframe or inline player script. The existing extraction path primarily observed network requests and media assignments; after MSE setup, the visible media URL may only be a `blob:` URL. That caused extraction to time out even when the existing matcher could recognize the underlying HTTP(S) URL.

The new scanners are explicitly opt-in and pass discovered candidates to the existing matcher without clicking or executing page content. Candidate counts and lengths are bounded, URLs are normalized and deduplicated, and observers are stopped during teardown.

## Impact

Selector datasource authors can enable `scanDomMediaUrls` and/or `scanInlineScriptUrls` for affected sites. Existing configurations keep the previous behavior because both flags default to `false`.

The datasource test service now packages the supported mpv runtime and initializes native library discovery and logging, improving real playback diagnostics.

## Validation

- `.\gradlew.bat :app:shared:app-data:desktopTest :tools:datasource-test-mcp:test --stacktrace`
- `.\gradlew.bat :app:shared:app-data:testAndroidHostTest --stacktrace`
- `.\gradlew.bat :tools:datasource-test-mcp:installDist --stacktrace`
- `git diff --cached --check`

All checks passed on Windows. The Apple implementation was reviewed statically because Apple targets are not available in this environment.