### PR TITLE
fix(desktop): install the bundled sqlite guard before startKoin

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -196,6 +196,10 @@ object AniDesktop {
 
         Log4j2Config.configureLogging(logsDir)
 
+        // Must run before any database access (startKoin below can initialize the
+        // BundledSQLiteDriver) and before JCEF loads NSS/system libsqlite3. See #3188.
+        BundledSqliteInterpositionGuard.install(cacheDir)
+
         if (AniBuildConfigDesktop.isDebug) {
             logger.info { "Debug mode enabled" }
         }
@@ -321,11 +325,6 @@ object AniDesktop {
         }
 
         val loadLibraryJob = coroutineScope.launch(Dispatchers.IO) {
-            // Must run before any database access and before JCEF loads NSS/system libsqlite3.
-            // The JCEF init coroutine joins this job before AniCefApp.initialize, so placing the
-            // guard here still guarantees the ordering. See #3188.
-            BundledSqliteInterpositionGuard.install(cacheDir)
-
             try {
                 AnitorrentLibraryLoader.loadLibraries()
                 logger.info { "Anitorrent is loaded." }

--- a/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
+++ b/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
@@ -45,8 +45,11 @@ import kotlin.io.path.absolutePathString
  * androidx.sqlite upgrade could silently break it — failure mode is a logged warning plus the
  * original racy behavior. The proper fix is upstream compiling `sqlite3_*` with hidden visibility.
  *
- * Must be called before database initialization and before [AniCefApp.initialize]. It runs as
- * the first step of the desktop `loadLibraryJob`, which the JCEF init coroutine joins.
+ * Must be called before database initialization and before [AniCefApp.initialize]. It runs
+ * synchronously at the top of `main()`, right after the cache directory is resolved: Koin
+ * startup can initialize the `BundledSQLiteDriver` before any coroutine gets scheduled, so
+ * placing this in a launched job is too late — the driver would extract and load its own
+ * `RTLD_LOCAL` copy before the redirect properties are set, reintroducing the race.
  */
 object BundledSqliteInterpositionGuard {
     private val logger = logger<BundledSqliteInterpositionGuard>()


### PR DESCRIPTION
#3195 引入的 `BundledSqliteInterpositionGuard` 运行在 `loadLibraryJob` 协程中, 而 Koin 在主线程上先一步
构造 `BundledSQLiteDriver`。守卫写入 `androidx.sqlite.driver.bundled.path/name` 时驱动已完成加载,
`NativeLibraryLoader` 读到的属性仍为 null, 因而走最后一条分支, 将 jar 中的 so 解压至 /tmp 后
`System.load`。Linux 进程内由此同时存在两份 libsqliteJni.so:

    Event: 0.921 Loaded shared library /tmp/androidx_sqliteJni14301168939025420465.tmp   驱动自身副本
    Event: 0.924 Loaded shared library ~/.cache/JNA/temp/jna...tmp                       守卫此时才初始化 JNA

    7fd02de3c000-...  ~/.cache/ani/ani-bundled-sqliteJni.so             RTLD_NOW | RTLD_GLOBAL
    7fd02e50e000-...  /tmp/androidx_sqliteJni14301168939025420465.tmp   RTLD_LOCAL, 惰性绑定

/tmp 副本的 `sqlite3_*` PLT 在首次调用时被守卫副本抢占, JNI 入口与 sqlite 实现分处两份库中。两份各持有
独立的 `sqlite3GlobalConfig`, 接收调用的一份从未执行 `sqlite3_initialize`, `m.xMalloc` 为 NULL:

    #  SIGSEGV (0xb) at pc=0x0000000000000000
    #  C  [ani-bundled-sqliteJni.so+0x6c0af]  dbMallocRawFinish+0xf
    j  androidx.sqlite.driver.bundled.BundledSQLiteStatementKt.nativeBindText(JILjava/lang/String;)V+0
    j  androidx.room.EntityUpsertAdapter.upsert(...)
    j  ...SubjectRelationsDao_Impl.upsertPersons$lambda$0(...)

`si_addr` 为 0 而非随机地址, 即跳转空函数指针的特征。#3195 之前进程内仅有一份库, 只在 NSS 抢先进入全局
作用域时崩溃; 之后则为必现, 守卫本身引入了必然发生符号抢占的第二副本。两份 hs_err 的崩溃点完全一致。

修改: `install(cacheDir)` 移至 `main()` 中 `configureLogging` 之后、`startKoin` 之前。该位置已解析出
cacheDir, 且早于任何数据库访问与 JCEF 初始化。

验证: Linux x64 release AppImage (启用 proguard) 播放正常, 首页数据库写入不再崩溃; hs_err 中
`/tmp/androidx_sqliteJni*.tmp` 映射消失。


🤖 Generated with [Claude Code](https://claude.com/claude-code)
