### PR TITLE
feat(watch-together): move "turn off" into a header overflow menu

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -1384,10 +1384,14 @@
     <string name="watch_together_leave">离开</string>
     <string name="watch_together_disband">解散</string>
     <string name="watch_together_disable">关闭</string>
+    <string name="watch_together_more_options">更多选项</string>
+    <string name="watch_together_disable_feature">关闭一起看功能</string>
+    <string name="watch_together_disable_feature_desc">将退出房间并隐藏悬浮球</string>
     <string name="watch_together_collapse">收起</string>
     <string name="watch_together_cancel">取消</string>
     <string name="watch_together_minimize">最小化</string>
     <string name="watch_together_confirm_disband">确定要为所有成员解散此房间吗？</string>
+    <string name="watch_together_confirm_disable">确定要关闭「一起看」吗？关闭后可在设置中重新开启。</string>
     <string name="watch_together_room_closed">房主已解散房间</string>
     <string name="watch_together_session_replaced">此房间已在另一台设备上打开。</string>
     <string name="watch_together_rejoined">原房间已过期，已为你重新创建。</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -1359,10 +1359,14 @@
     <string name="watch_together_leave">離開</string>
     <string name="watch_together_disband">解散</string>
     <string name="watch_together_disable">關閉</string>
+    <string name="watch_together_more_options">更多選項</string>
+    <string name="watch_together_disable_feature">關閉一起看功能</string>
+    <string name="watch_together_disable_feature_desc">將退出房間並隱藏懸浮球</string>
     <string name="watch_together_collapse">收起</string>
     <string name="watch_together_cancel">取消</string>
     <string name="watch_together_minimize">最小化</string>
     <string name="watch_together_confirm_disband">確定要為所有成員解散此房間嗎？</string>
+    <string name="watch_together_confirm_disable">確定要關閉「一起看」嗎？關閉後可在設定中重新開啟。</string>
     <string name="watch_together_room_closed">房主已解散房間</string>
     <string name="watch_together_session_replaced">此房間已在另一部裝置上開啟。</string>
     <string name="watch_together_rejoined">原房間已過期，已為你重新建立。</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -1349,10 +1349,14 @@
     <string name="watch_together_leave">離開</string>
     <string name="watch_together_disband">解散</string>
     <string name="watch_together_disable">關閉</string>
+    <string name="watch_together_more_options">更多選項</string>
+    <string name="watch_together_disable_feature">關閉一起看功能</string>
+    <string name="watch_together_disable_feature_desc">將退出房間並隱藏懸浮球</string>
     <string name="watch_together_collapse">收合</string>
     <string name="watch_together_cancel">取消</string>
     <string name="watch_together_minimize">最小化</string>
     <string name="watch_together_confirm_disband">確定要為所有成員解散此房間嗎？</string>
+    <string name="watch_together_confirm_disable">確定要關閉「一起看」嗎？關閉後可在設定中重新開啟。</string>
     <string name="watch_together_room_closed">房主已解散房間</string>
     <string name="watch_together_session_replaced">此房間已在另一台裝置上開啟。</string>
     <string name="watch_together_rejoined">原房間已過期，已為你重新建立。</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -1344,10 +1344,14 @@
     <string name="watch_together_leave">Leave</string>
     <string name="watch_together_disband">Disband</string>
     <string name="watch_together_disable">Turn off</string>
+    <string name="watch_together_more_options">More options</string>
+    <string name="watch_together_disable_feature">Turn off Watch Together</string>
+    <string name="watch_together_disable_feature_desc">Leaves the room and hides the bubble</string>
     <string name="watch_together_collapse">Collapse</string>
     <string name="watch_together_cancel">Cancel</string>
     <string name="watch_together_minimize">Minimize</string>
     <string name="watch_together_confirm_disband">Disband this room for everyone?</string>
+    <string name="watch_together_confirm_disable">Turn off Watch Together? You can turn it back on in Settings.</string>
     <string name="watch_together_room_closed">The host closed the room.</string>
     <string name="watch_together_session_replaced">This room was opened on another device.</string>
     <string name="watch_together_rejoined">The previous room expired, so it was created again.</string>

--- a/app/shared/ui-watchtogether/src/commonMain/kotlin/ui/watchtogether/WatchTogetherDialog.kt
+++ b/app/shared/ui-watchtogether/src/commonMain/kotlin/ui/watchtogether/WatchTogetherDialog.kt
@@ -32,8 +32,10 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Downloading
 import androidx.compose.material.icons.rounded.Groups
 import androidx.compose.material.icons.rounded.HourglassEmpty
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.PowerSettingsNew
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.rounded.Tv
 import androidx.compose.material.icons.rounded.Visibility
@@ -41,6 +43,8 @@ import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -79,11 +83,14 @@ import me.him188.ani.app.ui.lang.watch_together_cancel
 import me.him188.ani.app.ui.lang.watch_together_chip_following
 import me.him188.ani.app.ui.lang.watch_together_chip_free
 import me.him188.ani.app.ui.lang.watch_together_collapse
+import me.him188.ani.app.ui.lang.watch_together_confirm_disable
 import me.him188.ani.app.ui.lang.watch_together_confirm_disband
 import me.him188.ani.app.ui.lang.watch_together_connection_connected
 import me.him188.ani.app.ui.lang.watch_together_connection_degraded
 import me.him188.ani.app.ui.lang.watch_together_connection_reconnecting
 import me.him188.ani.app.ui.lang.watch_together_disable
+import me.him188.ani.app.ui.lang.watch_together_disable_feature
+import me.him188.ani.app.ui.lang.watch_together_disable_feature_desc
 import me.him188.ani.app.ui.lang.watch_together_disband
 import me.him188.ani.app.ui.lang.watch_together_disconnected
 import me.him188.ani.app.ui.lang.watch_together_episode_label
@@ -115,6 +122,7 @@ import me.him188.ani.app.ui.lang.watch_together_member_watching
 import me.him188.ani.app.ui.lang.watch_together_members_count
 import me.him188.ani.app.ui.lang.watch_together_members_label
 import me.him188.ani.app.ui.lang.watch_together_minimize
+import me.him188.ani.app.ui.lang.watch_together_more_options
 import me.him188.ani.app.ui.lang.watch_together_password
 import me.him188.ani.app.ui.lang.watch_together_room_name
 import me.him188.ani.app.ui.lang.watch_together_show_password
@@ -133,6 +141,8 @@ internal const val WATCH_TOGETHER_ROOM_NAME_TEST_TAG = "watch_together_room_name
 internal const val WATCH_TOGETHER_PASSWORD_TEST_TAG = "watch_together_password"
 internal const val WATCH_TOGETHER_JOIN_TEST_TAG = "watch_together_join"
 internal const val WATCH_TOGETHER_FOLLOW_TEST_TAG = "watch_together_follow"
+internal const val WATCH_TOGETHER_OPTIONS_TEST_TAG = "watch_together_options"
+internal const val WATCH_TOGETHER_DISABLE_TEST_TAG = "watch_together_disable"
 
 @Composable
 internal fun WatchTogetherDialog(
@@ -159,6 +169,7 @@ internal fun WatchTogetherDialogContent(
     var password by rememberSaveable { mutableStateOf("") }
     var passwordVisible by rememberSaveable { mutableStateOf(false) }
     var confirmDisband by remember { mutableStateOf(false) }
+    var confirmDisable by remember { mutableStateOf(false) }
 
     Box(modifier) {
         Surface(
@@ -186,7 +197,7 @@ internal fun WatchTogetherDialogContent(
                             if (state.isSelfHost) confirmDisband = true
                             else onIntent(WatchTogetherIntent.LeaveRoom)
                         },
-                        onDisable = { onIntent(WatchTogetherIntent.DisableFeature) },
+                        onDisable = { confirmDisable = true },
                         onCollapse = onDismissRequest,
                     )
 
@@ -202,7 +213,7 @@ internal fun WatchTogetherDialogContent(
                         onJoin = {
                             onIntent(WatchTogetherIntent.JoinRoom(roomName, password))
                         },
-                        onDisable = { onIntent(WatchTogetherIntent.DisableFeature) },
+                        onDisable = { confirmDisable = true },
                         onDismiss = onDismissRequest,
                     )
                 }
@@ -233,6 +244,79 @@ internal fun WatchTogetherDialogContent(
                 }
             },
         )
+    }
+
+    if (confirmDisable) {
+        AlertDialog(
+            onDismissRequest = { confirmDisable = false },
+            title = { Text(stringResource(Lang.watch_together_disable_feature)) },
+            text = { Text(stringResource(Lang.watch_together_confirm_disable)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        confirmDisable = false
+                        onIntent(WatchTogetherIntent.DisableFeature)
+                    },
+                ) {
+                    Text(
+                        stringResource(Lang.watch_together_disable),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDisable = false }) {
+                    Text(stringResource(Lang.watch_together_cancel))
+                }
+            },
+        )
+    }
+}
+
+/**
+ * The "⋮" overflow menu that hosts the feature-level "turn off Watch Together" action. Kept out of
+ * the bottom action row so it is never mistaken for the benign "collapse"/"minimize" dismiss, and
+ * given the friction (menu + consequence hint) a destructive feature toggle deserves.
+ */
+@Composable
+private fun WatchTogetherOptionsButton(onDisable: () -> Unit, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier) {
+        IconButton(
+            onClick = { expanded = true },
+            modifier = Modifier.testTag(WATCH_TOGETHER_OPTIONS_TEST_TAG),
+        ) {
+            Icon(Icons.Rounded.MoreVert, contentDescription = stringResource(Lang.watch_together_more_options))
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                leadingIcon = {
+                    Icon(
+                        Icons.Rounded.PowerSettingsNew,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                },
+                text = {
+                    Column {
+                        Text(
+                            stringResource(Lang.watch_together_disable_feature),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        Text(
+                            stringResource(Lang.watch_together_disable_feature_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                onClick = {
+                    expanded = false
+                    onDisable()
+                },
+                modifier = Modifier.testTag(WATCH_TOGETHER_DISABLE_TEST_TAG),
+            )
+        }
     }
 }
 
@@ -281,25 +365,31 @@ private fun JoinRoomContent(
     onDisable: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(
-            Icons.Rounded.Groups,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(28.dp),
-        )
-        Text(
-            text = stringResource(Lang.watch_together_title),
-            style = MaterialTheme.typography.headlineSmall,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 12.dp),
-        )
-        Text(
-            text = stringResource(Lang.watch_together_join_subtitle),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 4.dp, bottom = 20.dp),
+    Box(Modifier.fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Rounded.Groups,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.size(28.dp),
+            )
+            Text(
+                text = stringResource(Lang.watch_together_title),
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+            Text(
+                text = stringResource(Lang.watch_together_join_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 4.dp, bottom = 20.dp),
+            )
+        }
+        WatchTogetherOptionsButton(
+            onDisable = onDisable,
+            modifier = Modifier.align(Alignment.TopEnd),
         )
     }
     OutlinedTextField(
@@ -376,12 +466,8 @@ private fun JoinRoomContent(
     }
     Row(
         modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
     ) {
-        TextButton(onClick = onDisable) {
-            Text(stringResource(Lang.watch_together_disable), color = MaterialTheme.colorScheme.error)
-        }
         TextButton(onClick = onDismiss) {
             Text(stringResource(Lang.watch_together_minimize))
         }
@@ -425,6 +511,7 @@ private fun RoomContent(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        WatchTogetherOptionsButton(onDisable = onDisable, modifier = Modifier.padding(start = 2.dp))
     }
 
     if (room.playback != null) {
@@ -484,9 +571,6 @@ private fun RoomContent(
                 ),
                 color = MaterialTheme.colorScheme.error,
             )
-        }
-        TextButton(onClick = onDisable) {
-            Text(stringResource(Lang.watch_together_disable), color = MaterialTheme.colorScheme.error)
         }
         TextButton(onClick = onCollapse) {
             Text(stringResource(Lang.watch_together_collapse))


### PR DESCRIPTION
## What & why

一起看弹窗底部原本把三个按钮平铺在一行——**退出/解散房间**、**关闭一起看**、**收起**。其中「关闭一起看」是功能级破坏操作（会退出房间并隐藏悬浮球），却紧贴无害的「收起」，且与「退出房间」两个红色按钮相邻语义混淆，极易误触。

本 PR 把「关闭一起看」从底部动作区移到标题栏的 **⋮ 溢出菜单**，回归它「功能级开关」的身份。

## Changes

- **`WatchTogetherDialog.kt`**
  - 新增 `WatchTogetherOptionsButton`：`⋮` `IconButton` + `DropdownMenu`，菜单项为 error 色的「关闭一起看功能」+ 后果说明「将退出房间并隐藏悬浮球」。
  - **房间态**：`⋮` 置于标题栏右侧；底部行精简为 **退出/解散房间**（唯一红色·会话动作）+ **收起**（中性·关弹窗）。
  - **加入态**：`⋮` 置于右上角；底部行只留居中的 **最小化**。
  - 点选菜单项后弹 **二次确认** 才生效，破坏性动作有了应有的摩擦（复用既有 `AlertDialog` 样式）。
- **文案**：`watch_together_more_options` / `watch_together_disable_feature` / `watch_together_disable_feature_desc` / `watch_together_confirm_disable`，覆盖 zh-CN / HK / TW / EN 四语言。

## Design mockup

交互对比稿（Material 3 · 深浅双主题 · ⋮ 菜单与确认框可点）：
https://claude.ai/code/artifact/c4f23054-75f7-4c48-97c9-4d112d369778

## Testing

`:app:shared:ui-watchtogether` 编译 + desktopTest 通过（现有 dialog 测试点的是加入表单与跟随开关，不受影响）。Compose Preview 自动体现新布局（`WatchTogetherDialogContent` 渲染 ⋮ 与精简后的底部行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)