### PR TITLE
fix(desktop): keep the CMP internals resolved reflectively by the touch bridge

### DIFF
--- a/app/desktop/proguard-desktop.pro
+++ b/app/desktop/proguard-desktop.pro
@@ -132,6 +132,16 @@
 -keep class com.jthemedetecor.** { *; } #1404 OsThemeDetector
 -keep class oshi.** { *; } #1404 OsThemeDetector
 
+# ComposeSceneTouchBridge ProGuard rules
+# 原生 Windows 触摸桥接通过反射解析 CMP 内部结构. 这里 obfuscate 是关的, 但 optimize 会内联并删除
+# 这些访问器: 6.0.0-beta02 里 ComposeSceneMediator.getSceneBoundsInPx() 已经被内联掉, 桥接构建失败后
+# 静默退回 AWT 鼠标路径, 触摸被合成为鼠标事件而不跟手.
+-keep class androidx.compose.ui.awt.ComposeWindow { *; }
+-keep class androidx.compose.ui.awt.ComposePanel { *; }
+-keep class androidx.compose.ui.scene.ComposeContainer { *; }
+-keep class androidx.compose.ui.scene.ComposeSceneMediator { *; }
+-keep interface androidx.compose.ui.scene.ComposeScene { *; }
+
 # LayoutHitTestOwner ProGuard rules
 # 保持被反射调用的类
 -keep class androidx.compose.foundation.HoverableNode { *; }

--- a/app/desktop/proguard-desktop.pro
+++ b/app/desktop/proguard-desktop.pro
@@ -133,9 +133,6 @@
 -keep class oshi.** { *; } #1404 OsThemeDetector
 
 # ComposeSceneTouchBridge ProGuard rules
-# 原生 Windows 触摸桥接通过反射解析 CMP 内部结构. 这里 obfuscate 是关的, 但 optimize 会内联并删除
-# 这些访问器: 6.0.0-beta02 里 ComposeSceneMediator.getSceneBoundsInPx() 已经被内联掉, 桥接构建失败后
-# 静默退回 AWT 鼠标路径, 触摸被合成为鼠标事件而不跟手.
 -keep class androidx.compose.ui.awt.ComposeWindow { *; }
 -keep class androidx.compose.ui.awt.ComposePanel { *; }
 -keep class androidx.compose.ui.scene.ComposeContainer { *; }


### PR DESCRIPTION
## 问题

Release 构建中原生触摸事件从未到达 Compose。Windows 改用触摸合成鼠标事件，拖动因此不跟手，手指离开后滚动仍会继续滑行较长距离。通过 Gradle 运行不受影响，问题只在发布包中出现。

## 原因

ProGuard 关闭混淆但启用优化（`obfuscate = false`、`optimize = true`）。优化器内联并移除了 `ComposeSceneMediator.getSceneBoundsInPx()`，同一属性的 backing field 与 setter 均得以保留。

`ComposeSceneTouchBridge` 按名称反射该 getter。`create()` 抛出异常后仅记录一条警告并返回 null，应用随即退回 AWT 鼠标路径：

```
[WARN ] ComposeSceneTouchBridge: CMP ComposeScene touch bridge unavailable; keeping default mouse input
java.lang.NoSuchMethodException: androidx.compose.ui.scene.ComposeSceneMediator.getSceneBoundsInPx()
	at ComposeSceneTouchBridge$Companion.create(ComposeSceneTouchBridge.kt:143)
```

## 修复

保留桥接反射涉及的几个类。其成员成为入口点后，优化器不再内联或改写签名。

验证：`javap` 确认重新打包后被移除的成员已恢复；新 release 包日志中不再出现上述警告；Windows ARM64 二合一设备上触摸拖动恢复跟手。

## 补充

#3169 已实现原生触摸输入，本 PR 仅使其在 ProGuard 处理后依然生效。此前桥接在每个 release 构建中都初始化失败，用户侧行为始终未变。

Fixes #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
