### PR TITLE
fix(jellyfin): hierarchical Series→Seasons→Episodes search with subje…

### DIFF
--- a/datasource/jellyfin/README.md
+++ b/datasource/jellyfin/README.md
@@ -1,0 +1,77 @@
+# Jellyfin / Emby 数据源搜索逻辑问题
+
+## 现有 Issues
+
+### #1728 — 优化 Emby / Jellyfin 支持（Meta Issue）
+- **创建者**: Him188（项目 owner）
+- **时间**: 2025-02-26
+- **状态**: Open
+- **进度**: 仅 2/21 项完成
+- **内容**: 从 2025 年 2 月用户调研整理的需求列表，涵盖 Emby/Jellyfin 支持的各种改进点
+- **链接**: https://github.com/open-ani/animeko/issues/1728
+
+### #1484 — 关于 emby 源的若干建议和 bug
+- **状态**: Open
+- **关键讨论**: 
+  - "目前的数据源只匹配了 Season，并没有处理 Series"
+  - 有用户提供了 Emby API 的层级搜索示例代码（Series → Seasons → Episodes）
+- **链接**: https://github.com/open-ani/animeko/issues/1484
+
+---
+
+## 实际复现的问题（作为补充示例）
+
+### 场景
+Jellyfin 媒体库中有番剧：
+- `碧蓝之海 第三季`（Series 命名 = Bangumi subject 名）→ 能搜到 ✅
+- `幼女战记`（Series 命名 = 基础番名，不含"第二季"）→ 搜不到 ❌
+
+### 根因
+`BaseJellyfinMediaSource.kt` 的 `fetch()` 直接用 Bangumi 的完整 subject 名（如 `幼女战记 第二季`）作为 `searchTerm` 搜索 Jellyfin。当 Jellyfin 中 Series 名称不含季度后缀时，搜索返回空。
+
+### 代码位置
+`datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt`
+
+关键代码段（第 66-82 行）：
+```kotlin
+override suspend fun fetch(query: MediaFetchRequest): SizedSource<MediaMatch> {
+    return SinglePagePagedSource {
+        query.subjectNames
+            .asFlow()
+            .flatMapConcat { subjectName ->
+                val resp = doSearch(subjectName)  // 直接用完整 subject 名搜索
+                resp.Items.asFlow()
+            }
+            .flatMapMerge {
+                when (it.Type) {
+                    "Season", "Series" -> doSearch(parentId = it.Id).Items.asFlow()  // 递归 parentId
+                    "Episode" -> flowOf(it)
+                    "Movie" -> flowOf(it)
+                    else -> emptyFlow()
+                }
+            }
+            // ...
+    }
+}
+```
+
+### 建议的修复方向
+
+1. **解析 Bangumi subjectName**，提取基础番名 + 季度号
+   - `"碧蓝之海 第三季"` → `baseName="碧蓝之海"`, `targetSeason=3`
+   - `"幼女战记 第二季"` → `baseName="幼女战记"`, `targetSeason=2`
+   - 无季度后缀 → `targetSeason=null`（取第一个匹配的 Series）
+
+2. **改为 Series → Seasons → Episodes 层级搜索**
+   - 用基础番名搜索 Series
+   - 用 `/Shows/{seriesId}/Seasons?userId={userId}` 获取季度列表
+   - 按 `IndexNumber` 匹配合适的季节
+   - 用 `/Shows/{seriesId}/Episodes?Season={seasonNum}&userId={userId}` 获取剧集
+
+3. **保证 `matches()` 过滤通过**
+   - 在 MediaProperties.subjectName 中保留 query 中的完整 subject 名（含季度信息），确保后续的 `it.matches(query)` 能通过
+
+### 参考 API
+- Jellyfin API: `GET /Shows/{Id}/Seasons`
+- Jellyfin API: `GET /Shows/{Id}/Episodes`
+- Emby API 兼容同样接口

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapConcat
-import kotlinx.coroutines.flow.flatMapMerge
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.Serializable
 import me.him188.ani.datasources.api.DefaultMedia
@@ -68,16 +66,35 @@ abstract class BaseJellyfinMediaSource(
             query.subjectNames
                 .asFlow()
                 .flatMapConcat { subjectName ->
-                    val resp = doSearch(subjectName)
-                    resp.Items.asFlow()
-                }
-                .flatMapMerge {
-                    when (it.Type) {
-                        // jellyfin 的 type 为 "Series" 在这里应当被处理，否则会 fallback 到 emptyFlow
-                        "Season", "Series" -> doSearch(parentId = it.Id).Items.asFlow()
-                        "Episode" -> flowOf(it)
-                        "Movie" -> flowOf(it)
-                        else -> emptyFlow()
+                    val (baseName, targetSeason) = parseSubjectName(subjectName)
+
+                    val seriesSearchResp = doSearch(subjectName = baseName)
+                    val seriesItems = seriesSearchResp.Items.filter { it.Type == "Series" }
+
+                    if (seriesItems.isNotEmpty()) {
+                        seriesItems.asFlow().flatMapConcat { series ->
+                            val seasonsResp = doGetSeasons(seriesId = series.Id)
+                            val matchedSeasons = if (targetSeason != null) {
+                                seasonsResp.Items.filter { it.IndexNumber == targetSeason }
+                            } else {
+                                seasonsResp.Items
+                            }
+
+                            if (matchedSeasons.isNotEmpty()) {
+                                matchedSeasons.asFlow().flatMapConcat { season ->
+                                    doGetEpisodes(
+                                        seriesId = series.Id,
+                                        seasonNum = season.IndexNumber
+                                            ?: return@flatMapConcat emptyFlow(),
+                                    ).Items.asFlow()
+                                }
+                            } else {
+                                doSearch(parentId = series.Id).Items.asFlow()
+                            }
+                        }
+                    } else {
+                        val resp = doSearch(subjectName = subjectName)
+                        resp.Items.asFlow()
                     }
                 }
                 .filter { (it.Type == "Episode" || it.Type == "Movie") }
@@ -112,9 +129,10 @@ abstract class BaseJellyfinMediaSource(
                             originalTitle = originalTitle,
                             publishedTime = 0,
                             properties = MediaProperties(
-                                // Note: 这里我们 fallback 使用请求的名称, 这样可以在缺少信息时绝对通过后续的过滤, 避免资源被排除. 但这可能会导致有不满足的资源被匹配. 如果未来有问题再考虑. See also #1806.
-                                // subjectName 中 item.SeasonName 在 jellyfin 配合 Bangumi 插件应当是 第 x 季的形式，不修改为 item.SeriesName 不匹配 query 会导致结果进入模糊匹配(这也是为什么修改jellyfin的"季"标题可以通过这个逻辑)
-                                subjectName = item.SeriesName?.takeIf { it.isNotBlank() } ?: item.SeasonName?.takeIf { it.isNotBlank() } ?: query.subjectNameCN,
+                                subjectName = query.subjectNameCN
+                                    ?: item.SeriesName?.takeIf { it.isNotBlank() }
+                                    ?: item.SeasonName?.takeIf { it.isNotBlank() }
+                                    ?: query.subjectNames.firstOrNull() ?: "",
                                 episodeName = item.Name,
                                 subtitleLanguageIds = listOf("CHS"),
                                 resolution = "1080P",
@@ -159,6 +177,65 @@ abstract class BaseJellyfinMediaSource(
         return "$baseUrl/Videos/$itemId/$itemId/Subtitles/$index/0/Stream.$codec"
     }
 
+
+    private data class ParsedSubjectName(
+        val baseName: String,
+        val targetSeason: Int?,
+    )
+
+    private fun parseSubjectName(name: String): ParsedSubjectName {
+        // Chinese: "无职转生 第三季 ～到了异世界就拿出真本事～" → base="无职转生", season=3
+        val chineseSeasonRegex = Regex("[第]([一二三四五六七八九十]+)季")
+        val chineseMatch = chineseSeasonRegex.find(name)
+        if (chineseMatch != null) {
+            val baseName = name.substring(0, chineseMatch.range.first).trim()
+            if (baseName.isNotEmpty()) {
+                return ParsedSubjectName(baseName, chineseToNumber(chineseMatch.groupValues[1]))
+            }
+        }
+        // English: "Mushoku Tensei Season 2", "Mushoku Tensei S2"
+        val enSeasonRegex = Regex("""\b(?:Season|S)\s*(\d+)\b""", RegexOption.IGNORE_CASE)
+        val enMatch = enSeasonRegex.find(name)
+        if (enMatch != null) {
+            val baseName = name.substring(0, enMatch.range.first).trim()
+            if (baseName.isNotEmpty()) {
+                return ParsedSubjectName(baseName, enMatch.groupValues[1].toIntOrNull())
+            }
+        }
+        return ParsedSubjectName(name, null)
+    }
+
+    private fun chineseToNumber(chinese: String): Int {
+        return when (chinese) {
+            "一" -> 1
+            "二" -> 2
+            "三" -> 3
+            "四" -> 4
+            "五" -> 5
+            "六" -> 6
+            "七" -> 7
+            "八" -> 8
+            "九" -> 9
+            "十" -> 10
+            else -> chinese.toIntOrNull() ?: 1
+        }
+    }
+
+    private suspend fun doGetSeasons(seriesId: String) = client.use {
+        get("$baseUrl/Shows/$seriesId/Seasons") {
+            configureAuthorizationHeaders()
+            parameter("userId", userId)
+        }.body<SearchResponse>()
+    }
+
+    private suspend fun doGetEpisodes(seriesId: String, seasonNum: Int) = client.use {
+        get("$baseUrl/Shows/$seriesId/Episodes") {
+            configureAuthorizationHeaders()
+            parameter("userId", userId)
+            parameter("Season", seasonNum)
+            parameter("fields", "MediaStreams")
+        }.body<SearchResponse>()
+    }
 
     private suspend fun doSearch(
         subjectName: String? = null,

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ kotlin.code.style=official
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 # Project version, automatically updated by task :ci-helper:updateDevVersionNameFromGit
-version.name=4.9.0-dev
+version.name=6.0.0-alpha02
 # package.version must be major.minor.patch without meta
 package.version=5.0.0
 kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
…ct name parsing

- Add ParsedSubjectName and parseSubjectName() for Chinese/English season suffixes
- Implement doGetSeasons() and doGetEpisodes() Jellyfin API calls
- Replace flat search with Series→Seasons→Episodes hierarchical search in fetch()
- Preserve full Bangumi subjectName in MediaProperties for downstream matching
- Update version to 6.0.0-alpha02