### PR TITLE
Add always-on-top window toggle for desktop

### DIFF
--- a/.agents/skills/desktop-ui-verify/scripts/input-agent/InputAgent.java
+++ b/.agents/skills/desktop-ui-verify/scripts/input-agent/InputAgent.java
@@ -11,6 +11,7 @@ import java.lang.instrument.Instrumentation;
  * Protocol (one command per line, coordinates in window-CONTENT points of the
  * frontmost visible Frame):
  *   click <x> <y>
+ *   rightclick <x> <y>  (BUTTON3 with popup trigger, e.g. for context menus)
  *   press <x> <y>     (mouse down only)
  *   release <x> <y>
  *   move <x> <y>
@@ -58,7 +59,7 @@ public final class InputAgent {
         Frame frame = targetFrame();
         if (frame == null) return "err no visible frame";
         switch (a[0]) {
-            case "click": case "press": case "release": case "move": {
+            case "click": case "rightclick": case "press": case "release": case "move": {
                 String[] xy = a[1].split("\\s+");
                 int x = Integer.parseInt(xy[0]), y = Integer.parseInt(xy[1]);
                 return mouse(frame, a[0], x, y);
@@ -111,6 +112,11 @@ public final class InputAgent {
             EventQueue q = Toolkit.getDefaultToolkit().getSystemEventQueue();
             if (kind.equals("move")) {
                 q.postEvent(new MouseEvent(target, MouseEvent.MOUSE_MOVED, when, 0, p.x, p.y, 0, false));
+            } else if (kind.equals("rightclick")) {
+                // macOS convention: popup trigger fires on press
+                q.postEvent(new MouseEvent(target, MouseEvent.MOUSE_PRESSED, when, MouseEvent.BUTTON3_DOWN_MASK, p.x, p.y, 1, true, MouseEvent.BUTTON3));
+                q.postEvent(new MouseEvent(target, MouseEvent.MOUSE_RELEASED, when + 20, 0, p.x, p.y, 1, false, MouseEvent.BUTTON3));
+                q.postEvent(new MouseEvent(target, MouseEvent.MOUSE_CLICKED, when + 20, 0, p.x, p.y, 1, false, MouseEvent.BUTTON3));
             } else {
                 if (!kind.equals("release"))
                     q.postEvent(new MouseEvent(target, MouseEvent.MOUSE_PRESSED, when, 0, p.x, p.y, 1, false, MouseEvent.BUTTON1));

--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.InternalComposeUiApi
@@ -498,6 +499,8 @@ object AniDesktop {
             )
 
             val uiSettings by settingsRepository.uiSettings.flow.collectAsState(UISettings.Default)
+            // 窗口置顶为运行时状态, 不持久化, 关闭应用后自动清除
+            val alwaysOnTopState = remember { mutableStateOf(false) }
             val trayState = rememberAniTrayState()
             val appIcon = painterResource(Res.drawable.a_round)
 
@@ -519,6 +522,7 @@ object AniDesktop {
                 state = windowState,
                 title = "Ani",
                 icon = appIcon,
+                alwaysOnTop = alwaysOnTopState.value,
             ) {
                 // In dev mode this enables hot reload,
                 // In release mode this just executes the content
@@ -563,6 +567,7 @@ object AniDesktop {
                             platform = platform,
                             windowState = windowState,
                             layoutHitTestOwner = layoutHitTestOwner,
+                            alwaysOnTopState = alwaysOnTopState,
                         )
                     },
                     LocalOnBackPressedDispatcherOwner provides backPressedDispatcherOwner,

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -234,6 +234,8 @@
     <string name="settings_app_close_behavior_exit">关闭应用</string>
     <string name="settings_app_close_behavior_minimize_to_tray">最小化到系统托盘</string>
     <string name="desktop_tray_open">显示主窗口</string>
+    <string name="always_on_top">窗口置顶</string>
+    <string name="always_on_top_disable">取消窗口置顶</string>
 
     <!-- SoftwareUpdateGroup -->
     <string name="settings_update_software">软件更新</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -219,6 +219,8 @@
     <string name="settings_app_close_behavior_exit">關閉應用</string>
     <string name="settings_app_close_behavior_minimize_to_tray">最小化到系統托盤</string>
     <string name="desktop_tray_open">顯示主視窗</string>
+    <string name="always_on_top">視窗置頂</string>
+    <string name="always_on_top_disable">取消視窗置頂</string>
 
     <!-- SoftwareUpdateGroup -->
     <string name="settings_update_software">軟件更新</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -219,6 +219,8 @@
     <string name="settings_app_close_behavior_exit">關閉應用</string>
     <string name="settings_app_close_behavior_minimize_to_tray">最小化到系統托盤</string>
     <string name="desktop_tray_open">顯示主視窗</string>
+    <string name="always_on_top">視窗置頂</string>
+    <string name="always_on_top_disable">取消視窗置頂</string>
 
     <!-- SoftwareUpdateGroup -->
     <string name="settings_update_software">軟體更新</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -225,6 +225,8 @@
     <string name="settings_app_close_behavior_exit">Exit application</string>
     <string name="settings_app_close_behavior_minimize_to_tray">Minimize to system tray</string>
     <string name="desktop_tray_open">Open main window</string>
+    <string name="always_on_top">Always on top</string>
+    <string name="always_on_top_disable">Turn off always on top</string>
     <string name="settings_update_software">Software update</string>
     <string name="settings_update_current_version">Current version</string>
     <string name="settings_update_view_changelog">View changelog</string>

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
@@ -214,6 +215,17 @@ private fun EpisodeScreenContent(
     val context by rememberUpdatedState(LocalContext.current)
     val window = LocalPlatformWindow.current
     val scope = rememberCoroutineScope()
+
+    // 若窗口置顶是通过播放器内按钮开启的, 退出播放页时自动取消置顶
+    DisposableEffect(window, vm) {
+        onDispose {
+            if (vm.desktopAlwaysOnTopSetByPlayer) {
+                vm.desktopAlwaysOnTopSetByPlayer = false
+                window.setAlwaysOnTop(false)
+            }
+        }
+    }
+
     BackHandler(enabled = vm.isFullscreen) {
         scope.launch {
             context.setRequestFullScreen(window, false)
@@ -968,6 +980,12 @@ private fun EpisodeVideo(
                 context.setRequestFullScreen(window, false)
                 vm.isFullscreen = false
             }
+        },
+        alwaysOnTop = window.isAlwaysOnTop,
+        onToggleAlwaysOnTop = {
+            val newValue = !window.isAlwaysOnTop
+            window.setAlwaysOnTop(newValue)
+            vm.desktopAlwaysOnTopSetByPlayer = newValue
         },
         danmakuEditor = {
             PlayerDanmakuEditor(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -21,15 +21,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.OpenInNew
 import androidx.compose.material.icons.outlined.Analytics
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.rounded.DisplaySettings
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.PushPin
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
@@ -77,6 +83,7 @@ import me.him188.ani.app.ui.foundation.interaction.WindowDragArea
 import me.him188.ani.app.ui.foundation.rememberDebugSettingsViewModel
 import me.him188.ani.app.ui.foundation.theme.AniTheme
 import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.always_on_top
 import me.him188.ani.app.ui.lang.subject_episode_cache
 import me.him188.ani.app.ui.lang.subject_episode_collapse_sidebar
 import me.him188.ani.app.ui.lang.subject_episode_danmaku_settings_title
@@ -191,6 +198,8 @@ internal fun EpisodeVideoImpl(
     videoLoadingStateFlow: Flow<VideoLoadingState>,
     onClickFullScreen: () -> Unit,
     onExitFullscreen: () -> Unit,
+    alwaysOnTop: Boolean = false,
+    onToggleAlwaysOnTop: (() -> Unit)? = null,
     danmakuEditor: @Composable() (RowScope.() -> Unit),
     onClickScreenshot: () -> Unit,
     detachedProgressSlider: @Composable () -> Unit,
@@ -279,6 +288,8 @@ internal fun EpisodeVideoImpl(
                                 onToggleSidebar = onToggleSidebar,
                                 playerStatsVisible = showPlayerStats,
                                 onTogglePlayerStats = { showPlayerStats = !showPlayerStats },
+                                alwaysOnTop = alwaysOnTop,
+                                onToggleAlwaysOnTop = onToggleAlwaysOnTop,
                             )
                         },
                         // VideoScaffold already applies top/horizontal insets around the top bar.
@@ -597,6 +608,8 @@ private fun EpisodeVideoTopBarActions(
     onToggleSidebar: (isCollapsed: Boolean) -> Unit,
     playerStatsVisible: Boolean,
     onTogglePlayerStats: () -> Unit,
+    alwaysOnTop: Boolean = false,
+    onToggleAlwaysOnTop: (() -> Unit)? = null,
 ) {
     var showShareDropdown by rememberSaveable { mutableStateOf(false) }
     var showMoreDropdown by rememberSaveable { mutableStateOf(false) }
@@ -650,6 +663,22 @@ private fun EpisodeVideoTopBarActions(
         Modifier.testTag(TAG_SHOW_SETTINGS),
     ) {
         Icon(AniIcons.SubtitleGear, contentDescription = danmakuSettingsTitleText)
+    }
+
+    if (LocalPlatform.current.isDesktop() && onToggleAlwaysOnTop != null) {
+        val alwaysOnTopText = stringResource(Lang.always_on_top)
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+            tooltip = { PlainTooltip { Text(alwaysOnTopText) } },
+            state = rememberTooltipState(),
+        ) {
+            IconButton(onToggleAlwaysOnTop) {
+                Icon(
+                    if (alwaysOnTop) Icons.Rounded.PushPin else Icons.Outlined.PushPin,
+                    contentDescription = alwaysOnTopText,
+                )
+            }
+        }
     }
 
     Box {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -411,6 +411,11 @@ class EpisodeViewModel(
         }
     }
 
+    /**
+     * 桌面端: 用户是否通过播放器内按钮开启了窗口置顶. 退出播放页时需要自动取消置顶.
+     */
+    var desktopAlwaysOnTopSetByPlayer: Boolean = false
+
     val playerVolumeFlow: Flow<VideoScaffoldConfig.PlayerVolume> =
         settingsRepository.videoScaffoldConfig.flow.map { it.playerVolume }
 

--- a/app/shared/ui-foundation/src/androidMain/kotlin/platform/PlatformWindow.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/platform/PlatformWindow.android.kt
@@ -106,6 +106,11 @@ actual class PlatformWindow(
 
     actual fun floating() {
     }
+
+    actual val isAlwaysOnTop: Boolean get() = false
+
+    actual fun setAlwaysOnTop(alwaysOnTop: Boolean) {
+    }
 }
 
 @Suppress("DEPRECATION")

--- a/app/shared/ui-foundation/src/commonMain/kotlin/platform/PlatformWindow.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/platform/PlatformWindow.kt
@@ -30,6 +30,18 @@ expect class PlatformWindow {
      */
     fun maximize()
     fun floating()
+
+    /**
+     * 窗口是否置顶 (always on top). 这是运行时状态, 不会持久化, 关闭应用后自动清除.
+     *
+     * 仅在桌面端有效, 其他平台始终为 `false`.
+     */
+    val isAlwaysOnTop: Boolean
+
+    /**
+     * 设置窗口置顶. 仅在桌面端有效.
+     */
+    fun setAlwaysOnTop(alwaysOnTop: Boolean)
 }
 
 enum class DeviceOrientation {

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/PlatformWindow.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/PlatformWindow.desktop.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.platform
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,7 +34,8 @@ actual open class PlatformWindow(
     val windowScope: WindowScope? = null,
     val windowState: WindowState,
     val platform: Platform,
-    val layoutHitTestOwner: LayoutHitTestOwner? = null
+    val layoutHitTestOwner: LayoutHitTestOwner? = null,
+    private val alwaysOnTopState: MutableState<Boolean> = mutableStateOf(false),
 ) {
     internal var savedWindowsWindowState: SavedWindowsWindowState? = null
 
@@ -72,6 +74,12 @@ actual open class PlatformWindow(
 
     actual fun floating() {
         windowState.placement = WindowPlacement.Floating
+    }
+
+    actual val isAlwaysOnTop: Boolean get() = alwaysOnTopState.value
+
+    actual fun setAlwaysOnTop(alwaysOnTop: Boolean) {
+        alwaysOnTopState.value = alwaysOnTop
     }
 }
 

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/interaction/WindowDragArea.desktop.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/ui/foundation/interaction/WindowDragArea.desktop.kt
@@ -9,29 +9,51 @@
 
 package me.him188.ani.app.ui.foundation.interaction
 
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.window.WindowDraggableArea
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.always_on_top
+import me.him188.ani.app.ui.lang.always_on_top_disable
 import me.him188.ani.utils.platform.Platform
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 actual inline fun WindowDragArea(
     modifier: Modifier,
     crossinline content: @Composable () -> Unit
 ) {
-    if (LocalPlatform.current is Platform.Windows) {
-        Box(modifier) {
-            content()
-        }
-    } else {
-        val windowScope = LocalPlatformWindow.current.windowScope
-        windowScope?.run {
-            WindowDraggableArea(modifier) {
+    val platformWindow = LocalPlatformWindow.current
+    val alwaysOnTopText = stringResource(Lang.always_on_top)
+    val disableAlwaysOnTopText = stringResource(Lang.always_on_top_disable)
+    // 右键顶栏可切换窗口置顶. 置顶是运行时状态, 关闭应用后自动清除.
+    ContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem(
+                    if (platformWindow.isAlwaysOnTop) disableAlwaysOnTopText else alwaysOnTopText,
+                ) {
+                    platformWindow.setAlwaysOnTop(!platformWindow.isAlwaysOnTop)
+                },
+            )
+        },
+    ) {
+        if (LocalPlatform.current is Platform.Windows) {
+            Box(modifier) {
                 content()
             }
-        } ?: content()
+        } else {
+            val windowScope = platformWindow.windowScope
+            windowScope?.run {
+                WindowDraggableArea(modifier) {
+                    content()
+                }
+            } ?: content()
+        }
     }
 }

--- a/app/shared/ui-foundation/src/iosMain/kotlin/platform/PlatformWindow.ios.kt
+++ b/app/shared/ui-foundation/src/iosMain/kotlin/platform/PlatformWindow.ios.kt
@@ -69,6 +69,11 @@ actual class PlatformWindow(
 
     actual fun floating() {
     }
+
+    actual val isAlwaysOnTop: Boolean get() = false
+
+    actual fun setAlwaysOnTop(alwaysOnTop: Boolean) {
+    }
 }
 
 @Composable


### PR DESCRIPTION
## 功能

为桌面端添加"窗口置顶 (always on top)"功能。置顶为**运行时状态**:不持久化,关闭应用后自动清除。

两个入口:

1. **顶栏右键菜单** — 右键任意页面顶栏(WindowDragArea)弹出菜单,可切换"窗口置顶 / 取消窗口置顶"。
2. **播放器右上角图钉按钮** — 位于"更多"(⋮)按钮左侧,点击切换置顶,悬浮显示"窗口置顶"提示;未置顶为空心图钉,置顶后为实心。**若置顶是通过播放器按钮开启的,退出播放页时自动取消**;通过顶栏菜单开启的置顶不受影响。

## 实现

- `PlatformWindow`(common expect)新增 `isAlwaysOnTop` / `setAlwaysOnTop`,desktop actual 由 Compose `MutableState` 支撑并接到主窗口 `Window(alwaysOnTop = ...)`;Android/iOS 为 no-op(始终 false)。
- `WindowDragArea` desktop actual 包一层 `ContextMenuArea` 提供右键菜单(Windows / macOS / Linux 通用)。
- 播放器按钮经 `EpisodeVideoTopBarActions` 渲染(仅桌面显示),"由播放器开启"的标记存于 `EpisodeViewModel.desktopAlwaysOnTopSetByPlayer`,在 `EpisodeScreenContent` dispose 时清除置顶。
- 新增字符串 `always_on_top` / `always_on_top_disable`(en + zh-CN + zh-Hant 变体)。
- 另附:desktop-ui-verify 输入注入 agent 支持 `rightclick`(用于本 PR 的 UI 验证)。

## 验证(macOS 真机,打包 .app)

- 右键顶栏弹出"窗口置顶"菜单,点击后窗口 `kCGWindowLayer` 从 0 变为 3(floating);其他应用激活时 Ani 仍保持在最上层;再次右键显示"取消窗口置顶",点击后 layer 回 0。
- 播放页右上角图钉:悬浮显示"窗口置顶"tooltip;点击后图标变实心、layer=3;点返回退出播放页后 layer 自动回 0。
- 重启应用后置顶状态不保留(layer=0)。
- 编译验证:desktop / Android / iOS(ui-foundation)/ desktopTest 全部通过。

## 运行时截图（macOS 打包 .app）

### 顶栏右键菜单：开启置顶

<img src="https://github.com/user-attachments/assets/7d1db05d-da6e-429d-90ed-38a378ff8faf" alt="桌面端顶栏右键菜单显示窗口置顶" width="1000">

### 顶栏右键菜单：已置顶，可取消

<img src="https://github.com/user-attachments/assets/44b6b181-aca0-4094-ba50-450674c7d1b7" alt="桌面端窗口已置顶时右键菜单显示取消窗口置顶" width="1000">

### 播放器图钉：未置顶（空心图钉与提示）

<img src="https://github.com/user-attachments/assets/29d63e1f-c069-4484-9835-11003827e9f5" alt="桌面播放器未置顶时显示空心图钉与窗口置顶提示" width="1000">

### 播放器图钉：已置顶（实心图钉）

<img src="https://github.com/user-attachments/assets/adb3894d-da92-4d61-95f0-63f1a7a862aa" alt="桌面播放器已置顶时显示实心图钉" width="1000">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

