### PR TITLE
feat(player): enable WSOLA audio time-stretch and embedded subtitles on Android

### DIFF
--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -15,6 +15,7 @@ import android.widget.Toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.runBlocking
@@ -174,7 +175,14 @@ fun getAndroidModules(
     }
 
     single<MediampPlayerFactory<*>> {
-        MediampPlayerFactoryLoader.register(LibassExoPlayerMediampPlayerFactory())
+        val videoScaffoldConfig = get<SettingsRepository>().videoScaffoldConfig
+        MediampPlayerFactoryLoader.register(
+            LibassExoPlayerMediampPlayerFactory {
+                // 音频处理链在 ExoPlayer 构造时确定, 无法在已创建的播放器上切换.
+                // 工厂接口是同步的, 因此每次创建播放器时在此读取 DataStore 中的当前值.
+                runBlocking { videoScaffoldConfig.flow.first().enableHighQualityAudioTimeStretch }
+            },
+        )
         MediampPlayerSurfaceProviderLoader.register(ExoPlayerMediampPlayerSurfaceProvider())
         MediampPlayerFactoryLoader.first()
     }

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
@@ -82,6 +82,10 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
      */
     val autoSwitchMediaOnPlayerError: Boolean = true,
     /**
+     * 在 Android 上使用高质量 WSOLA 处理非 1x 速度的音频.
+     */
+    val enableHighQualityAudioTimeStretch: Boolean = true,
+    /**
      * 过滤 HLS 播放列表中的插播片段.
      *
      * @since 5.7
@@ -128,6 +132,7 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
             autoPlayNext = false,
             autoSkipOpEd = false,
             autoSwitchMediaOnPlayerError = false,
+            enableHighQualityAudioTimeStretch = false,
             enableExperimentalHlsSegmentFiltering = false,
         )
     }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorSubtitlePreferences.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorSubtitlePreferences.kt
@@ -82,7 +82,7 @@ value class MediaSelectorSubtitlePreferences(
                 is Platform.Android -> ImmutableEnumMap<SubtitleKind, _> {
                     when (it) {
                         SubtitleKind.EMBEDDED -> NORMAL
-                        SubtitleKind.CLOSED -> HIDE
+                        SubtitleKind.CLOSED -> NORMAL // 已由 libass 渲染
                         SubtitleKind.EXTERNAL_PROVIDED -> NORMAL
                         SubtitleKind.EXTERNAL_DISCOVER -> HIDE
                         SubtitleKind.CLOSED_OR_EXTERNAL_DISCOVER -> NORMAL

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/legacy/DefaultMediaSelectorSubtitleKindTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/legacy/DefaultMediaSelectorSubtitleKindTest.kt
@@ -145,18 +145,7 @@ sealed class DefaultMediaSelectorSubtitleKindPlatformTest(
     }
 
     class Windows : DefaultMediaSelectorSubtitleKindPlatformTest(Platform.Windows(Arch.X86_64))
-    class Android : DefaultMediaSelectorSubtitleKindPlatformTest(Platform.Android(Arch.ARMV8A)) {
-        @Test
-        fun `CLOSED is low priority`() = runTest {
-            val target: DefaultMedia
-            addMedia(
-                media(alliance = "字幕组1", subtitleKind = SubtitleKind.CLOSED),
-                media(alliance = "字幕组2").also { target = it },
-            )
-            savedDefaultPreference.value = DEFAULT_PREFERENCE
-            assertEquals(target, selector.trySelectDefault())
-        }
-    }
+    class Android : DefaultMediaSelectorSubtitleKindPlatformTest(Platform.Android(Arch.ARMV8A))
 
     // TODO: Test DefaultMediaSelectorSubtitleKindPlatformTest for iOS
 

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -279,6 +279,8 @@
     <string name="settings_player_hide_selector_on_select">选择数据源后自动关闭弹窗</string>
     <string name="settings_player_auto_fullscreen_on_landscape">旋转屏幕时自动全屏</string>
     <string name="settings_player_auto_play_next">自动连播</string>
+    <string name="settings_player_audio_time_stretch">高质量音频变速（WSOLA）</string>
+    <string name="settings_player_audio_time_stretch_description">变速时提供更好的音质；如遇爆音或音频损坏可关闭</string>
     <string name="settings_player_auto_skip_op_ed">自动跳过 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只对 BT 数据源的部分资源有效</string>
     <string name="settings_player_op_ed_skip_duration">OP/ED 跳过时长</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -264,6 +264,8 @@
     <string name="settings_player_hide_selector_on_select">選擇數據源後自動關閉彈窗</string>
     <string name="settings_player_auto_fullscreen_on_landscape">旋轉螢幕時自動全螢幕</string>
     <string name="settings_player_auto_play_next">自動連播</string>
+    <string name="settings_player_audio_time_stretch">高品質音訊變速（WSOLA）</string>
+    <string name="settings_player_audio_time_stretch_description">變速時提供更好的音質；如遇爆音或音訊損壞可關閉</string>
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">只對 BT 數據源的部分資源有效</string>
     <string name="settings_player_op_ed_skip_duration">OP/ED 跳過時長</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -264,6 +264,8 @@
     <string name="settings_player_hide_selector_on_select">選擇資料源後自動關閉彈出視窗</string>
     <string name="settings_player_auto_fullscreen_on_landscape">旋轉螢幕時自動全螢幕</string>
     <string name="settings_player_auto_play_next">自動連播</string>
+    <string name="settings_player_audio_time_stretch">高品質音訊變速（WSOLA）</string>
+    <string name="settings_player_audio_time_stretch_description">變速時提供更好的音質；如遇爆音或音訊損壞可關閉</string>
     <string name="settings_player_auto_skip_op_ed">自動跳過 OP 和 ED</string>
     <string name="settings_player_auto_skip_op_ed_description">僅對 BT 資料源的部分資源有效</string>
     <string name="settings_player_op_ed_skip_duration">OP/ED 跳過時長</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -266,6 +266,8 @@
     <string name="settings_player_hide_selector_on_select">Automatically close the pop-up after selecting a data source</string>
     <string name="settings_player_auto_fullscreen_on_landscape">Automatically go fullscreen on screen rotation</string>
     <string name="settings_player_auto_play_next">Auto-play next episode</string>
+    <string name="settings_player_audio_time_stretch">High-quality audio time-stretch (WSOLA)</string>
+    <string name="settings_player_audio_time_stretch_description">Better sound quality at non-1x speeds. Turn off if you hear crackling or corrupted audio</string>
     <string name="settings_player_auto_skip_op_ed">Automatically skip OP and ED</string>
     <string name="settings_player_auto_skip_op_ed_description">Only works for some resources from BT data sources</string>
     <string name="settings_player_op_ed_skip_duration">OP/ED skip duration</string>

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
@@ -65,6 +65,8 @@ import me.him188.ani.app.ui.lang.settings_app_nsfw_hide
 import me.him188.ani.app.ui.lang.settings_app_search
 import me.him188.ani.app.ui.lang.settings_app_language_system
 import me.him188.ani.app.ui.lang.settings_player
+import me.him188.ani.app.ui.lang.settings_player_audio_time_stretch
+import me.him188.ani.app.ui.lang.settings_player_audio_time_stretch_description
 import me.him188.ani.app.ui.lang.settings_player_auto_fullscreen_on_landscape
 import me.him188.ani.app.ui.lang.settings_player_auto_mark_done
 import me.him188.ani.app.ui.lang.settings_player_auto_play_next
@@ -133,6 +135,7 @@ import me.him188.ani.app.ui.update.AppUpdateViewModel
 import me.him188.ani.app.ui.update.NewVersion
 import me.him188.ani.app.ui.update.UpdateNotifier
 import me.him188.ani.utils.platform.annotations.TestOnly
+import me.him188.ani.utils.platform.isAndroid
 import me.him188.ani.utils.platform.isDesktop
 import me.him188.ani.utils.platform.isIos
 import me.him188.ani.utils.platform.isMobile
@@ -543,6 +546,17 @@ fun SettingsScope.PlayerGroup(
             },
             title = { Text(stringResource(Lang.settings_player_auto_switch_media_on_error)) },
         )
+        if (LocalPlatform.current.isAndroid()) {
+            HorizontalDividerItem()
+            SwitchItem(
+                checked = config.enableHighQualityAudioTimeStretch,
+                onCheckedChange = {
+                    videoScaffoldConfig.update(config.copy(enableHighQualityAudioTimeStretch = it))
+                },
+                title = { Text(stringResource(Lang.settings_player_audio_time_stretch)) },
+                description = { Text(stringResource(Lang.settings_player_audio_time_stretch_description)) },
+            )
+        }
         HorizontalDividerItem()
         if (!LocalPlatform.current.isIos()) {
             SwitchItem(

--- a/app/shared/video-player/src/androidMain/kotlin/media/LibassExoPlayerMediampPlayer.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/media/LibassExoPlayerMediampPlayer.kt
@@ -43,6 +43,7 @@ import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.MediampPlayerFactory
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.exoplayer.ExoPlayerAudioTimeStretch
 import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
 import org.openani.mediamp.io.SeekableInput
 import org.openani.mediamp.source.MediaData
@@ -69,10 +70,11 @@ class LibassExoPlayerMediampPlayer private constructor(
     constructor(
         context: Context,
         parentCoroutineContext: CoroutineContext,
+        audioTimeStretch: ExoPlayerAudioTimeStretch = ExoPlayerAudioTimeStretch.HighQualityWsola,
     ) : this(
         context,
         parentCoroutineContext,
-        ExoPlayerMediampPlayer(context, parentCoroutineContext),
+        ExoPlayerMediampPlayer(context, parentCoroutineContext, audioTimeStretch),
     )
 
     internal val assHandler = AssHandler(
@@ -293,7 +295,9 @@ class LibassExoPlayerMediampPlayer private constructor(
     }
 }
 
-class LibassExoPlayerMediampPlayerFactory : MediampPlayerFactory<LibassExoPlayerMediampPlayer> {
+class LibassExoPlayerMediampPlayerFactory(
+    private val enableHighQualityAudioTimeStretch: () -> Boolean = { true },
+) : MediampPlayerFactory<LibassExoPlayerMediampPlayer> {
     override val forClass: KClass<LibassExoPlayerMediampPlayer>
         get() = LibassExoPlayerMediampPlayer::class
 
@@ -302,6 +306,11 @@ class LibassExoPlayerMediampPlayerFactory : MediampPlayerFactory<LibassExoPlayer
         parentCoroutineContext: CoroutineContext,
     ): LibassExoPlayerMediampPlayer {
         require(context is Context) { "The context argument must be android.content.Context on Android" }
-        return LibassExoPlayerMediampPlayer(context, parentCoroutineContext)
+        val audioTimeStretch = if (enableHighQualityAudioTimeStretch()) {
+            ExoPlayerAudioTimeStretch.HighQualityWsola
+        } else {
+            ExoPlayerAudioTimeStretch.Media3Default
+        }
+        return LibassExoPlayerMediampPlayer(context, parentCoroutineContext, audioTimeStretch)
     }
 }


### PR DESCRIPTION
## 变更

- Android 默认使用 WSOLA 处理倍速音频，并提供设置开关；关闭后回退到 Media3 默认实现。
- 支持选择和播放内封 ASS/SSA 字幕资源。

<img width="598" height="132" alt="WSOLA 设置项" src="https://github.com/user-attachments/assets/59140b91-8a15-4075-b153-2a261cc02711" />

## 验证

- Android Debug 编译及字幕偏好测试通过。