### PR TITLE
fix(player): swipe-to-seek cancelled when drag starts inside the cancel area

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -122,7 +123,6 @@ import me.him188.ani.app.videoplayer.ui.gesture.LockableVideoGestureHost
 import me.him188.ani.app.videoplayer.ui.gesture.NoOpLevelController
 import me.him188.ani.app.videoplayer.ui.gesture.ScreenshotButton
 import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerConfig
-import me.him188.ani.app.videoplayer.ui.gesture.isInCancelArea
 import me.him188.ani.app.videoplayer.ui.gesture.mouseFamily
 import me.him188.ani.app.videoplayer.ui.gesture.rememberGestureIndicatorState
 import me.him188.ani.app.videoplayer.ui.gesture.rememberSwipeSeekerState
@@ -234,6 +234,7 @@ internal fun EpisodeVideoImpl(
         }
     }
     val indicatorState = rememberGestureIndicatorState()
+    val swipeSeekerConfig = SwipeSeekerConfig.Default
     // 桌面设备可能同时支持鼠标和触摸；当前 GestureFamily 不能按单次输入来源分流，
     // 因此桌面端仍使用 MOUSE 分支。后续实现来源级分流时再支持桌面触摸手势。
     // TODO: 根据触控能力与平台特性建立设备抽象，并据此选择手势策略。
@@ -241,6 +242,7 @@ internal fun EpisodeVideoImpl(
         enabled = gestureFamily == GestureFamily.TOUCH,
         controllerState = playerControllerState,
         indicatorState = indicatorState,
+        swipeSeekerConfig = swipeSeekerConfig,
     )
 
     AniTheme(darkModeOverride = DarkMode.DARK) {
@@ -317,7 +319,10 @@ internal fun EpisodeVideoImpl(
                 }
             },
             gestureHost = {
-                val swipeSeekerState = rememberSwipeSeekerState(constraints.maxWidth) {
+                val swipeSeekerState = rememberSwipeSeekerState(
+                    constraints.maxWidth,
+                    swipeSeekerConfig,
+                ) {
                     playerState.skip(it * 1000L)
                 }
                 val videoPropertiesState by playerState.mediaProperties.collectAsState(null)
@@ -396,7 +401,6 @@ internal fun EpisodeVideoImpl(
                     }
                 }
             },
-            touchSeekState = touchSeekState,
             framePreviewOverlay = {
                 if (!expanded) {
                     ProgressSliderCenteredPreviewFrame(
@@ -532,18 +536,20 @@ internal fun EpisodeVideoImpl(
 
 /**
  * 将进度条的通用触摸状态机接入播放器 UI：拖动期间保留 inline progress slider，
- * 手指进入取消区域时持续显示取消提示。非触屏分支返回 `null`，不改变原有交互。
+ * 手指向上滑过取消阈值时持续显示取消提示。非触屏分支返回 `null`，不改变原有交互。
  */
 @Composable
 private fun rememberPlayerTouchSeekState(
     enabled: Boolean,
     controllerState: PlayerControllerState,
     indicatorState: GestureIndicatorState,
+    swipeSeekerConfig: SwipeSeekerConfig,
 ): TouchSeekState? {
     if (!enabled) return null
 
-    return remember(controllerState, indicatorState) {
-        // requester 和 indicator ticket 跨状态迁移保持不变，确保每次请求都由同一实例撤销。
+    val density = LocalDensity.current
+    return remember(controllerState, indicatorState, swipeSeekerConfig, density) {
+        // 同一 TouchSeekState 生命周期内，每次请求都由固定 requester 和 indicator ticket 撤销。
         val controllerRequester = Any()
         var indicatorTicket: Int? = null
         fun stopCancellationIndicator() {
@@ -551,7 +557,8 @@ private fun rememberPlayerTouchSeekState(
             indicatorTicket = null
         }
         TouchSeekState(
-            isInCancelArea = SwipeSeekerConfig.Default::isInCancelArea,
+            swipeSeekerConfig = swipeSeekerConfig,
+            density = density,
             onStateChanged = { state ->
                 when (state) {
                     // 手势结束：恢复控制器的正常显隐，并关闭可能存在的取消提示。

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -112,6 +112,7 @@ import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.test.TestMediampPlayer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -1241,6 +1242,67 @@ class EpisodeVideoControllerTest {
             waitUntil(timeoutMillis = WAIT_TIMEOUT) { detachedProgressSlider.doesNotExist() }
             assertEquals(NORMAL_INVISIBLE, controllerState.visibility)
         }
+    }
+
+    @Test
+    fun `touch - swipeToSeek cancellation updates the hint and preview`() = runAniComposeUiTest {
+        setContent {
+            Player(GestureFamily.TOUCH)
+        }
+        waitForIdle()
+        val cancelHint = onNodeWithText("Release to cancel")
+
+        videoGestureHost.performTouchInput {
+            val start = Offset(width * 0.2f, height * 0.8f)
+            down(start)
+            moveTo(Offset(width * 0.8f, start.y))
+        }
+        runOnIdle {
+            assertTrue(progressSliderState.isPreviewing)
+            cancelHint.assertDoesNotExist()
+        }
+
+        videoGestureHost.performTouchInput {
+            moveTo(Offset(width * 0.8f, height * 0.1f))
+        }
+        runOnIdle {
+            cancelHint.assertExists()
+            assertFalse(progressSliderState.isPreviewing)
+        }
+
+        videoGestureHost.performTouchInput {
+            moveTo(Offset(width * 0.8f, height * 0.75f))
+        }
+        runOnIdle {
+            cancelHint.assertDoesNotExist()
+            assertTrue(progressSliderState.isPreviewing)
+        }
+
+        videoGestureHost.performTouchInput {
+            moveTo(Offset(width * 0.8f, height * 0.1f))
+        }
+        runOnIdle {
+            cancelHint.assertExists()
+            assertFalse(progressSliderState.isPreviewing)
+        }
+
+        mainClock.autoAdvance = false
+        videoGestureHost.performTouchInput {
+            up()
+        }
+
+        mainClock.advanceTimeBy(100L)
+        runOnIdle {
+            cancelHint.assertExists()
+        }
+
+        mainClock.advanceTimeBy(500L)
+        runOnIdle {
+            cancelHint.assertDoesNotExist()
+            assertFalse(progressSliderState.isPreviewing)
+            assertEquals(0L, currentPositionMillis)
+        }
+        mainClock.autoAdvance = true
     }
 
     /**

--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
@@ -54,7 +53,6 @@ import me.him188.ani.app.ui.foundation.layout.desktopTitleBar
 import me.him188.ani.app.ui.foundation.theme.slightlyWeaken
 import me.him188.ani.app.videoplayer.ui.gesture.PlayerGestureHost
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerBar
-import me.him188.ani.app.videoplayer.ui.progress.TouchSeekState
 import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
 
 /**
@@ -105,7 +103,6 @@ fun VideoScaffold(
     centerOverlay: @Composable BoxScope.() -> Unit = {},
     framePreviewOverlay: @Composable BoxScope.() -> Unit = {},
     playerStatsOverlay: @Composable BoxScope.() -> Unit = {},
-    touchSeekState: TouchSeekState? = null,
 ) {
     val inlineSliderOnly = controllerState.visibility == ControllerVisibility.InlineSliderOnly
     val controllerVisibility = controllerState.visibility
@@ -120,9 +117,6 @@ fun VideoScaffold(
     ) { // 16:9 box
         Box(
             Modifier
-                .onGloballyPositioned {
-                    touchSeekState?.containerCoordinates = it
-                }
                 .then(
                     if (!maintainAspectRatio) {
                         Modifier.fillMaxSize()

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -259,6 +260,27 @@ class GestureIndicatorState {
     }
 }
 
+@Immutable
+internal data class GestureIndicatorPresentation(
+    val state: GestureIndicatorState.State,
+    val deltaSeconds: Int,
+    val seekCancelled: Boolean,
+)
+
+internal fun gestureIndicatorPresentation(
+    state: GestureIndicatorState,
+    activeSwipeSeekerState: SwipeSeekerState?,
+): GestureIndicatorPresentation? {
+    if (!state.visible && activeSwipeSeekerState == null) return null
+    val presentationState = if (activeSwipeSeekerState != null) SEEKING
+    else state.state ?: return null
+    return GestureIndicatorPresentation(
+        state = presentationState,
+        deltaSeconds = activeSwipeSeekerState?.deltaSeconds ?: state.deltaSeconds,
+        seekCancelled = activeSwipeSeekerState?.isCancelled ?: state.seekCancelled,
+    )
+}
+
 /**
  * 展示当前快进/快退秒数的指示器.
  *
@@ -272,16 +294,24 @@ fun GestureIndicator(
     val shape = MaterialTheme.shapes.small
     val colors = MaterialTheme.colorScheme
     val activeSwipeSeekerState = swipeSeekerState?.takeIf { it.isSeeking }
-    var lastDelta by remember(state) {
-        mutableIntStateOf(state.deltaSeconds)
+    val presentation = gestureIndicatorPresentation(state, activeSwipeSeekerState)
+    // 淡出期间 presentation 为 null。滑动 seek 的指示器只由 swipeSeekerState 驱动,
+    // GestureIndicatorState.state 全程为 null；不保留最后一帧的话，松手后会淡出一个空 Surface。
+    // 在组合结束后才写入, 避免组合被丢弃时留下脏值; 淡出期间读到的是上一帧提交的快照。
+    val retainedPresentation = remember { mutableStateOf<GestureIndicatorPresentation?>(null) }
+    if (presentation != null) {
+        SideEffect { retainedPresentation.value = presentation }
     }
+    // presentation 非 null 时不读 retainedPresentation, 因此快进过程中不会因保留帧写入而多一次重组。
+    val currentPresentation = presentation ?: retainedPresentation.value
 
     AniAnimatedVisibility(
-        visible = state.visible || activeSwipeSeekerState != null,
+        visible = presentation != null,
         enter = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
         exit = fadeOut(tween(durationMillis = 500)),
         label = "SeekPositionIndicator",
     ) {
+        currentPresentation ?: return@AniAnimatedVisibility
         Surface(
             Modifier.alpha(0.8f),
             color = colors.surface,
@@ -300,7 +330,7 @@ fun GestureIndicator(
                 ) {
                     // Used by volume and brightness
                     val progressIndicator: @Composable () -> Unit = remember(state, colors) {
-                        // This remember is needed because Compose does not remember lambdas 
+                        // This remember is needed because Compose does not remember lambdas
                         // and can cause performance problem in this fast-changing composable.
                         {
                             LinearProgressIndicator(
@@ -313,7 +343,7 @@ fun GestureIndicator(
                         }
                     }
 
-                    when (if (activeSwipeSeekerState != null) SEEKING else state.state) {
+                    when (currentPresentation.state) {
                         RESUMED_ONCE -> {
                             Icon(
                                 Icons.Rounded.PlayArrow, null,
@@ -326,31 +356,20 @@ fun GestureIndicator(
                         }
 
                         SEEKING -> {
-                            val deltaDuration = activeSwipeSeekerState?.deltaSeconds ?: state.deltaSeconds
-                            val seekCancelled = activeSwipeSeekerState?.isCancelled ?: state.seekCancelled
-                            // 记忆变为 0 之前的 delta, 这样在快进/快退结束后, 会显示上一次的 delta, 而不是显示 0
-                            val duration = if (deltaDuration == 0) {
-                                lastDelta
-                            } else {
-                                deltaDuration.also {
-                                    lastDelta = deltaDuration
-                                }
-                            }
-
                             Icon(
                                 when {
-                                    seekCancelled -> Icons.Rounded.Close
-                                    duration > 0 -> Icons.Rounded.FastForward
+                                    currentPresentation.seekCancelled -> Icons.Rounded.Close
+                                    currentPresentation.deltaSeconds > 0 -> Icons.Rounded.FastForward
                                     else -> Icons.Rounded.FastRewind
                                 },
                                 contentDescription = null,
                                 modifier = Modifier.size(iconSize),
                             )
                             Text(
-                                text = if (seekCancelled) {
+                                text = if (currentPresentation.seekCancelled) {
                                     stringResource(Lang.video_player_release_to_cancel)
                                 } else {
-                                    renderTime(duration.absoluteValue)
+                                    renderTime(currentPresentation.deltaSeconds.absoluteValue)
                                 },
                                 maxLines = 1,
                             )
@@ -389,8 +408,6 @@ fun GestureIndicator(
                             Icon(Icons.Rounded.FastForward, null, Modifier.size(iconSize))
                             Text("${state.playbackSpeed.formatSpeedValue()}x", maxLines = 1)
                         }
-
-                        null -> {}
                     }
                 }
             }
@@ -457,7 +474,7 @@ val VIDEO_GESTURE_TOUCH_SHOW_CONTROLLER_DURATION = 3.seconds
 
 /**
  * 将屏幕横滑 seek 的状态迁移映射到控制器显隐和进度预览。
- * [SwipeSeekerState] 负责识别手势，本类只响应开始、取消区域变化和结束事件。
+ * [SwipeSeekerState] 负责识别手势，本类只响应开始、取消状态变化和结束事件。
  */
 private class SwipeSeekInteraction(
     private val controllerState: PlayerControllerState,

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/SwipeSeekerState.kt
@@ -30,7 +30,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import kotlin.math.roundToInt
@@ -43,10 +46,12 @@ fun rememberSwipeSeekerState(
     @UiThread onSeek: (offsetSeconds: Int) -> Unit,
 ): SwipeSeekerState {
     val onSeekState by rememberUpdatedState(onSeek)
-    return remember(swipeSeekerConfig, screenWidthPx) {
+    val density = LocalDensity.current
+    return remember(swipeSeekerConfig, screenWidthPx, density) {
         SwipeSeekerState(
             screenWidthPx,
             swipeSeekerConfig,
+            density,
         ) { onSeekState(it) }
     }
 }
@@ -65,72 +70,92 @@ data class SwipeSeekerConfig(
     // 实测差不多可以滑到 87 秒, 看三秒 op 让他知道他完了 op
     val maxDragSeconds: Int = 97,
     /**
-     * 屏幕顶部作为取消区域的高度占比.
+     * 向上滑动多少距离后取消本次快进.
+     *
+     * 快进过程中手指向上移动超过该距离即取消, 滑回该距离以内恢复.
      */
-    val cancelAreaHeightRatio: Float = 0.25f,
-    /**
-     * 屏幕左右两侧各自作为取消区域的宽度占比.
-     */
-    val cancelAreaWidthRatio: Float = 0.25f,
+    val cancelVerticalDragDistance: Dp = 144.dp,
 ) {
     companion object {
         val Default = SwipeSeekerConfig()
     }
 }
 
-fun SwipeSeekerConfig.isInCancelArea(position: Offset, containerSize: IntSize): Boolean {
-    if (!position.isSpecified || containerSize.width <= 0 || containerSize.height <= 0) return false
-
-    val inTopArea = position.y <= containerSize.height * cancelAreaHeightRatio
-    val inLeftArea = position.x <= containerSize.width * cancelAreaWidthRatio
-    val inRightArea = position.x >= containerSize.width * (1f - cancelAreaWidthRatio)
-    return inTopArea && (inLeftArea || inRightArea)
+internal fun isVerticalDragCancelled(
+    dragStartY: Float,
+    position: Offset,
+    cancelVerticalDragDistancePx: Float,
+): Boolean {
+    return position.isSpecified &&
+        dragStartY - position.y > cancelVerticalDragDistancePx
 }
 
-// draggable 继续负责识别单轴 seek；这里只观察二维位置，并在进入或离开取消区域时通知上层。
 private fun Modifier.trackSwipeSeekCancellation(
     seekerState: SwipeSeekerState,
     onCancellationChanged: (Boolean) -> Unit,
-): Modifier = onPointerEventMultiplatform(
-    PointerEventType.Move,
-    pass = PointerEventPass.Initial,
-) { event ->
-    val change = event.changes.firstOrNull() ?: return@onPointerEventMultiplatform
-    if (seekerState.updateCancellation(change.position, size)) {
-        onCancellationChanged(seekerState.isCancelled)
+): Modifier = this
+    .onPointerEventMultiplatform(
+        PointerEventType.Press,
+        pass = PointerEventPass.Initial,
+    ) { event ->
+        event.changes.firstOrNull()?.let { seekerState.onPointerDown(it.position) }
     }
-}
+    .onPointerEventMultiplatform(
+        PointerEventType.Move,
+        pass = PointerEventPass.Initial,
+    ) { event ->
+        val change = event.changes.firstOrNull() ?: return@onPointerEventMultiplatform
+        if (seekerState.updateCancellation(change.position)) {
+            onCancellationChanged(seekerState.isCancelled)
+        }
+    }
 
 @Stable
-class SwipeSeekerState(
+class SwipeSeekerState internal constructor(
     /**
      * 可滑动区域宽度
      */
     private val screenWidthPx: Int,
-    private val swipeSeekerConfig: SwipeSeekerConfig = SwipeSeekerConfig.Default,
+    private val swipeSeekerConfig: SwipeSeekerConfig,
+    density: Density,
     /**
      * 当一次滑动结束时的回调. `offsetSeconds` 为本次快进的秒数
      */
     @UiThread val onSeek: (offsetSeconds: Int) -> Unit,
 ) {
+    private val cancelVerticalDragDistancePx =
+        with(density) { swipeSeekerConfig.cancelVerticalDragDistance.toPx() }
+
     /**
      * [Float.NaN] iff not dragging
      */
     private var seekDelta: Float by mutableFloatStateOf(Float.NaN)
 
     /**
-     * 当前滑动是否已进入取消区域.
+     * 当前滑动是否已取消, 即手指是否已向上移动超过取消距离.
      */
     var isCancelled: Boolean by mutableStateOf(false)
         private set
 
-    private var lastPointerPosition: Offset = Offset.Unspecified
-    private var lastPointerContainerSize: IntSize = IntSize.Zero
+    /**
+     * 手指按下位置的 Y 坐标, 作为取消判定的基准线. [Float.NaN] 表示未在滑动.
+     *
+     * 基准取按下点而不是拖动手势识别点: 滑动大概率不是直的, 手势识别 (越过 touch slop)
+     * 时手指可能已经有垂直偏移, 以识别点为基准会把这部分偏移吃掉.
+     */
+    private var dragStartY: Float = Float.NaN
+
+    @UiThread
+    internal fun onPointerDown(position: Offset) {
+        if (!isSeeking && position.isSpecified) {
+            dragStartY = position.y
+        }
+    }
 
     @UiThread
     internal fun onSwipeStarted() {
         seekDelta = 0f
-        isCancelled = isInCancelArea(lastPointerPosition, lastPointerContainerSize)
+        isCancelled = false
     }
 
     @UiThread
@@ -141,6 +166,7 @@ class SwipeSeekerState(
         }
         seekDelta = Float.NaN
         isCancelled = false
+        dragStartY = Float.NaN
     }
 
     @UiThread
@@ -149,18 +175,13 @@ class SwipeSeekerState(
     }
 
     @UiThread
-    internal fun updateCancellation(position: Offset, containerSize: IntSize): Boolean {
+    internal fun updateCancellation(position: Offset): Boolean {
         val wasCancelled = isCancelled
-        lastPointerPosition = position
-        lastPointerContainerSize = containerSize
         if (isSeeking) {
-            isCancelled = isInCancelArea(position, containerSize)
+            isCancelled = isVerticalDragCancelled(dragStartY, position, cancelVerticalDragDistancePx)
         }
         return isCancelled != wasCancelled
     }
-
-    private fun isInCancelArea(position: Offset, containerSize: IntSize): Boolean =
-        swipeSeekerConfig.isInCancelArea(position, containerSize)
 
     /**
      * 是否正在快进, 即用户是否正在滑动屏幕

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -60,14 +61,13 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
@@ -87,6 +87,8 @@ import me.him188.ani.app.ui.foundation.dialogs.PlatformPopupProperties
 import me.him188.ani.app.ui.foundation.effects.onPointerEventMultiplatform
 import me.him188.ani.app.ui.foundation.theme.slightlyWeaken
 import me.him188.ani.app.ui.foundation.theme.weaken
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerConfig
+import me.him188.ani.app.videoplayer.ui.gesture.isVerticalDragCancelled
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.features.chapters
 import org.openani.mediamp.metadata.Chapter
@@ -269,19 +271,23 @@ class MediaProgressSliderColors(
  * 状态只按以下路径迁移:
  * ```
  * Idle --start--> Seeking
- * Seeking --move into cancel area--> Cancelling
- * Cancelling --move out--> Seeking
+ * Seeking --move upward past threshold--> Cancelling
+ * Cancelling --move back within threshold--> Seeking
  * Seeking / Cancelling --stop--> Idle
  * ```
- * [move] 根据手指是否位于取消区域，在 [State.Seeking] 和 [State.Cancelling] 之间切换；
+ * [move] 根据手指相对按下点的上滑距离，在 [State.Seeking] 和 [State.Cancelling] 之间切换；
  * [stop] 返回松手时是否处于取消状态，供进度条决定提交或放弃 seek.
  * [onStateChanged] 只在状态实际变化时调用，控制器显隐和取消提示统一在这里响应.
  */
 @Stable
 class TouchSeekState(
-    val isInCancelArea: (position: Offset, containerSize: IntSize) -> Boolean,
+    swipeSeekerConfig: SwipeSeekerConfig,
+    density: Density,
     val onStateChanged: (State) -> Unit,
 ) {
+    private val cancelVerticalDragDistancePx =
+        with(density) { swipeSeekerConfig.cancelVerticalDragDistance.toPx() }
+
     enum class State {
         Idle,
         Seeking,
@@ -291,17 +297,23 @@ class TouchSeekState(
     var state: State = State.Idle
         private set
 
-    internal var containerCoordinates: LayoutCoordinates? = null
+    private var dragStartY: Float = Float.NaN
+
+    internal fun onPointerDown(position: Offset) {
+        if (state == State.Idle && position.isSpecified) {
+            dragStartY = position.y
+        }
+    }
 
     internal fun start() {
         transitionTo(State.Seeking)
     }
 
-    internal fun move(sliderCoordinates: LayoutCoordinates, position: Offset): Boolean {
-        val containerCoordinates = containerCoordinates ?: return false
-        val cancelling = isInCancelArea(
-            containerCoordinates.localPositionOf(sliderCoordinates, position),
-            containerCoordinates.size,
+    internal fun move(position: Offset): Boolean {
+        val cancelling = isVerticalDragCancelled(
+            dragStartY,
+            position,
+            cancelVerticalDragDistancePx,
         )
         return transitionTo(if (cancelling) State.Cancelling else State.Seeking)
     }
@@ -309,6 +321,7 @@ class TouchSeekState(
     internal fun stop(): Boolean {
         val cancelled = state == State.Cancelling
         transitionTo(State.Idle)
+        dragStartY = Float.NaN
         return cancelled
     }
 
@@ -453,7 +466,6 @@ fun MediaProgressSlider(
         var mousePosX by rememberSaveable { mutableStateOf(0f) }
         var thumbWidth by rememberSaveable { mutableIntStateOf(0) }
         var sliderWidth by rememberSaveable { mutableIntStateOf(0) }
-        var sliderCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
         var latestTouchPreviewRatio by remember { mutableFloatStateOf(Float.NaN) }
         var handlingTouchInput by remember { mutableStateOf(false) }
 
@@ -628,9 +640,6 @@ fun MediaProgressSlider(
             },
             enabled = enabled,
             modifier = Modifier.fillMaxWidth().height(24.dp)
-                .onGloballyPositioned {
-                    sliderCoordinates = it
-                }
                 .onSizeChanged {
                     sliderWidth = it.width
                 }
@@ -639,7 +648,10 @@ fun MediaProgressSlider(
                     PointerEventType.Press,
                     pass = PointerEventPass.Initial,
                 ) { event ->
-                    handlingTouchInput = event.changes.firstOrNull()?.type == PointerType.Touch
+                    val touchChange = event.changes.firstOrNull()
+                        ?.takeIf { it.type == PointerType.Touch }
+                    handlingTouchInput = touchChange != null
+                    touchChange?.let { touchSeekState?.onPointerDown(it.position) }
                 }
                 .onPointerEventMultiplatform(
                     PointerEventType.Move,
@@ -652,8 +664,7 @@ fun MediaProgressSlider(
                     if (!handlingTouchInput || touchSeekState.state == TouchSeekState.State.Idle) {
                         return@onPointerEventMultiplatform
                     }
-                    val coordinates = sliderCoordinates ?: return@onPointerEventMultiplatform
-                    if (!touchSeekState.move(coordinates, change.position)) {
+                    if (!touchSeekState.move(change.position)) {
                         return@onPointerEventMultiplatform
                     }
 

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/GestureIndicatorStateTest.kt
@@ -16,9 +16,15 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GestureIndicatorStateTest {
+    @Test
+    fun `fresh state has no indicator presentation`() {
+        assertNull(gestureIndicatorPresentation(GestureIndicatorState(), null))
+    }
+
     @Test
     fun `playback speed is shown temporarily`() = runTest {
         val state = GestureIndicatorState()

--- a/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/gesture/SwipeSeekerStateTest.kt
@@ -10,78 +10,65 @@
 package me.him188.ani.app.videoplayer.ui.gesture
 
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SwipeSeekerStateTest {
-    private val containerSize = IntSize(width = 1000, height = 600)
+    private val screenWidthPx = 1000
 
     @Test
-    fun `releasing in top corner cancels seek`() {
+    fun `cancellation follows the configured threshold and can be resumed`() {
         val seeks = mutableListOf<Int>()
-        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
+        val threshold = 288f
+        val startY = 400f
+        val state = SwipeSeekerState(
+            screenWidthPx = screenWidthPx,
+            swipeSeekerConfig = SwipeSeekerConfig(cancelVerticalDragDistance = threshold.dp),
+            density = Density(1f),
+            onSeek = seeks::add,
+        )
 
+        state.onPointerDown(Offset(500f, startY))
         state.onSwipeStarted()
         state.onSwipeOffset(500f)
-        state.updateCancellation(Offset(100f, 100f), containerSize)
 
-        assertTrue(state.isCancelled)
-        state.onSwipeStopped()
-        assertEquals(emptyList(), seeks)
-        assertFalse(state.isSeeking)
+        state.updateCancellation(Offset(700f, startY - threshold))
         assertFalse(state.isCancelled)
-    }
 
-    @Test
-    fun `pointer entering cancel area before drag recognition is retained`() {
-        val seeks = mutableListOf<Int>()
-        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
-
-        state.updateCancellation(Offset(100f, 100f), containerSize)
-        state.onSwipeStarted()
-        state.onSwipeOffset(500f)
-
-        assertTrue(state.isCancelled)
-        state.onSwipeStopped()
-        assertEquals(emptyList(), seeks)
-    }
-
-    @Test
-    fun `moving out of top corner resumes seek`() {
-        val seeks = mutableListOf<Int>()
-        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = seeks::add)
-
-        state.onSwipeStarted()
-        state.onSwipeOffset(500f)
-        state.updateCancellation(Offset(900f, 100f), containerSize)
+        state.updateCancellation(Offset(700f, startY - threshold - 1f))
         assertTrue(state.isCancelled)
 
-        state.updateCancellation(Offset(500f, 300f), containerSize)
+        state.updateCancellation(Offset(700f, startY - threshold + 1f))
         assertFalse(state.isCancelled)
         state.onSwipeStopped()
+
         assertEquals(listOf(49), seeks)
     }
 
     @Test
-    fun `top center is outside cancel area`() {
-        val state = SwipeSeekerState(screenWidthPx = containerSize.width, onSeek = {})
+    fun `releasing beyond the cancellation threshold does not seek`() {
+        val seeks = mutableListOf<Int>()
+        val threshold = 144f
+        val startY = 300f
+        val state = SwipeSeekerState(
+            screenWidthPx = screenWidthPx,
+            swipeSeekerConfig = SwipeSeekerConfig(cancelVerticalDragDistance = threshold.dp),
+            density = Density(1f),
+            onSeek = seeks::add,
+        )
 
+        state.onPointerDown(Offset(500f, startY))
         state.onSwipeStarted()
-        state.updateCancellation(Offset(500f, 100f), containerSize)
+        state.onSwipeOffset(500f)
+        state.updateCancellation(Offset(700f, startY - threshold - 1f))
+        state.onSwipeStopped()
 
+        assertEquals(emptyList(), seeks)
+        assertFalse(state.isSeeking)
         assertFalse(state.isCancelled)
-    }
-
-    @Test
-    fun `invalid cancel area input is outside cancel area`() {
-        val config = SwipeSeekerConfig.Default
-
-        assertFalse(config.isInCancelArea(Offset.Unspecified, containerSize))
-        assertFalse(config.isInCancelArea(Offset.Zero, IntSize.Zero))
-        assertFalse(config.isInCancelArea(Offset.Zero, IntSize(width = -1, height = 600)))
-        assertFalse(config.isInCancelArea(Offset.Zero, IntSize(width = 1000, height = -1)))
     }
 }

--- a/app/shared/video-player/src/commonTest/kotlin/ui/progress/TouchSeekStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/progress/TouchSeekStateTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TouchSeekStateTest {
+    private fun create(
+        threshold: Float = 144f,
+        onChanged: (TouchSeekState.State) -> Unit = {},
+    ) = TouchSeekState(
+        swipeSeekerConfig = SwipeSeekerConfig(cancelVerticalDragDistance = threshold.dp),
+        density = Density(1f),
+        onStateChanged = onChanged,
+    )
+
+    @Test
+    fun `crossing the threshold cancels and moving back resumes`() {
+        val changes = mutableListOf<TouchSeekState.State>()
+        val state = create(onChanged = changes::add)
+        val startY = 300f
+        val threshold = 144f
+
+        state.onPointerDown(Offset(100f, startY))
+        state.start()
+
+        assertFalse(state.move(Offset(200f, startY - threshold)))
+        assertTrue(state.move(Offset(200f, startY - threshold - 1f)))
+        assertFalse(state.move(Offset(300f, startY - threshold - 2f)))
+        assertTrue(state.move(Offset(300f, startY - threshold + 1f)))
+
+        assertEquals(
+            listOf(
+                TouchSeekState.State.Seeking,
+                TouchSeekState.State.Cancelling,
+                TouchSeekState.State.Seeking,
+            ),
+            changes,
+        )
+    }
+
+    @Test
+    fun `stop returns cancellation and resets the drag origin`() {
+        val state = create()
+
+        state.onPointerDown(Offset(100f, 300f))
+        state.start()
+        state.move(Offset(200f, 155f))
+        assertTrue(state.stop())
+
+        state.start()
+        assertFalse(state.move(Offset(200f, 0f)))
+        assertFalse(state.stop())
+    }
+
+    @Test
+    fun `starting without a press cannot cancel`() {
+        val state = create()
+
+        state.start()
+        assertFalse(state.move(Offset(200f, -1000f)))
+        assertEquals(TouchSeekState.State.Seeking, state.state)
+        assertFalse(state.stop())
+    }
+}

--- a/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
+++ b/app/shared/video-player/src/desktopTest/kotlin/ui/gesture/SwipeToSeekTest.kt
@@ -13,21 +13,25 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Density
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
 import me.him188.ani.app.videoplayer.ui.gesture.SwipeSeekerState.Companion.swipeToSeek
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SwipeToSeekTest {
     @Test
-    fun `release in top corner cancels seek`() = runAniComposeUiTest {
+    fun `horizontal drag from top corner still seeks`() = runAniComposeUiTest {
         val seeks = mutableListOf<Int>()
         setContent {
             BoxWithConstraints(Modifier.fillMaxSize()) {
@@ -41,9 +45,48 @@ class SwipeToSeekTest {
         }
 
         onNodeWithTag("swipeTarget").performTouchInput {
-            down(center)
-            moveTo(Offset(width * 0.4f, height * 0.5f))
-            moveTo(Offset(width * 0.1f, height * 0.1f))
+            down(Offset(width * 0.95f, height * 0.2f))
+            moveTo(Offset(width * 0.5f, height * 0.1f))
+            up()
+        }
+
+        assertEquals(1, seeks.size)
+        assertTrue(seeks[0] < 0)
+    }
+
+    @Test
+    fun `144 dp cancellation threshold respects density`() = runAniComposeUiTest {
+        val seeks = mutableListOf<Int>()
+        val cancellationThresholdPx = 144f * 2f
+        val marginPx = 16f
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(2f)) {
+                BoxWithConstraints(Modifier.fillMaxSize()) {
+                    val state = rememberSwipeSeekerState(constraints.maxWidth, onSeek = seeks::add)
+                    Box(
+                        Modifier.fillMaxSize()
+                            .testTag("swipeTarget")
+                            .swipeToSeek(state, Orientation.Horizontal),
+                    )
+                }
+            }
+        }
+
+        onNodeWithTag("swipeTarget").performTouchInput {
+            val start = Offset(width * 0.2f, height * 0.8f)
+            down(start)
+            moveTo(Offset(width * 0.8f, start.y))
+            moveTo(Offset(width * 0.8f, start.y - cancellationThresholdPx + marginPx))
+            up()
+        }
+        assertEquals(1, seeks.size)
+
+        seeks.clear()
+        onNodeWithTag("swipeTarget").performTouchInput {
+            val start = Offset(width * 0.2f, height * 0.8f)
+            down(start)
+            moveTo(Offset(width * 0.8f, start.y))
+            moveTo(Offset(width * 0.8f, start.y - cancellationThresholdPx - marginPx))
             up()
         }
 


### PR DESCRIPTION
Fix #3211

取消手势只看手指当前位置, 没有考虑开始滑动时手指就在取消区域内的情况, 导致右手拇指向前滑动时 seek 极易在起手时被取消 (#3211)。

取消判定改为以起手位置为准: 从取消区域内开始的拖动本次不触发取消; 从区域外开始的拖动滑入角落取消、移出恢复, 与原来一致。取消区域同时从 0.25 × 0.25 缩小到 0.2 × 0.2, 减少拇指弧线误入。

测试: `SwipeSeekerStateTest` / `SwipeToSeekTest` 新增覆盖两种起手方式的单元与 UI 测试, 真机已验证。