### PR TITLE
fix(desktop): make the bundled sqlite guard structurally precede the driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1930,3 +1930,11 @@ jobs:
         chmod +x "$ANI_APPIMAGE"
         ANIMEKO_DESKTOP_TEST_TASK="sentry-dsn" "$ANI_APPIMAGE"
       if: '${{ (github.repository == ''open-ani/animeko'') && (!(github.event_name == ''pull_request'')) }}'
+    - id: 'step-6'
+      name: 'Check that bundled SQLite can be loaded'
+      timeout-minutes: 5
+      shell: 'bash'
+      run: |-
+        ANI_APPIMAGE="${{ github.workspace }}/ci-helper/verify/Animeko-x86_64.AppImage"
+        chmod +x "$ANI_APPIMAGE"
+        ANIMEKO_DESKTOP_TEST_TASK="sqlite-bundled-load-test" "$ANI_APPIMAGE"

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -664,8 +664,6 @@ fun getVerifyJobBody(
             step = "Check that MediaMP FFmpeg can run",
             enabledOnlyOn = listOf(Runner.GithubWindows11Arm64),
         ),
-        // Windows ARM64 relies on an external SQLite patch (AndroidX does not ship Windows ARM64 natives),
-        // so verify that the patched bundled SQLite loads correctly.
         VerifyTask(
             name = "dandanplay-app-id",
             step = "Check that Dandanplay APP ID is valid",
@@ -678,10 +676,14 @@ fun getVerifyJobBody(
             `if` = expr { github.isAnimekoRepository and !github.isPullRequest },
             disabledOn = listOf(Runner.GithubWindows11Arm64),
         ),
+        // Windows ARM64 relies on an external SQLite patch (AndroidX does not ship Windows ARM64
+        // natives). On Linux this additionally asserts that the process holds exactly one
+        // libsqliteJni image — the invariant behind #3188 and #3213, both of which crashed the
+        // shipped AppImage after the driver had loaded successfully.
         VerifyTask(
             name = "sqlite-bundled-load-test",
             step = "Check that bundled SQLite can be loaded",
-            enabledOnlyOn = listOf(Runner.GithubWindows11Arm64),
+            enabledOnlyOn = listOf(Runner.GithubWindows11Arm64, Runner.GithubUbuntu2404),
         ),
     ).filter { task ->
         // Filter task that should execute on this runner.

--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.data.models.preference.DarkMode
 import me.him188.ani.app.data.models.preference.UISettings
+import me.him188.ani.app.data.persistent.database.BundledSqliteInterpositionGuard
 import me.him188.ani.app.data.repository.SavedWindowState
 import me.him188.ani.app.data.repository.WindowStateRepository
 import me.him188.ani.app.data.repository.user.SettingsRepository
@@ -237,8 +238,9 @@ object AniDesktop {
         )
         startupTimeMonitor.mark(StepName.WindowAndContext)
 
-        // Koin startup launches jobs that may access Room immediately. Install this guard
-        // synchronously before Koin so AndroidX cannot load a second sqlite JNI image first.
+        // Covers constraint 2 in BundledSqliteInterpositionGuard: nothing about JCEF startup routes
+        // through the guard, so this explicit call is the only thing keeping the bundled sqlite
+        // ahead of the system libsqlite3 that CEF pulls in through NSS.
         BundledSqliteInterpositionGuard.install(cacheDir)
 
         SingleInstanceChecker.instance.ensureSingleInstance()

--- a/app/desktop/src/main/kotlin/TestTasks.kt
+++ b/app/desktop/src/main/kotlin/TestTasks.kt
@@ -13,6 +13,8 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.runBlocking
 import me.him188.ani.app.domain.foundation.HttpClientProvider
 import me.him188.ani.app.domain.foundation.ScopedHttpClientUserAgent
+import me.him188.ani.app.data.persistent.database.BundledSqliteInterpositionGuard
+import me.him188.ani.app.data.persistent.database.SqliteGlobalScopeProbe
 import me.him188.ani.app.domain.foundation.get
 import me.him188.ani.app.platform.DesktopContext
 import me.him188.ani.app.platform.currentAniBuildConfig
@@ -27,6 +29,7 @@ import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.platform.Platform
 import me.him188.ani.utils.platform.currentPlatformDesktop
+import me.him188.ani.utils.platform.isLinux
 import org.koin.core.context.GlobalContext
 import org.koin.mp.KoinPlatform
 import org.openani.mediamp.ffmpeg.FFmpegKit
@@ -104,6 +107,46 @@ object TestTasks {
 
     private fun checkBundledSqlite() {
         BundledSQLiteDriver().open(":memory:").use { }
+
+        // On Linux the driver loading successfully is not enough: #3188 and #3213 both crashed
+        // *after* a successful load, once a second sqlite build got into the process. Runs against
+        // the packaged AppImage after full startup, so JCEF/NSS and Koin have had their chance to
+        // break the ordering — which a unit test JVM cannot reproduce.
+        // See BundledSqliteInterpositionGuard for the two ordering constraints.
+        if (currentPlatformDesktop().isLinux()) {
+            val images = BundledSqliteInterpositionGuard.mappedSqliteJniImages()
+            check(images.size == 1) {
+                "expected exactly one libsqliteJni image in the process, got $images"
+            }
+            check(images.single().endsWith(BundledSqliteInterpositionGuard.LIB_FILE_NAME)) {
+                "the mapped libsqliteJni is not the guard's copy: ${images.single()}"
+            }
+            logger.info { "Bundled SQLite check: single image ${images.single()}" }
+
+            checkBundledSqliteOwnsGlobalScope()
+        }
+    }
+
+    /**
+     * Constraint 2 of [BundledSqliteInterpositionGuard]: the bundled sqlite must own the global
+     * scope, so that the system libsqlite3 cannot take the symbols over when CEF loads NSS later.
+     *
+     * This task exits the process long before JCEF initialization, so rather than reordering
+     * startup — every other verify task dispatches from the same point and would inherit a JCEF
+     * dependency — it publishes the system sqlite into the global scope itself, which is the only
+     * part of NSS that matters here.
+     */
+    private fun checkBundledSqliteOwnsGlobalScope() {
+        check(SqliteGlobalScopeProbe.loadSystemSqliteIntoGlobalScope()) {
+            "system libsqlite3 is not installed on this machine, so global scope ownership " +
+                    "cannot be verified; the check would pass vacuously"
+        }
+        val owner = SqliteGlobalScopeProbe.globalSqliteSymbolOwner()
+        check(owner != null && owner.endsWith(BundledSqliteInterpositionGuard.LIB_FILE_NAME)) {
+            "sqlite3_initialize resolves to $owner in the global scope, not the bundled library; " +
+                    "the guard ran too late and the system libsqlite3 has taken the symbols over"
+        }
+        logger.info { "Bundled SQLite check: global scope owned by $owner" }
     }
 
     // https://d.myani.org/v4.0.0-release-checksum-1/ani-4.0.0-release-checksum-1-macos-aarch64.dmg

--- a/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/BundledSqliteInterpositionGuard.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/BundledSqliteInterpositionGuard.kt
@@ -7,11 +7,10 @@
  * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
-package me.him188.ani.app.desktop
+package me.him188.ani.app.data.persistent.database
 
 import com.sun.jna.Library
 import com.sun.jna.NativeLibrary
-import me.him188.ani.app.platform.AniCefApp
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.logging.warn
@@ -22,6 +21,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import kotlin.io.path.absolutePathString
+import kotlin.io.path.readLines
 
 /**
  * Works around a native symbol interposition crash on Linux (#3188).
@@ -30,23 +30,38 @@ import kotlin.io.path.absolutePathString
  * via `System.load` (`RTLD_LOCAL`, lazy binding). When JCEF starts, CEF pulls in NSS, which loads
  * the system `/usr/lib/libsqlite3.so` into the *global* symbol scope. From then on, any not-yet-
  * called `sqlite3_*` PLT entry inside `libsqliteJni.so` resolves to the system library, mixing two
- * sqlite builds with incompatible internal layouts — observed as `SIGSEGV` in
- * `sqlite3_bind_text16` on the home screen's first DB query. Whether a machine crashes is a pure
- * load-order race. macOS (two-level namespace) and Windows (per-module imports) are immune, so
- * this guard is Linux-only.
+ * sqlite builds with incompatible internal layouts. macOS (two-level namespace) and Windows
+ * (per-module imports) are immune, so this guard is Linux-only.
  *
  * Mitigation: load the bundled library ourselves with `RTLD_NOW | RTLD_GLOBAL` before JCEF/NSS or
  * the driver touches sqlite, so its symbols bind to its own implementations first and occupy the
  * global scope; the whole process then uses exactly one sqlite build. The `...bundled.path`/`.name`
  * properties make the driver `System.load()` this same file instead of its own `RTLD_LOCAL` copy.
  *
+ * ## Two independent ordering constraints, both required
+ *
+ * 1. **Before the driver loads.** Violating this puts *two* `libsqliteJni.so` images in the
+ *    process: the driver's own `RTLD_LOCAL` copy under `/tmp` plus this one. The `/tmp` copy's
+ *    `sqlite3_*` PLT entries then bind to our globally-scoped copy on first call, so the JNI entry
+ *    points and the sqlite implementation live in different libraries, each with its own
+ *    `sqlite3GlobalConfig`. The one receiving calls never ran `sqlite3_initialize`, leaving
+ *    `xMalloc` NULL — `SIGSEGV` at `pc=0` in `dbMallocRawFinish`. This is the regression #3195
+ *    introduced by installing the guard from a coroutine that raced Koin's driver construction.
+ *
+ * 2. **Before JCEF/NSS.** Violating this lets the system `libsqlite3` occupy the global scope
+ *    first; `RTLD_NOW` then binds *our* `sqlite3_*` references to it. This is the original #3188 —
+ *    `SIGSEGV` at `pc=0` in `walIndexReadHdr`.
+ *
+ * Constraint 1 holds structurally: [Context.createDatabaseBuilder] installs the guard before
+ * handing out a builder, so no `BundledSQLiteDriver` can be constructed ahead of it. Constraint 2
+ * cannot be enforced that way — nothing about JCEF startup routes through this class — and is why
+ * the desktop `main()` still calls [install] explicitly, ahead of JCEF initialization.
+ *
  * Trade-offs: NSS will use the bundled sqlite instead of the system one (format-compatible, low
  * risk); the guard relies on the semi-internal property and jar resource layout, so an
  * androidx.sqlite upgrade could silently break it — failure mode is a logged warning plus the
- * original racy behavior. The proper fix is upstream compiling `sqlite3_*` with hidden visibility.
- *
- * Must be called before database initialization and before [AniCefApp.initialize]. It runs as
- * part of synchronous desktop startup, before Koin can launch jobs that access Room.
+ * original racy behavior. `BundledSqliteInterpositionGuardTest` is the canary for that upgrade.
+ * The proper fix is upstream compiling `sqlite3_*` with hidden visibility.
  */
 object BundledSqliteInterpositionGuard {
     private val logger = logger<BundledSqliteInterpositionGuard>()
@@ -55,6 +70,11 @@ object BundledSqliteInterpositionGuard {
     private const val RTLD_NOW = 0x2
     private const val RTLD_GLOBAL = 0x100
 
+    /** Fixed name of the extracted copy, so [mappedSqliteJniImages] callers can recognise it. */
+    const val LIB_FILE_NAME = "ani-bundled-sqliteJni.so"
+
+    private val lock = Any()
+
     // Strong reference to the preloaded library. JNA 5.x registers a Cleaner that dlclose()es the
     // native handle when the NativeLibrary instance is GC'd, and JNA's own cache only keeps a
     // WeakReference — dropping this reference would let a GC undo the preload and reintroduce
@@ -62,18 +82,46 @@ object BundledSqliteInterpositionGuard {
     private var preloadedLibrary: NativeLibrary? = null
 
     /**
+     * Preloads the bundled `libsqliteJni.so` into the global symbol scope. No-op off Linux, and
+     * no-op on every call after the first: [install] is reached from both desktop startup and
+     * [Context.createDatabaseBuilder], and re-running it would rewrite the properties the driver
+     * may already have read.
+     *
      * @param cacheDir app-owned directory used to hold the extracted library. A stable location
      * with a fixed name (rewritten only when the bundled bytes change) avoids leaving stale
      * `.so` files in the system temp directory after abnormal exits.
      */
     fun install(cacheDir: Path) {
         if (!currentPlatformDesktop().isLinux()) return
-        try {
-            install0(cacheDir)
-        } catch (e: Throwable) {
-            // Never break startup because of this workaround; the crash it prevents is a race anyway.
-            logger.warn(e) { "Failed to preload bundled libsqliteJni with RTLD_GLOBAL" }
+        synchronized(lock) {
+            if (preloadedLibrary != null) return
+            try {
+                install0(cacheDir)
+            } catch (e: Throwable) {
+                // Never break startup because of this workaround; the crash it prevents is a race anyway.
+                logger.warn(e) { "Failed to preload bundled libsqliteJni with RTLD_GLOBAL" }
+            }
         }
+    }
+
+    /**
+     * Backing files of every `sqliteJni` mapping this process currently holds, as seen by the
+     * kernel. Exactly one entry, ending in [LIB_FILE_NAME], is the invariant both ordering
+     * constraints exist to preserve; anything else is one of the two crashes described above.
+     *
+     * Linux-only — returns an empty set elsewhere, where the problem does not exist.
+     */
+    fun mappedSqliteJniImages(): Set<String> {
+        if (!currentPlatformDesktop().isLinux()) return emptySet()
+        // A /proc/self/maps line ends with the mapped path, e.g.
+        // `7f..-7f.. r-xp 00000000 00:1b 123  /home/u/.cache/ani/ani-bundled-sqliteJni.so`.
+        return Path.of("/proc/self/maps").readLines()
+            .mapNotNull { line ->
+                line.substringAfter(" /", missingDelimiterValue = "")
+                    .let { if (it.isEmpty()) null else "/$it" }
+            }
+            .filter { it.substringAfterLast('/').contains("sqliteJni", ignoreCase = true) }
+            .toSet()
     }
 
     private fun install0(cacheDir: Path) {
@@ -87,7 +135,7 @@ object BundledSqliteInterpositionGuard {
             .getResourceAsStream(resource)?.use { it.readBytes() }
             ?: error("Resource $resource not found on classpath")
 
-        val libFile = cacheDir.resolve("ani-bundled-sqliteJni.so")
+        val libFile = cacheDir.resolve(LIB_FILE_NAME)
         if (!Files.exists(libFile) || !Files.readAllBytes(libFile).contentEquals(bytes)) {
             // Write to a sibling temp file and move atomically: the target may still be mapped
             // by a previous process (or this one), and in-place writes to a mapped .so can SIGBUS.

--- a/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/DatabaseStorage.desktop.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/DatabaseStorage.desktop.kt
@@ -16,6 +16,12 @@ import me.him188.ani.app.platform.DesktopContext
 
 actual fun Context.createDatabaseBuilder(): RoomDatabase.Builder<AniDatabase> {
     this as DesktopContext
+    // Do not remove: this is what makes constraint 1 in BundledSqliteInterpositionGuard structural
+    // rather than a convention about where main() calls install(). Because it sits here, no
+    // BundledSQLiteDriver can be constructed before the guard runs, however startup is later
+    // reordered — #3195 regressed precisely by moving that call into a coroutine that raced Koin.
+    // Idempotent, so the earlier call from main() (which additionally covers constraint 2) wins.
+    BundledSqliteInterpositionGuard.install(cacheDir.toPath())
     return Room.databaseBuilder<AniDatabase>(
         name = dataDir.resolve("ani_room_database_main.db").absolutePath,
     )

--- a/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/SqliteGlobalScopeProbe.kt
+++ b/app/shared/app-data/src/desktopMain/kotlin/data/persistent/database/SqliteGlobalScopeProbe.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.persistent.database
+
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+import me.him188.ani.utils.platform.currentPlatformDesktop
+import me.him188.ani.utils.platform.isLinux
+
+/**
+ * Verification helper for constraint 2 of [BundledSqliteInterpositionGuard]: that the bundled
+ * sqlite owns the `sqlite3_*` symbols in the process-wide global scope, and that a library loaded
+ * into that scope afterwards cannot take them over.
+ *
+ * [BundledSqliteInterpositionGuard.mappedSqliteJniImages] cannot answer this — `/proc/self/maps`
+ * shows which files are mapped, not which of them a symbol resolves to, and the system
+ * `libsqlite3` is mapped by NSS in the healthy case too.
+ *
+ * Used by the `sqlite-bundled-load-test` CI task. Kept out of the guard itself because
+ * [loadSystemSqliteIntoGlobalScope] deliberately does the thing the guard defends against.
+ */
+object SqliteGlobalScopeProbe {
+    // dlopen(2) flags, Linux values — macOS uses different ones (RTLD_GLOBAL is 0x8 there), so
+    // every entry point below is gated on Linux rather than relying on callers to do it.
+    private const val RTLD_NOW = 0x2
+    private const val RTLD_GLOBAL = 0x100
+
+    /** `dlsym(3)` pseudo-handle for a global-scope lookup; NULL on glibc. */
+    private val RTLD_DEFAULT: Pointer? = null
+
+    @Suppress("FunctionName", "SpellCheckingInspection")
+    private interface Dl : Library {
+        fun dlsym(handle: Pointer?, symbol: String): Pointer?
+        fun dladdr(addr: Pointer, info: DlInfo): Int
+    }
+
+    @Suppress("unused", "PropertyName", "SpellCheckingInspection")
+    @Structure.FieldOrder("dli_fname", "dli_fbase", "dli_sname", "dli_saddr")
+    class DlInfo : Structure() {
+        @JvmField
+        var dli_fname: String? = null
+
+        @JvmField
+        var dli_fbase: Pointer? = null
+
+        @JvmField
+        var dli_sname: String? = null
+
+        @JvmField
+        var dli_saddr: Pointer? = null
+    }
+
+    // glibc 2.34+ folded libdl into libc, but libdl.so.2 remains as a forwarding stub. Try it
+    // first so older glibc keeps working, then fall back.
+    private val dl: Dl by lazy {
+        runCatching { Native.load("dl", Dl::class.java) }
+            .getOrElse { Native.load("c", Dl::class.java) }
+    }
+
+    /**
+     * Path of the library that currently owns `sqlite3_initialize` in the global scope, or `null`
+     * if the symbol is not globally visible (which is itself fine — it means nothing has published
+     * sqlite globally yet).
+     */
+    fun globalSqliteSymbolOwner(): String? {
+        if (!currentPlatformDesktop().isLinux()) return null
+        val symbol = dl.dlsym(RTLD_DEFAULT, "sqlite3_initialize") ?: return null
+        val info = DlInfo()
+        if (dl.dladdr(symbol, info) == 0) return null
+        info.read()
+        return info.dli_fname
+    }
+
+    /**
+     * Does to this process what CEF does via NSS: publishes the *system* sqlite into the global
+     * scope. If the guard ran first, its symbols were already bound by `RTLD_NOW` and stay in
+     * front; if it ran late, this is what takes them over.
+     *
+     * @return false if the system library is not installed, in which case the check it supports
+     * proves nothing and callers must say so rather than pass silently.
+     */
+    fun loadSystemSqliteIntoGlobalScope(): Boolean {
+        if (!currentPlatformDesktop().isLinux()) return false
+        val flags = mapOf(Library.OPTION_OPEN_FLAGS to (RTLD_NOW or RTLD_GLOBAL))
+        // Distributions ship the runtime SONAME; the bare `libsqlite3.so` symlink comes with the
+        // -dev package and is often absent.
+        for (name in listOf("libsqlite3.so.0", "sqlite3")) {
+            runCatching { NativeLibrary.getInstance(name, flags) }.onSuccess { return true }
+        }
+        return false
+    }
+}

--- a/app/shared/app-data/src/desktopTest/kotlin/data/persistent/database/BundledSqliteInterpositionGuardTest.kt
+++ b/app/shared/app-data/src/desktopTest/kotlin/data/persistent/database/BundledSqliteInterpositionGuardTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.persistent.database
+
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #3188 / #3195 / #3213.
+ *
+ * The crash these tests protect against is a load-order race that cannot be triggered on demand,
+ * so they assert the *invariant* instead of the symptom: after the guard runs, the process must
+ * hold exactly one `libsqliteJni.so` image and the bundled sqlite must own the `sqlite3_*` symbols
+ * in the global scope.
+ *
+ * This also acts as the canary for androidx.sqlite upgrades — the redirect relies on the
+ * semi-internal `androidx.sqlite.driver.bundled.path`/`.name` properties, and an upgrade that
+ * stops honouring them shows up here as a second image.
+ */
+@EnabledOnOs(
+    value = [OS.LINUX],
+    disabledReason = "ELF global symbol interposition; macOS and Windows are immune by design.",
+)
+class BundledSqliteInterpositionGuardTest {
+    @Test
+    fun `driver reuses the preloaded image instead of extracting its own`() {
+        BundledSqliteInterpositionGuard.install(Files.createTempDirectory("ani-sqlite-guard-test"))
+
+        // Forces BundledSQLiteDriver to load its JNI library, which is what would extract a second
+        // copy into /tmp if the redirect properties were not in place before this point.
+        BundledSQLiteDriver().open(":memory:").use { }
+
+        val mappings = BundledSqliteInterpositionGuard.mappedSqliteJniImages()
+        assertEquals(
+            1, mappings.size,
+            "expected exactly one libsqliteJni image in the process, got $mappings",
+        )
+        assertTrue(
+            mappings.single().endsWith(BundledSqliteInterpositionGuard.LIB_FILE_NAME),
+            "the mapped image is not the guard's copy: ${mappings.single()}",
+        )
+    }
+
+    @Test
+    fun `install is idempotent`() {
+        BundledSqliteInterpositionGuard.install(Files.createTempDirectory("ani-sqlite-guard-test"))
+        val path = System.getProperty("androidx.sqlite.driver.bundled.path")
+        val name = System.getProperty("androidx.sqlite.driver.bundled.name")
+
+        // A second call must not repoint the driver at a different file: by the time anything calls
+        // install() twice, the driver may already have resolved these properties.
+        BundledSqliteInterpositionGuard.install(Files.createTempDirectory("ani-sqlite-guard-test-2"))
+
+        assertEquals(path, System.getProperty("androidx.sqlite.driver.bundled.path"))
+        assertEquals(name, System.getProperty("androidx.sqlite.driver.bundled.name"))
+        assertEquals(1, BundledSqliteInterpositionGuard.mappedSqliteJniImages().size)
+    }
+
+    /**
+     * Covers the `dlsym`/`dladdr` plumbing that the `sqlite-bundled-load-test` CI task relies on,
+     * and the property itself: publishing the system sqlite into the global scope afterwards — what
+     * CEF does through NSS — must not displace symbols the guard already bound with `RTLD_NOW`.
+     */
+    @Test
+    fun `bundled sqlite keeps global scope ownership after the system library is published`() {
+        BundledSqliteInterpositionGuard.install(Files.createTempDirectory("ani-sqlite-guard-test"))
+
+        val before = SqliteGlobalScopeProbe.globalSqliteSymbolOwner()
+        assertNotNull(before, "sqlite3_initialize is not globally visible; the guard did not load")
+        assertTrue(
+            before.endsWith(BundledSqliteInterpositionGuard.LIB_FILE_NAME),
+            "the global sqlite3_initialize belongs to $before, not the bundled library",
+        )
+
+        assumeTrue(
+            SqliteGlobalScopeProbe.loadSystemSqliteIntoGlobalScope(),
+            "no system libsqlite3 on this machine; the takeover half would prove nothing",
+        )
+        assertEquals(
+            before, SqliteGlobalScopeProbe.globalSqliteSymbolOwner(),
+            "the system libsqlite3 took over sqlite3_initialize after being published globally",
+        )
+    }
+}


### PR DESCRIPTION
## 问题

guard 的顺序要求现在只体现为 `main()` 里的调用位置，没有任何机制保证它不被破坏。#3195 就破坏过一次，换来的崩溃比原本要防的更严重：driver 自行解压出 `/tmp` 副本，进程内存在两份 libsqliteJni，真正接收调用的那份从未执行过 `sqlite3_initialize`。

```
#  SIGSEGV (0xb) at pc=0x0000000000000000
#  C  [ani-bundled-sqliteJni.so+0x6c0af]  dbMallocRawFinish+0xf
```

实际上有两条互相独立的约束：

| 约束 | 违反后 | 崩溃点 |
|---|---|---|
| guard 先于 driver 加载 | 进程内两份镜像 | `dbMallocRawFinish`（#3195） |
| guard 先于 JCEF/NSS | 系统 libsqlite3 占住全局作用域 | `walIndexReadHdr`（#3188） |

## 改动

- 约束 1 改由代码结构保证。`Context.createDatabaseBuilder()` 在返回 builder 前调用 `install`，`BundledSQLiteDriver` 不可能抢在 guard 前面构造出来。`install` 随之改为幂等。
- 约束 2 只能靠显式调用，JCEF 启动不经过这个类，`main()` 里那次保持原位。
- guard 下沉到 `app-data/desktopMain`，供 `createDatabaseBuilder` 引用。

## CI

`sqlite-bundled-load-test` 增加在 Ubuntu 上运行。它检查的是打包 AppImage 完整启动之后的状态，也就是三份 hs_err 的来源环境。两次崩溃都发生在 driver 成功加载之后，原有的「能否加载」检查抓不到。新增两条断言：

- 进程内只有一份 libsqliteJni 映射，且是 guard 那份。
- `sqlite3_initialize` 在全局作用域中归 guard 那份所有。映射看不出符号归属，健康状态下系统 libsqlite3 同样在映射里，所以改用 `dlsym(RTLD_DEFAULT)` 配合 `dladdr`。

这个 task 在 JCEF 初始化之前就退出了，而所有 verify task 共用一个派发点，把派发点后移会让它们全部依赖 JCEF。于是改为由 task 自己把系统 sqlite 载入全局作用域，NSS 在这里起作用的也只有这一步。系统库缺失时直接失败，不静默跳过。

## 验证

- 单元测试三项通过，并确认没有空转：`dladdr` 返回真实路径，系统 libsqlite3 载入成功。
- 断言确实能区分好坏状态：清掉重定向属性后映射变成两份，断言转红；系统库先加载时符号归属变成 `/usr/lib/libsqlite3.so.0`，断言转红。
- `build.yml` 由 `src.main.kts` 重新生成，diff 只有 Ubuntu verify job 的 8 行。
