### PR TITLE
fix(desktop): stabilize Linux native library startup

### DIFF
--- a/.run/Run Desktop (Normal).run.xml
+++ b/.run/Run Desktop (Normal).run.xml
@@ -8,20 +8,6 @@
   -->
 
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="Run Desktop (Normal)" type="JetRunConfigurationType">
-        <option name="MAIN_CLASS_NAME" value="me.him188.ani.app.desktop.AniDesktop" />
-        <module name="animeko.app.desktop.main" />
-        <shortenClasspath name="ARGS_FILE" />
-        <option name="VM_PARAMETERS"
-                value="-XX:+UseZGC -XX:+EnableDynamicAgentLoading -Dorg.slf4j.simpleLogger.defaultLogLevel=TRACE -Dkotlinx.coroutines.debug=on -Dani.debug=true -Xmx256m" />
-        <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/app/desktop/test-sandbox" />
-        <method v="2">
-            <option name="Make" enabled="true" />
-            <option name="Gradle.BeforeRunTask" enabled="true" tasks="assemble"
-                    externalProjectPath="$PROJECT_DIR$/app/desktop" vmOptions=""
-                    scriptParameters="" />
-        </method>
-    </configuration>
     <configuration default="false" name="Run Desktop (Normal)" type="GradleRunConfiguration"
             factoryName="Gradle">
         <ExternalSystemSettings>

--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -237,6 +237,10 @@ object AniDesktop {
         )
         startupTimeMonitor.mark(StepName.WindowAndContext)
 
+        // Koin startup launches jobs that may access Room immediately. Install this guard
+        // synchronously before Koin so AndroidX cannot load a second sqlite JNI image first.
+        BundledSqliteInterpositionGuard.install(cacheDir)
+
         SingleInstanceChecker.instance.ensureSingleInstance()
         startupTimeMonitor.mark(StepName.SingletonChecker)
 
@@ -321,11 +325,6 @@ object AniDesktop {
         }
 
         val loadLibraryJob = coroutineScope.launch(Dispatchers.IO) {
-            // Must run before any database access and before JCEF loads NSS/system libsqlite3.
-            // The JCEF init coroutine joins this job before AniCefApp.initialize, so placing the
-            // guard here still guarantees the ordering. See #3188.
-            BundledSqliteInterpositionGuard.install(cacheDir)
-
             try {
                 AnitorrentLibraryLoader.loadLibraries()
                 logger.info { "Anitorrent is loaded." }

--- a/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
+++ b/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
@@ -77,6 +77,8 @@ object BundledSqliteInterpositionGuard {
     }
 
     private fun install0(cacheDir: Path) {
+        Files.createDirectories(cacheDir)
+
         val resource = when (System.getProperty("os.arch")) {
             "aarch64" -> "natives/linux_arm64/libsqliteJni.so"
             else -> "natives/linux_x64/libsqliteJni.so"

--- a/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
+++ b/app/desktop/src/main/kotlin/BundledSqliteInterpositionGuard.kt
@@ -46,7 +46,7 @@ import kotlin.io.path.absolutePathString
  * original racy behavior. The proper fix is upstream compiling `sqlite3_*` with hidden visibility.
  *
  * Must be called before database initialization and before [AniCefApp.initialize]. It runs as
- * the first step of the desktop `loadLibraryJob`, which the JCEF init coroutine joins.
+ * part of synchronous desktop startup, before Koin can launch jobs that access Room.
  */
 object BundledSqliteInterpositionGuard {
     private val logger = logger<BundledSqliteInterpositionGuard>()


### PR DESCRIPTION
## Summary

- use the Gradle-backed desktop run configuration so runtime-only native dependencies are present on the classpath
- install the bundled SQLite interposition guard synchronously before Koin starts
- prevent Room startup jobs from racing with SQLite JNI initialization

## Motivation

The direct IntelliJ application configuration only assembled the desktop module and then launched its main class using the IDE module classpath. Runtime-only dependencies were omitted, causing the bundled mpv runtime descriptor to be missing:

```text
mpv native runtime not found: 'mpv-natives-linux-x64.txt' is not on the classpath
```

After correcting the launch classpath, Linux startup could also race while loading SQLite. Koin may launch jobs that access Room before the asynchronous native library job installs `BundledSqliteInterpositionGuard`, allowing two SQLite JNI images to be loaded into the process.

## Changes

- remove the duplicate direct IntelliJ launch configuration and retain the Gradle-backed `Run Desktop (Normal)` configuration
- move `BundledSqliteInterpositionGuard.install(cacheDir)` before Koin startup
- keep the guard ahead of both Room access and JCEF initialization

## Verification

- `:app:desktop:compileKotlin` passed
- launched Animeko through the Gradle-backed desktop configuration
- confirmed the bundled mpv runtime was discovered without a global `LD_LIBRARY_PATH`
- opened an episode and successfully played video through mpv
- confirmed there was no native-runtime or duplicate SQLite JNI crash
