### PR TITLE
fix(desktop): handle touch on Windows caption buttons

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -377,5 +377,10 @@ fun JavaExec.configureDevProperties() {
     systemProperty("org.slf4j.simpleLogger.defaultLogLevel", "TRACE")
     systemProperty("kotlinx.coroutines.debug", "on")
     systemProperty("ani.debug", "true")
+    // Windows 原生触摸事件日志: ./gradlew :app:desktop:run -Pani.windows.nativeTouch.debug=true
+    systemProperty(
+        "ani.windows.nativeTouch.debug",
+        providers.gradleProperty("ani.windows.nativeTouch.debug").getOrElse("false"),
+    )
     workingDir(file("test-sandbox"))
 }

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsPointerInput.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsPointerInput.kt
@@ -29,6 +29,13 @@ internal const val WM_POINTERDOWN: Int = 0x0246
 internal const val WM_POINTERUP: Int = 0x0247
 internal const val WM_POINTERCAPTURECHANGED: Int = 0x024C
 
+// Touches that hit-test into the non-client area (our Compose-drawn caption buttons report
+// HTMINBUTTON/HTMAXBUTTON/HTCLOSE) are delivered as WM_NCPOINTER* instead of WM_POINTER*.
+// They carry the same pointer id and screen coordinates, so they are injected identically.
+internal const val WM_NCPOINTERUPDATE: Int = 0x0241
+internal const val WM_NCPOINTERDOWN: Int = 0x0242
+internal const val WM_NCPOINTERUP: Int = 0x0243
+
 internal const val POINTER_FLAG_INCONTACT: Int = 0x00000004
 internal const val POINTER_FLAG_CANCELED: Int = 0x00008000
 
@@ -336,6 +343,13 @@ internal class POINTER_INFO : Structure() {
     )
 }
 
+/**
+ * Bridges native Win32 pointer messages into [WindowsTouchEvent]s owned by a single sequence state
+ * machine.
+ *
+ * Instances are confined to the wndproc thread of their owning hook; a single [POINTER_INFO] is
+ * reused across messages to keep the hot path allocation-free.
+ */
 internal class WindowsPointerInputHandler(
     private val readPointerInfo: (pointerId: Int, pointerInfo: POINTER_INFO) -> Boolean,
     private val dispatch: (WindowsTouchEvent) -> Unit,
@@ -346,13 +360,19 @@ internal class WindowsPointerInputHandler(
     private var closed = false
     private var disabled = false
 
+    // Reused across messages; safe because the handler is confined to one wndproc thread and the
+    // data is copied into WindowsPointerData before dispatch.
+    private val reusedPointerInfo = POINTER_INFO()
+
     fun handleMessage(uMsg: Int, wParam: WPARAM, callbackWindow: HWND? = null): Boolean {
         if (closed || disabled) return false
         if (uMsg == WM_POINTERCAPTURECHANGED) {
             WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, null)
         }
 
-        val pointerId = if (uMsg == WM_POINTERDOWN || uMsg == WM_POINTERUPDATE || uMsg == WM_POINTERUP) {
+        val pointerId = if (uMsg == WM_POINTERDOWN || uMsg == WM_POINTERUPDATE || uMsg == WM_POINTERUP ||
+            uMsg == WM_NCPOINTERDOWN || uMsg == WM_NCPOINTERUPDATE || uMsg == WM_NCPOINTERUP
+        ) {
             pointerIdFromWParam(wParam)
         } else {
             null
@@ -366,6 +386,9 @@ internal class WindowsPointerInputHandler(
                 WM_POINTERDOWN,
                 WM_POINTERUPDATE,
                 WM_POINTERUP,
+                WM_NCPOINTERDOWN,
+                WM_NCPOINTERUPDATE,
+                WM_NCPOINTERUP,
                     -> handlePointerMessage(uMsg, wParam, callbackWindow)
 
                 else -> false
@@ -384,7 +407,7 @@ internal class WindowsPointerInputHandler(
 
     private fun handlePointerMessage(uMsg: Int, wParam: WPARAM, callbackWindow: HWND?): Boolean {
         val pointerId = pointerIdFromWParam(wParam)
-        val pointerInfo = POINTER_INFO()
+        val pointerInfo = reusedPointerInfo
         if (!readPointerInfo(pointerId.toInt(), pointerInfo)) {
             WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, null)
             return apply(sequence.handleReadFailure(pointerId))
@@ -392,9 +415,9 @@ internal class WindowsPointerInputHandler(
         WindowsNativeTouchDebug.logPointerMessage(debugHookName, uMsg, callbackWindow, wParam, pointerInfo)
 
         val message = when (uMsg) {
-            WM_POINTERDOWN -> WindowsPointerMessage.DOWN
-            WM_POINTERUPDATE -> WindowsPointerMessage.UPDATE
-            WM_POINTERUP -> WindowsPointerMessage.UP
+            WM_POINTERDOWN, WM_NCPOINTERDOWN -> WindowsPointerMessage.DOWN
+            WM_POINTERUPDATE, WM_NCPOINTERUPDATE -> WindowsPointerMessage.UPDATE
+            WM_POINTERUP, WM_NCPOINTERUP -> WindowsPointerMessage.UP
             else -> error("Unsupported pointer message: $uMsg")
         }
         return apply(sequence.handle(message, pointerInfo.toPointerData(pointerId)))
@@ -431,6 +454,9 @@ private fun Int.debugName(): String = when (this) {
     WM_POINTERUPDATE -> "WM_POINTERUPDATE"
     WM_POINTERDOWN -> "WM_POINTERDOWN"
     WM_POINTERUP -> "WM_POINTERUP"
+    WM_NCPOINTERUPDATE -> "WM_NCPOINTERUPDATE"
+    WM_NCPOINTERDOWN -> "WM_NCPOINTERDOWN"
+    WM_NCPOINTERUP -> "WM_NCPOINTERUP"
     WM_POINTERCAPTURECHANGED -> "WM_POINTERCAPTURECHANGED"
     else -> "0x${toString(16)}"
 }

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsPointerInputTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsPointerInputTest.kt
@@ -217,6 +217,39 @@ class WindowsPointerInputTest {
         assertFalse(handler.handleMessage(WM_POINTERUP, WPARAM(1)))
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // 非客户区消息 (Compose 自绘的标题栏按钮)
+    ///////////////////////////////////////////////////////////////////////////
+
+    @Test
+    fun `non-client pointer lifecycle`() {
+        val dispatched = mutableListOf<WindowsTouchEvent>()
+        val handler = touchHandler(dispatch = { dispatched += it })
+
+        assertTrue(handler.handleMessage(WM_NCPOINTERDOWN, WPARAM(1)))
+        assertTrue(handler.handleMessage(WM_NCPOINTERUPDATE, WPARAM(1)))
+        assertTrue(handler.handleMessage(WM_NCPOINTERUP, WPARAM(1)))
+
+        assertEquals(
+            listOf(WindowsTouchEventType.PRESS, WindowsTouchEventType.MOVE, WindowsTouchEventType.RELEASE),
+            dispatched.map { it.type },
+        )
+    }
+
+    private fun touchHandler(
+        dispatch: (WindowsTouchEvent) -> Unit = {},
+        cancel: () -> Unit = {},
+    ) = WindowsPointerInputHandler(
+        readPointerInfo = { _, info ->
+            info.pointerType = PT_TOUCH
+            info.pointerFlags = POINTER_FLAG_INCONTACT
+            info.ptPixelLocation = POINT(30, 30)
+            true
+        },
+        dispatch = dispatch,
+        cancel = cancel,
+    )
+
     private fun pointer(
         id: Long,
         x: Int,


### PR DESCRIPTION
## 问题

Windows 会根据 `WM_NCHITTEST` 的结果区分客户区与非客户区指针消息。Compose 自绘的最小化、最大化和关闭按钮分别返回 `HTMINBUTTON`、`HTMAXBUTTON` 和 `HTCLOSE`，因此触摸这些按钮时，系统发送的是 `WM_NCPOINTER*`，而不是普通的 `WM_POINTER*`。

现有触摸桥只处理 `WM_POINTERDOWN`、`WM_POINTERUPDATE` 和 `WM_POINTERUP`。非客户区触摸会落入 `DefWindowProc`，但系统窗口过程无法操作 Compose 绘制的按钮，因此这些按钮无法响应触摸。

## 改动

- 接入 `WM_NCPOINTERDOWN`、`WM_NCPOINTERUPDATE` 和 `WM_NCPOINTERUP`。
- 将非客户区消息交给现有触摸状态机，并向 `ComposeScene` 注入对应的按下、移动和释放事件。
- 每个窗口过程保留一个 `POINTER_INFO` 实例，避免为每条指针消息分配新对象。
- 增加可选的原生触摸日志开关：

  ```text
  -Pani.windows.nativeTouch.debug=true
  ```

## 验证

- 增加非客户区指针生命周期测试，验证 `WM_NCPOINTERDOWN → WM_NCPOINTERUPDATE → WM_NCPOINTERUP` 会产生 `PRESS → MOVE → RELEASE`。
- `WindowsPointerInputTest` 共 14 项测试通过。
- 在 Windows ARM64 二合一设备上验证：
  - 最小化、最大化和关闭按钮可以响应触摸；
  - 窗口拖动和缩放仍能正常工作。

自动测试只覆盖消息映射和状态机逻辑。Windows 消息投递及真实触屏输入仍需在设备上验证。
