### PR TITLE
feat(player): add a playback speed scope toggle and digit shortcuts

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
@@ -100,19 +100,30 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
      */
     val displayModeId: Int = 0,
     /**
-     * 长按快进的速度倍率
+     * 长按期间使用的播放速度. 是绝对速度, 不是相对当前倍速的倍率.
      *
      * @since 4.9
      */
     val fastForwardSpeed: Float = 2.5f, // 3 倍弹幕会跳, 所以慢点, see #1524
     /**
-     * 全局常驻播放倍速. 跨剧集、条目和应用重启保持.
+     * 播放倍速. 语义取决于 [rememberPlaybackSpeed]:
+     *
+     * - [rememberPlaybackSpeed] 为 `true` 时, 这是**全局常驻倍速**: 播放器内的调整会写回这里,
+     *   跨剧集、条目和应用重启保持.
+     * - [rememberPlaybackSpeed] 为 `false` 时, 这是**默认倍速**: 只作为每次进入播放器的起始值,
+     *   播放器内的调整不会写回, 退出播放器后即丢弃.
      *
      * 始终位于 [minPlaybackSpeed]..[maxPlaybackSpeed] 范围内; 量化由 UI 层 (SteppedSlider) 保证.
      *
      * @since 5.8
      */
     val playbackSpeed: Float = 1f,
+    /**
+     * 是否记住播放器内的倍速调整. 见 [playbackSpeed].
+     *
+     * @since 6.0
+     */
+    val rememberPlaybackSpeed: Boolean = true,
     /**
      * 用户可调倍速范围的下界.
      *

--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/PlaybackSpeedExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/PlaybackSpeedExtension.kt
@@ -9,37 +9,39 @@
 
 package me.him188.ani.app.domain.player.extension
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
-import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.episode.EpisodeSession
 import org.koin.core.Koin
 import org.openani.mediamp.features.PlaybackSpeed
 
 /**
- * 将全局持久化的倍速同步到播放器, 并持续跟随设置变更.
+ * 将当前生效的倍速同步到播放器, 并持续跟随其变更.
+ *
+ * [playbackSpeedFlow] 由调用方 (通常是播放页 ViewModel) 提供, 其作用域即为一次播放:
+ * 播放页内切集时本扩展会随新的 [EpisodeSession] 重新应用当前值, 因此倍速在切集后保持;
+ * 播放页退出后该 flow 随之消失.
  */
 class PlaybackSpeedExtension(
     private val context: PlayerExtensionContext,
-    koin: Koin
+    private val playbackSpeedFlow: Flow<Float>,
 ) : PlayerExtension("PlaybackSpeed") {
-    private val settingsRepository: SettingsRepository by koin.inject()
-
     override fun onStart(
         episodeSession: EpisodeSession,
         backgroundTaskScope: ExtensionBackgroundTaskScope
     ) {
         backgroundTaskScope.launch("PlaybackSpeed") {
-            settingsRepository.videoScaffoldConfig.flow
-                .map { it.playbackSpeed }
+            playbackSpeedFlow
                 .distinctUntilChanged()
                 .collect { context.player.features[PlaybackSpeed]?.set(it) }
         }
     }
 
-    companion object : EpisodePlayerExtensionFactory<PlaybackSpeedExtension> {
+    class Factory(
+        private val playbackSpeedFlow: Flow<Float>,
+    ) : EpisodePlayerExtensionFactory<PlaybackSpeedExtension> {
         override fun create(context: PlayerExtensionContext, koin: Koin): PlaybackSpeedExtension {
-            return PlaybackSpeedExtension(context, koin)
+            return PlaybackSpeedExtension(context, playbackSpeedFlow)
         }
     }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/preference/VideoScaffoldConfigTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/preference/VideoScaffoldConfigTest.kt
@@ -44,6 +44,8 @@ class VideoScaffoldConfigTest {
         assertEquals(1f, config.playbackSpeed)
         assertEquals(0.5f, config.minPlaybackSpeed)
         assertEquals(2.5f, config.maxPlaybackSpeed)
+        // 升级到 6.0 的用户保持原有的全局常驻倍速行为
+        assertEquals(true, config.rememberPlaybackSpeed)
     }
 
     @Test

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/PlaybackSpeedExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/PlaybackSpeedExtensionTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.player.extension
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import me.him188.ani.app.domain.episode.EpisodeFetchSelectPlayState
+import me.him188.ani.app.domain.episode.EpisodePlayerTestSuite
+import me.him188.ani.utils.coroutines.childScope
+import org.openani.mediamp.features.PlaybackSpeed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackSpeedExtensionTest : AbstractPlayerExtensionTest() {
+    private val newEpisodeId = 3
+
+    private fun TestScope.createCase(
+        playbackSpeedFlow: MutableStateFlow<Float>,
+    ): Triple<CoroutineScope, EpisodePlayerTestSuite, EpisodeFetchSelectPlayState> {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val testScope = this.childScope()
+        val suite = EpisodePlayerTestSuite(this, testScope)
+
+        val state = suite.createState(
+            extensions = listOf(PlaybackSpeedExtension.Factory(playbackSpeedFlow)),
+        )
+        state.onUIReady()
+        advanceUntilIdle()
+        return Triple(testScope, suite, state)
+    }
+
+    private val EpisodePlayerTestSuite.playerSpeed: Float?
+        get() = player.features[PlaybackSpeed]?.value
+
+    /**
+     * 播放页内切集时倍速必须保持. 播放器在换片源后可能把速度重置回 1x, 扩展需要在新 session 上重新应用.
+     */
+    @Test
+    fun `reapplies the speed after switching episode`() = runTest {
+        val speed = MutableStateFlow(1f)
+        val (testScope, suite, state) = createCase(speed)
+        try {
+            speed.value = 1.75f
+            advanceUntilIdle()
+            assertEquals(1.75f, suite.playerSpeed)
+
+            // 模拟播放器换片源后速度被重置
+            suite.player.features[PlaybackSpeed]?.set(1f)
+            state.switchEpisode(newEpisodeId)
+            advanceUntilIdle()
+
+            assertEquals(1.75f, suite.playerSpeed)
+        } finally {
+            testScope.cancel()
+        }
+    }
+}

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -289,9 +289,13 @@
     <string name="settings_player_experimental_hls_segment_filter">过滤贴片广告（实验性）</string>
     <string name="settings_player_experimental_hls_segment_filter_description">尝试过滤部分在线源插入的贴片广告。只对以独立片段插入的广告有效，识别错误时可能跳过正常内容。</string>
     <string name="settings_player_long_press_fast_forward_speed">长按播放速度</string>
-    <string name="settings_player_long_press_fast_forward_speed_description">长按时使用的播放倍率</string>
+    <string name="settings_player_long_press_fast_forward_speed_description">长按时使用的播放速度</string>
     <string name="settings_player_playback_speed_range">倍速范围</string>
     <string name="settings_player_playback_speed_range_description">影响播放页倍速滑块和长按播放速度的可调范围</string>
+    <string name="settings_player_remember_playback_speed">记住播放倍速</string>
+    <string name="settings_player_remember_playback_speed_description">在播放器内调整的倍速跨剧集和重启保持。关闭后仅对本次播放生效，退出播放器即回到默认倍速。</string>
+    <string name="settings_player_default_playback_speed">默认倍速</string>
+    <string name="settings_player_default_playback_speed_description">每次进入播放器时的起始倍速</string>
 
     <!-- Version Expired Overlay -->
     <string name="settings_update_version_expired_title">版本过期</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -274,9 +274,13 @@
     <string name="settings_player_experimental_hls_segment_filter">過濾貼片廣告（實驗性）</string>
     <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾部分線上來源插入的貼片廣告。只對以獨立片段插入的廣告有效，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按播放速度</string>
-    <string name="settings_player_long_press_fast_forward_speed_description">長按時使用的播放倍率</string>
+    <string name="settings_player_long_press_fast_forward_speed_description">長按時使用的播放速度</string>
     <string name="settings_player_playback_speed_range">倍速範圍</string>
     <string name="settings_player_playback_speed_range_description">影響播放頁倍速滑桿和長按播放速度的可調範圍</string>
+    <string name="settings_player_remember_playback_speed">記住播放倍速</string>
+    <string name="settings_player_remember_playback_speed_description">在播放器內調整的倍速跨劇集和重啟保持。關閉後僅對本次播放生效，退出播放器即回到預設倍速。</string>
+    <string name="settings_player_default_playback_speed">預設倍速</string>
+    <string name="settings_player_default_playback_speed_description">每次進入播放器時的起始倍速</string>
 
     <!-- Storage Settings -->
     <string name="settings_storage_title">存儲設置</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -274,9 +274,13 @@
     <string name="settings_player_experimental_hls_segment_filter">過濾貼片廣告（實驗性）</string>
     <string name="settings_player_experimental_hls_segment_filter_description">嘗試過濾部分線上來源插入的貼片廣告。僅對以獨立片段插入的廣告有效，識別錯誤時可能跳過正常內容。</string>
     <string name="settings_player_long_press_fast_forward_speed">長按播放速度</string>
-    <string name="settings_player_long_press_fast_forward_speed_description">長按時使用的播放倍率</string>
+    <string name="settings_player_long_press_fast_forward_speed_description">長按時使用的播放速度</string>
     <string name="settings_player_playback_speed_range">倍速範圍</string>
     <string name="settings_player_playback_speed_range_description">影響播放頁倍速滑桿和長按播放速度的可調範圍</string>
+    <string name="settings_player_remember_playback_speed">記住播放倍速</string>
+    <string name="settings_player_remember_playback_speed_description">在播放器內調整的倍速跨劇集和重啟保持。關閉後僅對本次播放生效，退出播放器即回到預設倍速。</string>
+    <string name="settings_player_default_playback_speed">預設倍速</string>
+    <string name="settings_player_default_playback_speed_description">每次進入播放器時的起始倍速</string>
 
     <!-- Storage Settings -->
     <string name="settings_storage_title">儲存設定</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -279,6 +279,10 @@
     <string name="settings_player_long_press_fast_forward_speed_description">Playback speed used while long-pressing</string>
     <string name="settings_player_playback_speed_range">Playback speed range</string>
     <string name="settings_player_playback_speed_range_description">Range for the in-player speed slider and long-press playback speed</string>
+    <string name="settings_player_remember_playback_speed">Remember playback speed</string>
+    <string name="settings_player_remember_playback_speed_description">Keep the speed you set in the player across episodes and restarts. When off, it applies only until you leave the player, then returns to the default speed.</string>
+    <string name="settings_player_default_playback_speed">Default playback speed</string>
+    <string name="settings_player_default_playback_speed_description">Speed to start at each time you open the player</string>
     <string name="settings_storage_title">Storage settings</string>
     <string name="settings_storage_bt_cache_location">BT video cache location</string>
     <string name="settings_storage_bt_cache_location_description">Changing this won\'t automatically migrate data nor delete old data.\nIf you want to remove old data, please click &quot;Open BT cache directory&quot; before making changes and remove all files in that directory.\n\nRestart required to take effect.</string>

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -280,12 +280,25 @@ class EpisodeViewModel(
     val player: MediampPlayer =
         playerStateFactory.create(context, backgroundScope.coroutineContext)
 
+    /** `null` 表示本次播放尚未调整过倍速, 此时跟随配置. */
+    private val playbackSpeedOverride = MutableStateFlow<Float?>(null)
+
+    /**
+     * 当前生效的倍速. 作用域为一次播放 (本 ViewModel 的生命周期), 播放页内切集保持.
+     */
+    private val playbackSpeedFlow: Flow<Float> = combine(
+        settingsRepository.videoScaffoldConfig.flow,
+        playbackSpeedOverride,
+    ) { config, override ->
+        override ?: config.playbackSpeed
+    }.distinctUntilChanged()
+
     @OptIn(UnsafeEpisodeSessionApi::class)
     private val fetchPlayState = EpisodeFetchSelectPlayState(
         subjectId, initialEpisodeId, player, backgroundScope,
         extensions = listOf(
             AnalyticsExtension,
-            PlaybackSpeedExtension,
+            PlaybackSpeedExtension.Factory(playbackSpeedFlow),
             RememberPlayProgressExtension,
             WatchTogetherPlayerExtension,
             MarkAsWatchedExtension,
@@ -386,11 +399,14 @@ class EpisodeViewModel(
     val playbackSpeedRange: ClosedFloatingPointRange<Float>
         get() = videoScaffoldConfig.minPlaybackSpeed..videoScaffoldConfig.maxPlaybackSpeed
 
-    /** 持久化全局倍速；播放器会通过上方的配置订阅同步该值. */
+    /** 总是对本次播放生效; 仅在开启「记住播放倍速」时才另外写回配置. */
     fun setPlaybackSpeed(speed: Float) {
+        playbackSpeedOverride.value = speed
         launchInBackground {
-            settingsRepository.videoScaffoldConfig.update {
-                copy(playbackSpeed = speed)
+            if (settingsRepository.videoScaffoldConfig.flow.first().rememberPlaybackSpeed) {
+                settingsRepository.videoScaffoldConfig.update {
+                    copy(playbackSpeed = speed)
+                }
             }
         }
     }

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -664,6 +664,49 @@ class EpisodeVideoControllerTest {
     }
 
     @Test
+    fun `touch - keyboard shortcuts - digit keys jump to speed presets`() = runAniComposeUiTest {
+        lateinit var playbackSpeed: TestPlaybackSpeed
+        val committedPlaybackSpeeds = mutableListOf<Float>()
+        setContent {
+            CompositionLocalProvider(LocalPlatform provides Platform.Android(Arch.ARMV8A)) {
+                playbackSpeed = remember { TestPlaybackSpeed(1f) }
+                Player(
+                    GestureFamily.TOUCH,
+                    playbackSpeed = playbackSpeed,
+                    onCommitPlaybackSpeed = { committedPlaybackSpeeds.add(it) },
+                )
+            }
+        }
+        waitForIdle()
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Two)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(2f, playbackSpeed.value)
+        }
+
+        // 3x 超出默认范围 0.5x..2.5x, clamp 到上界而不是不响应
+        videoGestureHost.performKeyInput {
+            pressKey(Key.Three)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(2.5f, playbackSpeed.value)
+        }
+
+        videoGestureHost.performKeyInput {
+            pressKey(Key.NumPad1)
+        }
+        waitForIdle()
+        runOnIdle {
+            assertEquals(1f, playbackSpeed.value)
+            assertEquals(listOf(2f, 2.5f, 1f), committedPlaybackSpeeds)
+        }
+    }
+
+    @Test
     fun `touch - keyboard shortcuts - yield focus to editor and reclaim it from video click`() = runAniComposeUiTest {
         lateinit var playerState: TestMediampPlayer
         var toggleDanmakuCount = 0

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/app/AppSettingsTab.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.ui.settings.tabs.app
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.material.icons.Icons
@@ -51,6 +52,7 @@ import me.him188.ani.app.platform.currentAniBuildConfig
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.SteppedSlider
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
+import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
 import me.him188.ani.app.ui.foundation.quantizeSliderValue
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.settings_app_close_behavior
@@ -81,6 +83,8 @@ import me.him188.ani.app.ui.lang.settings_player_auto_skip_op_ed
 import me.him188.ani.app.ui.lang.settings_player_auto_skip_op_ed_description
 import me.him188.ani.app.ui.lang.settings_player_auto_switch_media_on_error
 import me.him188.ani.app.utils.formatSpeedValue
+import me.him188.ani.app.ui.lang.settings_player_default_playback_speed
+import me.him188.ani.app.ui.lang.settings_player_default_playback_speed_description
 import me.him188.ani.app.ui.lang.settings_player_experimental_hls_segment_filter
 import me.him188.ani.app.ui.lang.settings_player_experimental_hls_segment_filter_description
 import me.him188.ani.app.ui.lang.settings_player_enable_regex_filter
@@ -99,6 +103,8 @@ import me.him188.ani.app.ui.lang.settings_player_op_ed_skip_duration_seconds
 import me.him188.ani.app.ui.lang.settings_player_pause_on_edit_danmaku
 import me.him188.ani.app.ui.lang.settings_player_playback_speed_range
 import me.him188.ani.app.ui.lang.settings_player_playback_speed_range_description
+import me.him188.ani.app.ui.lang.settings_player_remember_playback_speed
+import me.him188.ani.app.ui.lang.settings_player_remember_playback_speed_description
 import me.him188.ani.app.ui.lang.settings_update_auto_check
 import me.him188.ani.app.ui.lang.settings_update_auto_check_description
 import me.him188.ani.app.ui.lang.settings_update_auto_download
@@ -597,9 +603,9 @@ fun SettingsScope.PlayerGroup(
 }
 
 /**
- * 倍速范围 + 长按倍速两个设置项.
+ * 倍速范围 + 记住倍速 + 默认倍速 + 长按播放速度.
  *
- * 两者共享范围拖动状态: 拖动范围 RangeSlider 期间, 下方长按倍速 Slider 的范围和 clamp 后的值
+ * 各条 Slider 共享范围拖动状态: 拖动范围 RangeSlider 期间, 下方各条 Slider 的范围和 clamp 后的值
  * 实时跟随, 被 clamp 时通过动画过渡, 避免松手后数值「突变」.
  */
 @Composable
@@ -643,24 +649,81 @@ private fun SettingsScope.PlaybackSpeedItems(
         description = { Text(stringResource(Lang.settings_player_playback_speed_range_description)) },
     )
 
-    HorizontalDividerItem()
-
-    var speedDragOverride by remember { mutableStateOf<Float?>(null) }
-    var speedDragging by remember { mutableStateOf(false) }
     // 范围变化以动画过渡, 避免 thumb 映射位置瞬移
     val animatedRangeStart by animateFloatAsState(effectiveRange.start, label = "playbackSpeedRangeStart")
     val animatedRangeEnd by animateFloatAsState(effectiveRange.endInclusive, label = "playbackSpeedRangeEnd")
     val displayRange =
         if (animatedRangeStart < animatedRangeEnd) animatedRangeStart..animatedRangeEnd else effectiveRange
-    val displayValue = (speedDragOverride ?: config.fastForwardSpeed).coerceIn(displayRange)
-    LaunchedEffect(config.fastForwardSpeed, speedDragOverride, speedDragging) {
-        if (!speedDragging && speedDragOverride == config.fastForwardSpeed) {
-            speedDragOverride = null
+
+    HorizontalDividerItem()
+
+    SwitchItem(
+        checked = config.rememberPlaybackSpeed,
+        onCheckedChange = {
+            videoScaffoldConfig.update(config.copy(rememberPlaybackSpeed = it))
+        },
+        title = { Text(stringResource(Lang.settings_player_remember_playback_speed)) },
+        description = { Text(stringResource(Lang.settings_player_remember_playback_speed_description)) },
+    )
+
+    // 此处没有 ColumnScope 接收者, 不显式指定就会落到 fadeIn/fadeOut 的重载上, 高度瞬间撑开、下方条目跳位.
+    val motionScheme = LocalAniMotionScheme.current.animatedVisibility
+    AniAnimatedVisibility(
+        visible = !config.rememberPlaybackSpeed,
+        enter = motionScheme.columnEnter,
+        exit = motionScheme.columnExit,
+    ) {
+        Column {
+            HorizontalDividerItem()
+            SpeedSliderItem(
+                value = config.playbackSpeed,
+                displayRange = displayRange,
+                commitRange = effectiveRange,
+                onCommit = { videoScaffoldConfig.update(config.copy(playbackSpeed = it)) },
+                title = { Text(stringResource(Lang.settings_player_default_playback_speed)) },
+                description = { Text(stringResource(Lang.settings_player_default_playback_speed_description)) },
+            )
+        }
+    }
+
+    HorizontalDividerItem()
+
+    SpeedSliderItem(
+        value = config.fastForwardSpeed,
+        displayRange = displayRange,
+        commitRange = effectiveRange,
+        onCommit = { videoScaffoldConfig.update(config.copy(fastForwardSpeed = it)) },
+        title = { Text(stringResource(Lang.settings_player_long_press_fast_forward_speed)) },
+        description = { Text(stringResource(Lang.settings_player_long_press_fast_forward_speed_description)) },
+    )
+}
+
+/**
+ * 一条倍速 Slider. 拖动期间使用瞬态值实时预览, 松手后量化到 [commitRange] 再提交.
+ *
+ * @param displayRange 渲染用范围, 可能正处于动画过渡中
+ * @param commitRange 提交用范围, 即用户配置的真实范围
+ */
+@Composable
+private fun SettingsScope.SpeedSliderItem(
+    value: Float,
+    displayRange: ClosedFloatingPointRange<Float>,
+    commitRange: ClosedFloatingPointRange<Float>,
+    onCommit: (Float) -> Unit,
+    title: @Composable RowScope.() -> Unit,
+    description: @Composable (() -> Unit)? = null,
+) {
+    var dragOverride by remember { mutableStateOf<Float?>(null) }
+    var dragging by remember { mutableStateOf(false) }
+    val displayValue = (dragOverride ?: value).coerceIn(displayRange)
+    LaunchedEffect(value, dragOverride, dragging) {
+        if (!dragging && dragOverride == value) {
+            dragOverride = null
         }
     }
     SliderItem(
-        title = { Text(stringResource(Lang.settings_player_long_press_fast_forward_speed)) },
-        description = { Text(stringResource(Lang.settings_player_long_press_fast_forward_speed_description)) },
+        title = title,
+        description = description,
         valueLabel = {
             Text("${quantizeSliderValue(displayValue, displayRange).formatSpeedValue()}x")
         },
@@ -668,19 +731,15 @@ private fun SettingsScope.PlaybackSpeedItems(
         SteppedSlider(
             value = displayValue,
             onValueChange = {
-                speedDragging = true
-                speedDragOverride = quantizeSliderValue(it, displayRange)
+                dragging = true
+                dragOverride = quantizeSliderValue(it, displayRange)
             },
             onValueChangeFinished = { displayedValue ->
-                val finalValue = speedDragOverride ?: displayedValue
-                val committedValue = quantizeSliderValue(finalValue, effectiveRange)
-                speedDragging = false
-                speedDragOverride = committedValue
-                videoScaffoldConfig.update(
-                    config.copy(
-                        fastForwardSpeed = committedValue,
-                    ),
-                )
+                val finalValue = dragOverride ?: displayedValue
+                val committedValue = quantizeSliderValue(finalValue, commitRange)
+                dragging = false
+                dragOverride = committedValue
+                onCommit(committedValue)
             },
             valueRange = displayRange,
             valueIndicator = { Text(it.formatSpeedValue(), maxLines = 1, softWrap = false) },

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/FastSkipState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/FastSkipState.kt
@@ -51,7 +51,7 @@ class PlayerFastSkipState(
                     SkipDirection.BACKWARD -> error("Backward skipping is not supported")
                 },
             )
-            gestureIndicatorTicket = gestureIndicatorState.startFastForward()
+            gestureIndicatorTicket = gestureIndicatorState.startFastForward(fastForwardSpeed)
         },
         onStop = {
             playbackSpeed.set(originalSpeed)

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerGestureHost.kt
@@ -230,9 +230,12 @@ class GestureIndicatorState {
         stopShow(ticket)
     }
 
+    /**
+     * @param speed 长按期间使用的播放速度, 会显示在指示器上.
+     */
     @UiThread
-    fun startFastForward(): Int {
-        startShow(FAST_FORWARD, setup = { })
+    fun startFastForward(speed: Float): Int {
+        startShow(FAST_FORWARD, setup = { playbackSpeed = speed })
         return counter
     }
 
@@ -379,6 +382,7 @@ fun GestureIndicator(
 
                         FAST_FORWARD -> {
                             Icon(Icons.Rounded.FastForward, null, Modifier.size(iconSize))
+                            Text("${state.playbackSpeed.formatSpeedValue()}x", maxLines = 1)
                         }
 
                         FAST_BACKWARD -> {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/gesture/PlayerKeyboardShortcuts.kt
@@ -20,6 +20,15 @@ import me.him188.ani.app.ui.foundation.effects.ComposeKey
 import me.him188.ani.app.ui.foundation.effects.onKey
 import me.him188.ani.app.videoplayer.ui.nextPlaybackSpeed
 
+private val PLAYBACK_SPEED_SHORTCUTS = listOf(
+    ComposeKey.One to 1f,
+    ComposeKey.NumPad1 to 1f,
+    ComposeKey.Two to 2f,
+    ComposeKey.NumPad2 to 2f,
+    ComposeKey.Three to 3f,
+    ComposeKey.NumPad3 to 3f,
+)
+
 /**
  * Installs the player keyboard commands on a single focus target.
  *
@@ -79,6 +88,11 @@ internal fun Modifier.playerKeyboardShortcuts(
             .onKey(ComposeKey.S) {
                 onPlaybackSpeedChanged(1f.coerceIn(playbackSpeedRange))
             }
+        for ((key, speed) in PLAYBACK_SPEED_SHORTCUTS) {
+            result = result.onKey(key) {
+                onPlaybackSpeedChanged(speed.coerceIn(playbackSpeedRange))
+            }
+        }
     }
     return result
         .onKey(ComposeKey.B, onToggleDanmaku)


### PR DESCRIPTION
为播放倍速增加作用域开关,并补上数字键档位切换与长按速度显示。

### 倍速作用域

新增「记住播放倍速」开关,默认开启,保持现有的全局常驻倍速行为。关闭后作用域收窄为一次播放:播放页内切集保持,退出后回到默认倍速。设置页随之在开关下方插入「默认倍速」滑条。

<img width="1181" height="720" alt="记住播放倍速开启时的播放器设置" src="https://github.com/user-attachments/assets/af7f36bd-68b0-425c-af06-da349be817a9" />

<img width="1183" height="983" alt="记住播放倍速关闭后，下方出现默认倍速滑条" src="https://github.com/user-attachments/assets/f70ff439-dc22-4a34-97a9-048914262ad5" />

倍速此前只有全局配置一个来源。`PlaybackSpeedExtension` 每次 `onStart` 都从配置重新灌值,无法表达「仅本次播放有效」。

会话级倍速不需要新的持有者:扩展实例的生命周期本就与播放页一致。`PlayerExtensionManager` 在 `EpisodeFetchSelectPlayState` 中只构造一次,per-session 的只有 `onStart`。

改为由调用方传入倍速 flow:`EpisodeViewModel` 持有会话级 override,用户未调整时取配置值。开关只决定 `setPlaybackSpeed` 要不要额外写回 DataStore。

不做升级迁移。已设置过全局倍速的用户保留原值,起播速度不变;新字段带默认值,旧数据缺 key 时解码为 `true`。

### 数字键与长按指示器

数字键 1/2/3 及小键盘对应键直达 1x/2x/3x,超出配置范围时 clamp。长按快进的指示器此前只有图标,现补上正在使用的速度值。

<img width="309" height="197" alt="长按快进时的手势指示器，显示当前使用的速度" src="https://github.com/user-attachments/assets/745e20ae-6377-4ce8-98c4-33f228e26493" />

`fastForwardSpeed` 是绝对速度而非倍率,中文文案「长按时使用的播放倍率」随之改为「速度」,简繁四个 locale 同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
