### PR TITLE
feat(app-data): support channel-level media source tiers

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
@@ -342,12 +342,15 @@ class MediaSourceManagerImpl(
     }
 
     override fun mediaSourceTiersFlow(): Flow<MediaSelectorSourceTiers> = instances.flow.map { list ->
+        val arguments = list.mapNotNull { save ->
+            save.getArgumentOrNull(codecManager)?.let { save.mediaSourceId to it }
+        }
         MediaSelectorSourceTiers(
-            buildMap {
-                for (save in list) {
-                    val argument = save.getArgumentOrNull(codecManager)
-                    if (argument != null) {
-                        put(save.mediaSourceId, argument.tier)
+            tiers = arguments.associate { (id, argument) -> id to argument.tier },
+            channelTiers = buildMap {
+                for ((id, argument) in arguments) {
+                    if (argument.channelTiers.isNotEmpty()) {
+                        put(id, argument.channelTiers)
                     }
                 }
             },

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelector.kt
@@ -76,14 +76,19 @@ import kotlin.coroutines.CoroutineContext
  * 每个数据源 [me.him188.ani.datasources.api.source.MediaSource] 都拥有阶级 [me.him188.ani.app.domain.mediasource.codec.MediaSourceTier]. 阶级会影响排序.
  * 阶级值越低, 数据源排序越靠前.
  *
+ * 数据源还可以为各个 channel (对应 [me.him188.ani.datasources.api.MediaProperties.alliance]) 单独指定 tier
+ * ([MediaSelectorSourceTiers.channelTiers]). 排序时以资源的有效 tier 为准: channel tier 优先, 没有 channel tier 时使用数据源 tier.
+ * 因此同一个数据源的不同 channel 的资源可以有不同的排序优先级.
+ *
  * ### 快速选择
  *
  * 快速选择是由 [MediaSelectorAutoSelect] 实现的[拓展功能][MediaSelectorAutoSelect.fastSelectWebSources], 仅对 [WEB][MediaSourceKind.WEB] 源有效.
  * 如果快速选择数据源功能为启用状态 ([MediaSelectorSettings.fastSelectWebKind] 为 [WEB][MediaSourceKind.WEB]), 将会考虑如下因素:
  *
- * - 当任意 Tier 0 数据源在 [fastSelectWebLowTierToleranceDuration][MediaSelectorSettings.fastSelectWebLowTierToleranceDuration] 
+ * - 当任意 Tier 0 数据源在 [fastSelectWebLowTierToleranceDuration][MediaSelectorSettings.fastSelectWebLowTierToleranceDuration]
  * 时长内加载好, [MediaSelectorAutoSelect] 将会立即选择该数据源.
- * - 在等待 [fastSelectWebLowTierToleranceDuration][MediaSelectorSettings.fastSelectWebLowTierToleranceDuration] 时长后, 
+ * 判定与选择均按 channel 粒度: 只有有效 tier (channel tier 优先) 不超过阈值的资源才会被立即选择.
+ * - 在等待 [fastSelectWebLowTierToleranceDuration][MediaSelectorSettings.fastSelectWebLowTierToleranceDuration] 时长后,
  * 选择所有已加载好的数据源中 Tier 最低的一个.
  *
  * ## 使用示例
@@ -219,6 +224,8 @@ interface MediaSelector {
      * @param blacklistMediaIds 黑名单, 这些 media 不会被选择. 如果遇到黑名单中的 media, 将会跳过.
      * @param allowNonPreferred 是否允许选择不满足用户偏好设置的项目. 如果为 `false`, 将只会从 [preferredCandidatesMedia] 中选择.
      * 如果为 `true`, 则放弃用户偏好, 只根据数据源顺序选择.
+     * @param candidateMediaFilter 额外的 media 级过滤. 只有返回 `true` 的 media 才会被选择.
+     * `null` 表示不额外过滤. 用于 channel 级 tier 等需要比数据源更细粒度控制的场景.
      *
      * @return 成功选择且已经记录的 [Media]. 返回 `null` 时表示没有选择.
      */
@@ -227,11 +234,12 @@ interface MediaSelector {
         overrideUserSelection: Boolean = false,
         blacklistMediaIds: Set<String> = emptySet(),
         allowNonPreferred: Boolean = false,
+        candidateMediaFilter: ((Media) -> Boolean)? = null,
     ): Media?
 
     /**
      * 根据提供的 [candidateSources], 挂起到第一个满足的 media 出现为止.
-     * 
+     *
      * @see trySelectFromMediaSources
      */
     suspend fun awaitSelectFromMediaSources(
@@ -239,6 +247,7 @@ interface MediaSelector {
         overrideUserSelection: Boolean = false,
         blacklistMediaIds: Set<String> = emptySet(),
         allowNonPreferred: Boolean = false,
+        candidateMediaFilter: ((Media) -> Boolean)? = null,
     ): Media?
 
     /**
@@ -722,12 +731,16 @@ class DefaultMediaSelector(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,
-        allowNonPreferred: Boolean
+        allowNonPreferred: Boolean,
+        candidateMediaFilter: ((Media) -> Boolean)?
     ): Media? {
         if (candidateSources.isEmpty()) return null
 
         fun bake(candidates: List<MaybeExcludedMedia.Included>): List<MaybeExcludedMedia.Included> {
-            return candidates.filter { it.result.mediaSourceId in candidateSources && it.result.mediaId !in blacklistMediaIds }
+            return candidates.filter {
+                it.result.mediaSourceId in candidateSources && it.result.mediaId !in blacklistMediaIds
+                        && (candidateMediaFilter == null || candidateMediaFilter(it.result))
+            }
                 .sortedBy { candidateSources.indexOf(it.result.mediaSourceId) }
         }
 
@@ -772,12 +785,16 @@ class DefaultMediaSelector(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,
-        allowNonPreferred: Boolean
+        allowNonPreferred: Boolean,
+        candidateMediaFilter: ((Media) -> Boolean)?
     ): Media? {
         if (candidateSources.isEmpty()) return null
 
         fun bake(candidates: List<MaybeExcludedMedia.Included>): List<MaybeExcludedMedia.Included> {
-            return candidates.filter { it.result.mediaSourceId in candidateSources && it.result.mediaId !in blacklistMediaIds }
+            return candidates.filter {
+                it.result.mediaSourceId in candidateSources && it.result.mediaId !in blacklistMediaIds
+                        && (candidateMediaFilter == null || candidateMediaFilter(it.result))
+            }
                 .sortedBy { candidateSources.indexOf(it.result.mediaSourceId) }
         }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelect.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorAutoSelect.kt
@@ -100,7 +100,14 @@ class MediaSelectorAutoSelect(
         instantSelectTierThreshold: MediaSourceTier = InstantSelectTierThreshold,
     ): Media? {
 
-        fun MediaSourceFetchResult.getTier(): MediaSourceTier = sourceTiers[this.mediaSourceId]
+        // 数据源能达到的最优 tier: 只要有一个 channel 足够低就有机会被立即选择
+        fun MediaSourceFetchResult.getBestTier(): MediaSourceTier = sourceTiers.getBestTier(this.mediaSourceId)
+
+        // media 级过滤: 只有其有效 tier (channel tier 优先) 满足阈值的资源才能被立即选择.
+        // 这保证了例如数据源整体是 tier 0, 但某个 channel 被降到 tier 1 时, 该 channel 的资源不会被秒选.
+        val instantSelectMediaFilter: (Media) -> Boolean = { media ->
+            sourceTiers.get(media.mediaSourceId, media.properties.alliance) <= instantSelectTierThreshold
+        }
 
         return cancellableCoroutineScope {
             val backgroundTasks = childScope()
@@ -120,7 +127,7 @@ class MediaSelectorAutoSelect(
                     // 所有满足 fast select 条件的源: low tier, succeeded, 有结果
                     val candidateResults = buildList {
                         list.forEach { result ->
-                            if (result.getTier() > instantSelectTierThreshold) return@forEach // high tier 不考虑
+                            if (result.getBestTier() > instantSelectTierThreshold) return@forEach // high tier 不考虑
                             if (result.state.value !is MediaSourceFetchState.Succeed) return@forEach // 没完事的不考虑
                             if (result.results.first().count() <= 0) return@forEach // 没结果的不考虑
                             add(result)
@@ -141,7 +148,8 @@ class MediaSelectorAutoSelect(
                         candidateResults.map { it.mediaSourceId },
                         overrideUserSelection = overrideUserSelection,
                         blacklistMediaIds = blacklistMediaIds,
-                        allowNonPreferred = true, // 快速选择源是 web 源, 可以不考虑偏好. 
+                        allowNonPreferred = true, // 快速选择源是 web 源, 可以不考虑偏好.
+                        candidateMediaFilter = instantSelectMediaFilter,
                     )
                 }
                     .filterNotNull()

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorContext.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/MediaSelectorContext.kt
@@ -128,10 +128,44 @@ data class MediaSelectorSourceTiers(
      * Key is [me.him188.ani.datasources.api.source.MediaSource.mediaSourceId]
      */
     val tiers: Map<String, MediaSourceTier>,
+    /**
+     * Channel 级别的 tier 覆盖. 外层 key 是 [me.him188.ani.datasources.api.source.MediaSource.mediaSourceId],
+     * 内层 key 是 channel 名称, 即 [me.him188.ani.datasources.api.MediaProperties.alliance].
+     *
+     * 若一个 media 的 channel 在此表中有记录, 则以该 channel tier 为准, 否则回退到数据源本身的 tier.
+     *
+     * @since 4.9
+     */
+    val channelTiers: Map<String, Map<String, MediaSourceTier>> = emptyMap(),
     val fallback: (mediaSourceId: String) -> MediaSourceTier = { MediaSourceTier.Fallback },
 ) {
     operator fun get(mediaSourceId: String): MediaSourceTier {
         return tiers[mediaSourceId] ?: fallback(mediaSourceId)
+    }
+
+    /**
+     * 获取一个资源的有效 tier: 优先使用其 channel ([channel], 即 alliance) 的 tier, 否则使用数据源的 tier.
+     *
+     * @since 4.9
+     */
+    fun get(mediaSourceId: String, channel: String?): MediaSourceTier {
+        if (!channel.isNullOrEmpty()) {
+            channelTiers[mediaSourceId]?.get(channel)?.let { return it }
+        }
+        return get(mediaSourceId)
+    }
+
+    /**
+     * 数据源能达到的最优 (数值最低) tier, 即数据源自身 tier 与其所有 channel tier 中的最小值.
+     *
+     * 用于快速选择: 只要数据源存在一个足够低 tier 的 channel, 该数据源就有可能立即提供低 tier 资源.
+     *
+     * @since 4.9
+     */
+    fun getBestTier(mediaSourceId: String): MediaSourceTier {
+        val sourceTier = get(mediaSourceId)
+        val channelMin = channelTiers[mediaSourceId]?.values?.minOrNull() ?: return sourceTier
+        return minOf(sourceTier, channelMin)
     }
 
     companion object {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/filter/MediaSelectorFilterSortAlgorithm.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/selector/filter/MediaSelectorFilterSortAlgorithm.kt
@@ -315,7 +315,8 @@ class MediaSelectorFilterSortAlgorithm {
                 )
                 .thenBy { maybe ->
                     val tiers = context.mediaSourceTiers
-                    tiers?.get(maybe.original.mediaSourceId)
+                    // channel (alliance) 级 tier 优先, 否则数据源级 tier
+                    tiers?.get(maybe.original.mediaSourceId, maybe.original.properties.alliance)
                         ?: MediaSourceTier.MaximumValue // 还没加载出来, 先不排序
                 }
                 .thenByDescending {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/codec/MediaSourceArguments.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/codec/MediaSourceArguments.kt
@@ -28,6 +28,15 @@ interface MediaSourceArguments {
      * @since 4.7
      */
     val tier: MediaSourceTier
+
+    /**
+     * Channel 级别的 tier 覆盖, key 为 channel 名称.
+     * 支持 channel 概念的数据源 (如 web selector 源) 可以覆盖此属性, 为不同 channel 指定不同 tier.
+     * 未在此表中的 channel 使用 [tier].
+     *
+     * @since 4.9
+     */
+    val channelTiers: Map<String, MediaSourceTier> get() = emptyMap()
 }
 
 @RequiresOptIn("实现新的 MediaSourceArgument 时, 还需要在 MediaSourceCodecManager 注册此 Argument 类型的 codec")

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSource.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSource.kt
@@ -81,6 +81,11 @@ data class SelectorMediaSourceArguments(
     val iconUrl: String,
     val searchConfig: SelectorSearchConfig = SelectorSearchConfig.Empty,
     override val tier: MediaSourceTier = MediaSourceTier.Fallback,
+    /**
+     * Channel 级别的 tier 覆盖, key 为 channel 名称 (与页面解析出的 channel 名一致).
+     * @since 4.9
+     */
+    override val channelTiers: Map<String, MediaSourceTier> = emptyMap(),
 ) : MediaSourceArguments {
     companion object {
         val Default = SelectorMediaSourceArguments(

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorSourceTierAutoSelectTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorSourceTierAutoSelectTest.kt
@@ -23,6 +23,7 @@ import me.him188.ani.app.domain.media.fetch.MediaFetchSession
 import me.him188.ani.app.domain.media.selector.testFramework.FetchMediaSelectorTestSuite
 import me.him188.ani.app.domain.media.selector.testFramework.MediaSelectorTestSuite
 import me.him188.ani.app.domain.media.selector.testFramework.assert
+import me.him188.ani.app.domain.media.selector.testFramework.channelTiers
 import me.him188.ani.app.domain.media.selector.testFramework.runFetchMediaSelectorTestSuite
 import me.him188.ani.app.domain.media.selector.testFramework.tier
 import me.him188.ani.datasources.api.Media
@@ -219,6 +220,93 @@ class MediaSelectorSourceTierAutoSelectTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `channel tier - auto select t0 channel of a high tier source`() = runFetchMediaSelectorTestSuite {
+        initSubject()
+        val (handles, session, sources) = configureFetchSession {
+            object {
+                val web1 by web {
+                    tier = 2
+                    channelTiers("channel-a" to 0)
+                }
+                val web2 by web { tier = 2 }
+            }
+        }
+        createFastSelectFlow(session).test {
+            expectNoEvents()
+            sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName, alliance = "channel-a"))
+            testScope().runCurrent()
+            listOf(assertNotNull(awaitItem())).assert {
+                single().assert(source = sources.web1)
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `channel tier - dont auto select media from demoted channel`() = runFetchMediaSelectorTestSuite {
+        // 数据源整体 tier 0, 但结果全在被降到 tier 2 的 channel, 不能秒选
+        initSubject()
+        val (handles, session, sources) = configureFetchSession {
+            object {
+                val web1 by web {
+                    tier = 0
+                    channelTiers("bad-channel" to 2)
+                }
+                val web2 by web { tier = 2 }
+            }
+        }
+        createFastSelectFlow(session).test {
+            expectNoEvents()
+            sources.web1.complete(media(kind = WEB, subjectName = initApi.subjectName, alliance = "bad-channel"))
+            testScope().runCurrent()
+            expectNoEvents()
+
+            testScope().advanceTimeBy(5.seconds) // Wait for timeout
+            testScope().runCurrent()
+
+            // 超时后 fallback 仍可以选择
+            listOf(assertNotNull(awaitItem())).assert {
+                single().assert(source = sources.web1)
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `channel tier - t0 channel selected instantly while t1 channel of other source waits`() =
+        runFetchMediaSelectorTestSuite {
+            // 用户场景: 优先等 A 源的 channel A/B (tier 0), 其次才是 B 源的 channel C (tier 1)
+            initSubject()
+            val (handles, session, sources) = configureFetchSession {
+                object {
+                    val webA by web {
+                        tier = 3
+                        channelTiers("channel-a" to 0, "channel-b" to 0)
+                    }
+                    val webB by web {
+                        tier = 3
+                        channelTiers("channel-c" to 1)
+                    }
+                }
+            }
+            createFastSelectFlow(session).test {
+                expectNoEvents()
+                // B 源先完成, 但其最优 channel 只有 tier 1, 不满足秒选
+                sources.webB.complete(media(kind = WEB, subjectName = initApi.subjectName, alliance = "channel-c"))
+                testScope().runCurrent()
+                expectNoEvents()
+
+                // A 源完成, channel-b 是 tier 0, 立即选择
+                sources.webA.complete(media(kind = WEB, subjectName = initApi.subjectName, alliance = "channel-b"))
+                testScope().runCurrent()
+                listOf(assertNotNull(awaitItem())).assert {
+                    single().assert(source = sources.webA)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     private fun FetchMediaSelectorTestSuite.createFastSelectFlow(
         session: MediaFetchSession,

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorSourceTierSortTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/MediaSelectorSourceTierSortTest.kt
@@ -14,6 +14,7 @@ package me.him188.ani.app.domain.media.selector
 import me.him188.ani.app.domain.media.selector.testFramework.MediaSelectorTestSuite
 import me.him188.ani.app.domain.media.selector.testFramework.assertMedias
 import me.him188.ani.app.domain.media.selector.testFramework.runSimpleMediaSelectorTestSuite
+import me.him188.ani.app.domain.media.selector.testFramework.setChannelTiers
 import me.him188.ani.app.domain.media.selector.testFramework.setSourceTiers
 import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.source.MediaSourceKind.BitTorrent
@@ -232,6 +233,77 @@ class MediaSelectorSourceTierSortTest {
             next().assert(sourceId = "t2")
             next().assert(sourceId = "t2")
             next().assert(sourceId = "t3")
+            assertNoMoreElements()
+        }
+    }
+
+    @Test
+    fun `channel tier - channels within one source sorted by channel tier`() = runSimpleMediaSelectorTestSuite {
+        initSubject()
+        mediaApi.addMedia(
+            media(sourceId = "s", kind = WEB, alliance = "channel-b", mediaId = "s.b"),
+            media(sourceId = "s", kind = WEB, alliance = "channel-a", mediaId = "s.a"),
+            media(sourceId = "s", kind = WEB, alliance = "channel-c", mediaId = "s.c"),
+        )
+        mediaApi.shuffle()
+        setSourceTiers("s" to 1u)
+        setChannelTiers(
+            "s",
+            "channel-a" to 0u,
+            "channel-b" to 2u,
+            // channel-c falls back to source tier 1
+        )
+
+        assertMedias {
+            next().assert(mediaId = "s.a")
+            next().assert(mediaId = "s.c")
+            next().assert(mediaId = "s.b")
+            assertNoMoreElements()
+        }
+    }
+
+    @Test
+    fun `channel tier - channel tier participates in cross-source sorting`() = runSimpleMediaSelectorTestSuite {
+        // 用户场景: A 源的 channel A/B 是 tier 0, B 源的 channel C 是 tier 1
+        initSubject()
+        mediaApi.addMedia(
+            media(sourceId = "B", kind = WEB, alliance = "channel-c", mediaId = "B.c"),
+            media(sourceId = "A", kind = WEB, alliance = "channel-a", mediaId = "A.a"),
+            media(sourceId = "A", kind = WEB, alliance = "channel-b", mediaId = "A.b"),
+        )
+        setSourceTiers(
+            "A" to 3u,
+            "B" to 3u,
+        )
+        setChannelTiers("A", "channel-a" to 0u, "channel-b" to 0u)
+        setChannelTiers("B", "channel-c" to 1u)
+
+        assertMedias {
+            // A 源的两个 tier 0 channel 在前 (稳定排序保持加入顺序), B 源的 tier 1 channel 其次
+            next().assert(mediaId = "A.a")
+            next().assert(mediaId = "A.b")
+            next().assert(mediaId = "B.c")
+            assertNoMoreElements()
+        }
+    }
+
+    @Test
+    fun `channel tier - demoted channel ranks after other source`() = runSimpleMediaSelectorTestSuite {
+        // 数据源整体 tier 0, 但单个 channel 被降级到 2, 应排在 tier 1 的其他源之后
+        initSubject()
+        mediaApi.addMedia(
+            media(sourceId = "A", kind = WEB, alliance = "bad-channel", mediaId = "A.bad"),
+            media(sourceId = "B", kind = WEB, alliance = "channel", mediaId = "B.ch"),
+        )
+        setSourceTiers(
+            "A" to 0u,
+            "B" to 1u,
+        )
+        setChannelTiers("A", "bad-channel" to 2u)
+
+        assertMedias {
+            next().assert(mediaId = "B.ch")
+            next().assert(mediaId = "A.bad")
             assertNoMoreElements()
         }
     }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/testFramework/MediaSelectorTestSuite.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/selector/testFramework/MediaSelectorTestSuite.kt
@@ -426,8 +426,22 @@ fun MediaSelectorTestSuite.setSourceTier(sourceId: String, tier: MediaSourceTier
         newMap.remove(sourceId)
     }
     preferenceApi.mediaSelectorContext.value = preferenceApi.mediaSelectorContext.value.copy(
-        mediaSourceTiers = MediaSelectorSourceTiers(newMap) {
+        mediaSourceTiers = MediaSelectorSourceTiers(newMap, oldTiers?.channelTiers.orEmpty()) {
             // fallback function if not found
+            MediaSourceTier.Fallback
+        },
+    )
+}
+
+/**
+ * Sets channel-level tiers for a source. Channels not listed fall back to the source tier.
+ */
+fun MediaSelectorTestSuite.setChannelTiers(sourceId: String, vararg pairs: Pair<String, UInt>) {
+    val oldTiers = preferenceApi.mediaSelectorContext.value.mediaSourceTiers
+    val newChannelTiers = oldTiers?.channelTiers.orEmpty().toMutableMap()
+    newChannelTiers[sourceId] = pairs.associate { (channel, tier) -> channel to MediaSourceTier(tier) }
+    preferenceApi.mediaSelectorContext.value = preferenceApi.mediaSelectorContext.value.copy(
+        mediaSourceTiers = MediaSelectorSourceTiers(oldTiers?.tiers.orEmpty(), newChannelTiers) {
             MediaSourceTier.Fallback
         },
     )
@@ -452,7 +466,7 @@ fun MediaSelectorTestSuite.setSourceTiers(vararg pairs: Pair<String, UInt?>) {
         }
     }
     preferenceApi.mediaSelectorContext.value = preferenceApi.mediaSelectorContext.value.copy(
-        mediaSourceTiers = MediaSelectorSourceTiers(newMap) {
+        mediaSourceTiers = MediaSelectorSourceTiers(newMap, oldTiers?.channelTiers.orEmpty()) {
             MediaSourceTier.Fallback
         },
     )
@@ -466,6 +480,18 @@ var Handle.tier: Int?
     set(value) {
         suite.setSourceTier(instance.mediaSourceId, value?.toUInt())
     }
+
+/**
+ * Sets channel-level tiers for this source.
+ * @see setChannelTiers
+ */
+context(suite: MediaSelectorTestSuite)
+fun Handle.channelTiers(vararg pairs: Pair<String, Int>) {
+    suite.setChannelTiers(
+        instance.mediaSourceId,
+        *pairs.map { (channel, tier) -> channel to tier.toUInt() }.toTypedArray(),
+    )
+}
 
 
 ///////////////////////////////////////////////////////////////////////////

--- a/app/shared/src/desktopTest/kotlin/data/TestMediaSelector.kt
+++ b/app/shared/src/desktopTest/kotlin/data/TestMediaSelector.kt
@@ -115,7 +115,8 @@ open class TestMediaSelector(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,
-        allowNonPreferred: Boolean
+        allowNonPreferred: Boolean,
+        candidateMediaFilter: ((Media) -> Boolean)?
     ): Media? {
         throw UnsupportedOperationException()
     }
@@ -124,7 +125,8 @@ open class TestMediaSelector(
         candidateSources: List<String>,
         overrideUserSelection: Boolean,
         blacklistMediaIds: Set<String>,
-        allowNonPreferred: Boolean
+        allowNonPreferred: Boolean,
+        candidateMediaFilter: ((Media) -> Boolean)?
     ): Media? {
         throw UnsupportedOperationException()
     }

--- a/docs/contributing/code/media/media-code-map.md
+++ b/docs/contributing/code/media/media-code-map.md
@@ -83,6 +83,15 @@
 - 过滤/排序主实现：`MediaSelectorFilterSortAlgorithm`。算法细节见
   [MediaSelector](media-selector.md)。
 - 选择器主实现：`DefaultMediaSelector`。
+- 阶级（tier）：`MediaSelectorSourceTiers`
+  （`app/shared/app-data/.../domain/media/selector/MediaSelectorContext.kt`）
+  持有数据源级 `tiers` 与 channel 级 `channelTiers`，由
+  `MediaSourceManagerImpl.mediaSourceTiersFlow()` 从各实例的
+  `MediaSourceArguments.tier` / `channelTiers` 汇总。排序按
+  `(mediaSourceId, alliance)` 查有效阶级；快速选择
+  `MediaSelectorAutoSelect.fastSelectWebSources` 用 `getBestTier(...)` 判定候选数据源，
+  并通过 `awaitSelectFromMediaSources` 的 `candidateMediaFilter` 参数把秒选限制在低阶级
+  channel 的资源上。
 - 查询结果并不天然“正确”；数据源实现应尽量返回准确的 `episodeRange`，`MediaSelector`
   只是在其上做额外的过滤和排序。
 

--- a/docs/contributing/code/media/media-selector.md
+++ b/docs/contributing/code/media/media-selector.md
@@ -7,7 +7,7 @@ MediaSelector 主要包含以下四个阶段：
 
 1. **过滤**：基于条目和剧集信息，遍历每个 media，决定是保留还是排除一个
    media。当被过滤时，会携带排除原因。
-2. **排序**：通过第一阶段的 media，将会按数据源的阶级（质量）、字幕类型等属性排序。
+2. **排序**：通过第一阶段的 media，将会按阶级（数据源或 channel 级，代表质量）、字幕类型等属性排序。
 3. **偏好**：根据用户对这个番剧的偏好，只采取满足用户喜好的 media。
 4. **选择**：支持手动或自动方式来选中某个 [Media]：
     - 手动调用 `select` 方法。
@@ -125,6 +125,28 @@ Sealed class [`MaybeExcludedMedia`][MaybeExcludedMedia] 表示一个可能被排
 ### 过滤规则列表
 
 参考代码中 [`MediaSelectorFilterSortAlgorithm.filterMediaList`][MediaSelectorFilterSortAlgorithm]。
+
+## 排序阶段
+
+排序入口为 [`MediaSelectorFilterSortAlgorithm.sortMediaList`][MediaSelectorFilterSortAlgorithm]。
+排序是**稳定**的，按以下优先级逐级比较，前一级相等才比较下一级：
+
+1. **是否被排除**：`Included` 在前，`Excluded` 全部排在最后；
+2. **播放器兼容性**：当前平台播放器不能正常播放的字幕类型靠后；
+3. **资源类型**：本地缓存永远最前；其余按用户偏好的类型（`preferKind`，WEB 或 BT）排序；
+4. **下载代价**：`Local` < `Lan` < `Online`；
+5. **阶级（tier）**：按资源的*有效阶级*升序。有效阶级优先取该资源所属 channel 的阶级
+   （`MediaSelectorSourceTiers.channelTiers`，以 `Media.properties.alliance` 为 channel 名），
+   未配置时回退到数据源阶级，详见[数据源阶级](media-source.md#数据源阶级)；
+6. **发布时间**：新的在前；
+7. **条目名称相似度**：高的在前。
+
+由于 channel 阶级参与第 5 级比较，同一数据源不同 channel 的资源可以与其他数据源交叉排序。
+例如 A 源的 channel A/B 为 tier 0、B 源的 channel C 为 tier 1 时，排序为
+`A/channelA、A/channelB → B/channelC`，而不是按数据源整体分块。
+
+快速选择（`MediaSelectorAutoSelect.fastSelectWebSources`）同样按 channel 粒度判定：
+只有有效阶级不超过阈值的资源才会被立即选择。
 
 [MediaSelectorFilterSortAlgorithm]: ../../../../app/shared/app-data/src/commonMain/kotlin/domain/media/selector/filter/MediaSelectorFilterSortAlgorithm.kt
 

--- a/docs/contributing/code/media/media-source.md
+++ b/docs/contributing/code/media/media-source.md
@@ -36,7 +36,54 @@ interface MediaSource {
 
 ## 数据源阶级
 
-> 自 Animeko v4.8
+> 自 Animeko v4.8。Channel 级阶级自 v4.9。
+
+每个数据源拥有一个阶级 [`MediaSourceTier`][MediaSourceTier]。阶级值越低表示质量越高：`0`
+为最高阶级。阶级影响 [MediaSelector](media-selector.md) 的两个环节：
+
+- **排序**：有效阶级低的资源排在前面，详见[排序阶段](media-selector.md#排序阶段)；
+- **快速选择**：阶级不超过阈值（目前为 `0`）的 WEB 数据源查询完成后会被立即选择，
+  无需等待其他数据源。超过阈值的数据源只能在等待一段时间后通过兜底逻辑被选择。
+  入口为 `MediaSelectorAutoSelect.fastSelectWebSources`。
+
+阶级来源于数据源配置 `MediaSourceArguments.tier`，通常由订阅提供；用户未配置时使用回退值
+`MediaSourceTier.Fallback`（`2`）。
+
+### Channel 级阶级
+
+> 自 Animeko v4.9
+
+`SelectorMediaSource` 支持 channel（俗称“线路”）：同一个页面上的多个播放列表。
+数据源解析出的 channel 名称会写入资源的 `Media.properties.alliance` 属性。
+
+`SelectorMediaSourceArguments.channelTiers` 可以为单个 channel 指定阶级，覆盖数据源整体的
+`tier`；未列出的 channel 回退到数据源阶级。资源的**有效阶级**因此为：
+
+```
+有效阶级 = channelTiers[channel 名] ?: 数据源 tier
+```
+
+排序与快速选择都按有效阶级进行。这意味着：
+
+- 同一数据源的不同 channel 可以与其他数据源交叉排序；
+- 数据源整体阶级较高（数值大），但拥有一个 tier 0 channel 时，该 channel 的资源仍可被快速选择立即选中；
+- 反之，数据源整体是 tier 0，但被降级的 channel 的资源不会被立即选中，只能走兜底。
+
+订阅 JSON 中的配置示例（`SelectorMediaSourceArguments` 片段）：
+
+```json
+{
+  "name": "示例源",
+  "tier": 2,
+  "channelTiers": {
+    "线路A": 0,
+    "线路B": 1
+  }
+}
+```
+
+新增字段对旧版本客户端向后兼容：解码器开启了 `ignoreUnknownKeys`，旧客户端会忽略
+`channelTiers` 并继续使用数据源级阶级。
 
 ## 扩展数据源支持
 
@@ -50,6 +97,8 @@ interface MediaSource {
 [Media]: ../../../../datasource/api/src/commonMain/kotlin/Media.kt
 
 [MediaSource]: ../../../../datasource/api/src/commonMain/kotlin/source/MediaSource.kt
+
+[MediaSourceTier]: ../../../../datasource/api/src/commonMain/kotlin/source/MediaSource.kt
 
 [dmhy]: http://www.dmhy.org/
 


### PR DESCRIPTION
## 概述

将现有的 media source 级 tier 系统扩展为 **channel 级**:同一数据源的每个 channel 可以拥有不同 tier,并完整参与排序与快速选择。例如可以配置为:优先等待 A 源的 channel A/B (tier 0),其次才是 B 源的 channel C (tier 1)。

## 实现

**Channel 的标识**:web selector 源解析出的 channel 名会写入 `Media.properties.alliance`,因此 channel 级 tier 按 `(mediaSourceId, alliance)` 查询。

- **`MediaSelectorSourceTiers`** 新增 `channelTiers: Map<sourceId, Map<channelName, tier>>`:
  - `get(sourceId, channel)` — 有效 tier:channel 覆盖优先,未列出的 channel 回退到数据源 tier;
  - `getBestTier(sourceId)` — 数据源自身 tier 与其所有 channel tier 的最小值。
- **配置**:`SelectorMediaSourceArguments.channelTiers`(默认空)。订阅 JSON 直接写该字段即可;codec 已开 `ignoreUnknownKeys`,旧客户端忽略新字段,无需 bump codec 版本。`MediaSourceManager.mediaSourceTiersFlow()` 负责汇总。
- **排序**:`MediaSelectorFilterSortAlgorithm.sortMediaList` 的 tier 比较键改为有效 tier,同源不同 channel 可与其他源交叉排序。
- **快速选择**:`fastSelectWebSources`
  - 候选判定用 `getBestTier`:源整体 tier 较高但拥有 tier 0 channel 时也可进入秒选候选;
  - 秒选通过 `MediaSelector.awaitSelectFromMediaSources`/`trySelectFromMediaSources` 新增的 `candidateMediaFilter` 参数,只放行有效 tier ≤ 阈值的资源。源整体 tier 0 但被降级的 channel 不会被秒选,只能走超时 fallback。

## 测试

- 新增 3 个排序测试(同源多 channel 按 channel tier 排序、跨源交叉排序、被降级 channel 排到其他源之后)。
- 新增 3 个快速选择测试(高 tier 源的 t0 channel 被秒选、降级 channel 不被秒选走超时、完整用户场景)。
- `:app:shared:app-data:desktopTest` 全量 838 个测试通过;`compileAndroidMain` 通过。

## 兼容性

- 未配置 `channelTiers` 时行为与之前完全一致(所有 channel 回退到源 tier)。
- 新接口参数带默认值,旧调用方无需修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)