### PR TITLE
fix(subject-details): keep tab labels on one line

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -898,7 +898,11 @@ private fun SubjectDetailsContentTabRow(
                         scope.launch { pagerState.animateScrollToPage(index) }
                     },
                     text = {
-                        Text(text = renderSubjectDetailsTab(tabId))
+                        Text(
+                            text = renderSubjectDetailsTab(tabId),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     },
                 )
             }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -51,8 +51,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -878,7 +878,7 @@ private fun SubjectDetailsContentTabRow(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
     ) {
-        TabRow(
+        ScrollableTabRow(
             selectedTabIndex = pagerState.currentPage,
             modifier = Modifier.widthIn(max = SubjectDetailsDefaults.TabRowWidth),
             indicator = @Composable { tabPositions ->
@@ -893,15 +893,13 @@ private fun SubjectDetailsContentTabRow(
             SubjectDetailsTab.entries.forEachIndexed { index, tabId ->
                 Tab(
                     selected = pagerState.currentPage == index,
-                    modifier = Modifier.widthIn(max = SubjectDetailsDefaults.TabWidth),
                     onClick = {
                         scope.launch { pagerState.animateScrollToPage(index) }
                     },
                     text = {
                         Text(
                             text = renderSubjectDetailsTab(tabId),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+                            softWrap = false,
                         )
                     },
                 )

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -36,7 +37,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -112,6 +112,7 @@ import me.him188.ani.app.ui.foundation.layout.NestedScrollableColumnState
 import me.him188.ani.app.ui.foundation.layout.NestedScrollableScope
 import me.him188.ani.app.ui.foundation.layout.PaddingValuesSides
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
+import me.him188.ani.app.ui.foundation.layout.isWidthCompact
 import me.him188.ani.app.ui.foundation.layout.only
 import me.him188.ani.app.ui.foundation.layout.paneHorizontalPadding
 import me.him188.ani.app.ui.foundation.layout.paneVerticalPadding
@@ -160,12 +161,12 @@ import me.him188.ani.app.ui.subject.details.components.SubjectDetailsHeader
 import me.him188.ani.app.ui.subject.details.layout.CompactDetailsTabContent
 import me.him188.ani.app.ui.subject.details.layout.SubjectDetailsLayoutParams
 import me.him188.ani.app.ui.subject.details.layout.SubjectDetailsMultiColumnPage
-import me.him188.ani.app.ui.subject.person.PeoplePreviewHost
 import me.him188.ani.app.ui.subject.details.layout.SubjectDetailsMultiColumnPlaceholder
 import me.him188.ani.app.ui.subject.details.sections.SubjectCommentsSheet
 import me.him188.ani.app.ui.subject.details.state.SubjectDetailsState
 import me.him188.ani.app.ui.subject.details.state.createTestSubjectDetailsState
 import me.him188.ani.app.ui.subject.episode.list.EpisodeListDialog
+import me.him188.ani.app.ui.subject.person.PeoplePreviewHost
 import me.him188.ani.app.ui.user.SelfInfoUiState
 import me.him188.ani.app.ui.user.TestSelfInfoUiState
 import me.him188.ani.datasources.api.PackedDate
@@ -461,10 +462,10 @@ private fun SubjectDetailsPage(
             },
             tabRow = { isOverlay, visible ->
                 SubjectDetailsContentTabRow(
-                    pagerState, 
+                    pagerState,
                     modifier = Modifier.ifThen(!isOverlay) {
                         alpha(if (visible) 1f else 0f)
-                    }
+                    },
                 )
             },
             nestedScrollableColumnState = nestedScrollableColumnState,
@@ -724,7 +725,7 @@ fun SubjectDetailsSingleColumnPage(
                 contentAlignment = Alignment.TopCenter,
             ) {
                 var tabRowHeightPx by remember { mutableStateOf(0) }
-                
+
                 // 粘性面板: 第二个 TopAppBar + 第二份 TabRow.
                 // 作为模糊来源的 sibling 绘制在其上方, 毛玻璃可采样到下方滚动的内容.
                 val density = LocalDensity.current
@@ -836,7 +837,8 @@ fun SubjectDetailsSingleColumnPage(
                                         modifier = panelBackgroundModifier,
                                         navigationIcon = navigationIcon,
                                         actions = topAppBarActions,
-                                        colors = AniThemeDefaults.topAppBarColors().copy(containerColor = Color.Transparent),
+                                        colors = AniThemeDefaults.topAppBarColors()
+                                            .copy(containerColor = Color.Transparent),
                                         windowInsets = windowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
                                     )
                                 }
@@ -872,6 +874,7 @@ fun SubjectDetailsSingleColumnPage(
 private fun SubjectDetailsContentTabRow(
     pagerState: PagerState,
     modifier: Modifier = Modifier,
+    compact: Boolean = currentWindowAdaptiveInfo1().isWidthCompact
 ) {
     val scope = rememberCoroutineScope()
     Box(
@@ -888,11 +891,13 @@ private fun SubjectDetailsContentTabRow(
             },
             containerColor = Color.Transparent,
             contentColor = TabRowDefaults.secondaryContentColor,
+            edgePadding = if (compact) 0.dp else TabRowDefaults.ScrollableTabRowEdgeStartPadding,
             divider = {},
         ) {
             SubjectDetailsTab.entries.forEachIndexed { index, tabId ->
                 Tab(
                     selected = pagerState.currentPage == index,
+                    modifier = Modifier.widthIn(min = TabRowDefaults.ScrollableTabRowMinTabWidth),
                     onClick = {
                         scope.launch { pagerState.animateScrollToPage(index) }
                     },

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/SubjectDetailsDefaults.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/SubjectDetailsDefaults.kt
@@ -25,7 +25,6 @@ import me.him188.ani.app.ui.subject.renderSubjectSeason
 import me.him188.ani.datasources.api.PackedDate
 
 object SubjectDetailsDefaults {
-    val TabWidth = 80.dp
     val TabRowWidth = 80.dp * 3 // 240.dp, 三个 Tab 的宽度
     val MaximumContentWidth = 1300.dp
 }


### PR DESCRIPTION
Closes #3139

## Summary

- Keep Subject Details tab labels on a single line.
- Restore a scrollable tab row so localized labels can use their natural width without ellipsis.

## Validation

- `:app:shared:ui-subject:compileKotlinDesktop`
- Focused English `SubjectDetailsScreenshotTest.compact` with direct screenshot inspection
- `:app:shared:ui-subject:check`
