### PR TITLE
fix(desktop): preload bundled libsqliteJni with RTLD_GLOBAL on Linux

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -321,6 +321,11 @@ object AniDesktop {
         }
 
         val loadLibraryJob = coroutineScope.launch(Dispatchers.IO) {
+            // Must run before any database access and before JCEF loads NSS/system libsqlite3.
+            // The JCEF init coroutine joins this job before AniCefApp.initialize, so placing the
+            // guard here still guarantees the ordering. See #3188.
+            BundledSqliteInterpositionGuard.install(cacheDir)
+
             try {
                 AnitorrentLibraryLoader.loadLibraries()
                 logger.info { "Anitorrent is loaded." }

--- a/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
+++ b/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.desktop
+
+import com.sun.jna.Library
+import com.sun.jna.NativeLibrary
+import me.him188.ani.app.platform.AniCefApp
+import me.him188.ani.utils.logging.info
+import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.warn
+import me.him188.ani.utils.platform.currentPlatformDesktop
+import me.him188.ani.utils.platform.isLinux
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.absolutePathString
+
+/**
+ * Works around a native symbol interposition crash on Linux (#3188).
+ *
+ * Room's [androidx.sqlite.driver.bundled.BundledSQLiteDriver] loads its bundled `libsqliteJni.so`
+ * via `System.load` (`RTLD_LOCAL`, lazy binding). When JCEF starts, CEF pulls in NSS, which loads
+ * the system `/usr/lib/libsqlite3.so` into the *global* symbol scope. From then on, any not-yet-
+ * called `sqlite3_*` PLT entry inside `libsqliteJni.so` resolves to the system library, mixing two
+ * sqlite builds with incompatible internal layouts — observed as `SIGSEGV` in
+ * `sqlite3_bind_text16` on the home screen's first DB query. Whether a machine crashes is a pure
+ * load-order race. macOS (two-level namespace) and Windows (per-module imports) are immune, so
+ * this guard is Linux-only.
+ *
+ * Mitigation: load the bundled library ourselves with `RTLD_NOW | RTLD_GLOBAL` before JCEF/NSS or
+ * the driver touches sqlite, so its symbols bind to its own implementations first and occupy the
+ * global scope; the whole process then uses exactly one sqlite build. The `...bundled.path`/`.name`
+ * properties make the driver `System.load()` this same file instead of its own `RTLD_LOCAL` copy.
+ *
+ * Trade-offs: NSS will use the bundled sqlite instead of the system one (format-compatible, low
+ * risk); the guard relies on the semi-internal property and jar resource layout, so an
+ * androidx.sqlite upgrade could silently break it — failure mode is a logged warning plus the
+ * original racy behavior. The proper fix is upstream compiling `sqlite3_*` with hidden visibility.
+ *
+ * Must be called before database initialization and before [AniCefApp.initialize]. It runs as
+ * the first step of the desktop `loadLibraryJob`, which the JCEF init coroutine joins.
+ */
+object BundledSqliteInterpositionGuard {
+    private val logger = logger<BundledSqliteInterpositionGuard>()
+
+    // dlopen(2) flags on Linux.
+    private const val RTLD_NOW = 0x2
+    private const val RTLD_GLOBAL = 0x100
+
+    // Strong reference to the preloaded library. JNA 5.x registers a Cleaner that dlclose()es the
+    // native handle when the NativeLibrary instance is GC'd, and JNA's own cache only keeps a
+    // WeakReference — dropping this reference would let a GC undo the preload and reintroduce
+    // the race this guard exists to prevent.
+    private var preloadedLibrary: NativeLibrary? = null
+
+    /**
+     * @param cacheDir app-owned directory used to hold the extracted library. A stable location
+     * with a fixed name (rewritten only when the bundled bytes change) avoids leaving stale
+     * `.so` files in the system temp directory after abnormal exits.
+     */
+    fun install(cacheDir: Path) {
+        if (!currentPlatformDesktop().isLinux()) return
+        try {
+            install0(cacheDir)
+        } catch (e: Throwable) {
+            // Never break startup because of this workaround; the crash it prevents is a race anyway.
+            logger.warn(e) { "Failed to preload bundled libsqliteJni with RTLD_GLOBAL" }
+        }
+    }
+
+    private fun install0(cacheDir: Path) {
+        val resource = when (System.getProperty("os.arch")) {
+            "aarch64" -> "natives/linux_arm64/libsqliteJni.so"
+            else -> "natives/linux_x64/libsqliteJni.so"
+        }
+        val bytes = BundledSqliteInterpositionGuard::class.java.classLoader
+            .getResourceAsStream(resource)?.use { it.readBytes() }
+            ?: error("Resource $resource not found on classpath")
+
+        val libFile = cacheDir.resolve("ani-bundled-sqliteJni.so")
+        if (!Files.exists(libFile) || !Files.readAllBytes(libFile).contentEquals(bytes)) {
+            // Write to a sibling temp file and move atomically: the target may still be mapped
+            // by a previous process (or this one), and in-place writes to a mapped .so can SIGBUS.
+            val tmp = Files.createTempFile(cacheDir, "ani-bundled-sqliteJni", ".tmp")
+            Files.write(tmp, bytes)
+            try {
+                Files.move(tmp, libFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(tmp, libFile, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+        // Load with RTLD_GLOBAL | RTLD_NOW so the bundled sqlite symbols occupy the global scope
+        // before CEF/NSS can load the system libsqlite3.
+        preloadedLibrary = NativeLibrary.getInstance(
+            libFile.absolutePathString(),
+            mapOf(Library.OPTION_OPEN_FLAGS to (RTLD_NOW or RTLD_GLOBAL)),
+        )
+
+        // Make BundledSQLiteDriver System.load() the same file rather than its own RTLD_LOCAL copy.
+        System.setProperty("androidx.sqlite.driver.bundled.path", libFile.parent.absolutePathString())
+        System.setProperty("androidx.sqlite.driver.bundled.name", libFile.fileName.toString())
+
+        logger.info { "Preloaded bundled libsqliteJni ($libFile) with RTLD_GLOBAL to avoid symbol interposition with the system libsqlite3." }
+    }
+}


### PR DESCRIPTION
Fixes #3188

## 概要

修复 Linux 桌面端启动数秒后概率性 native 崩溃（`SIGSEGV`，`pc=0`，位于系统 `libsqlite3.so` 内）。

## 根因

Room 的 `BundledSQLiteDriver` 通过 `System.load`（即 `dlopen(..., RTLD_LOCAL)`，惰性绑定）加载自带的 `libsqliteJni.so`，其内部静态链接了一份 sqlite 并以默认可见性导出全部 `sqlite3_*` 符号。JCEF 启动时，CEF 经 NSS 把系统 `/usr/lib/libsqlite3.so` 载入**全局符号空间**；此后 `libsqliteJni.so` 内尚未被调用过的 `sqlite3_*` PLT 项会解析到系统库，进程内混入两份内部结构不兼容的 sqlite 构建，解引用时跳到空指针段错误。

是否崩溃取决于加载顺序，是纯竞态：同一台机器、同一份二进制，首次 DB 调用先于 NSS 加载则正常，反之则崩。macOS（two-level namespace）和 Windows（按模块绑定导入）不存在该问题，故本修复仅作用于 Linux。

## 修复

新增 `BundledSqliteInterpositionGuard`（`app/desktop`），在 `main()` 中尽早执行，先于数据库初始化和 `AniCefApp.initialize`：

1. 从 `sqlite-bundled` jar 解出 `natives/linux_<arch>/libsqliteJni.so`，用 JNA 以 `RTLD_NOW | RTLD_GLOBAL` 加载——`RTLD_NOW` 在加载时把库内 `sqlite3_*` 引用全部绑死到自身实现，`RTLD_GLOBAL` 让 bundled 符号抢先占据全局空间，之后系统库再加载也无法插入。整个进程最终只有一份 sqlite 实现。
2. 设置 `androidx.sqlite.driver.bundled.path/name` 属性，让 driver 复用这同一份库，不再自解压 `RTLD_LOCAL` 副本。

失败仅记录告警并退回原行为，不影响启动。

## 验证

- `:app:desktop:run` 实测：日志确认 guard 生效（`Preloaded bundled libsqliteJni ... with RTLD_GLOBAL`）；进程 maps 中仅有本 guard 加载的一份 `libsqliteJni`，无 driver 自解压副本；系统 `libsqlite3` 仍被 NSS 加载但已无法抢占符号。
- 在 CachyOS（与报告者相同的系统 sqlite 3.53.3）上走完 JCEF 初始化并进入首页触发 DB 查询，应用存活无崩溃。
- `:app:desktop:compileKotlin` 通过。
