### PR TITLE
Preserve executable permissions in desktop ZIP

### DIFF
--- a/ci-helper/build.gradle.kts
+++ b/ci-helper/build.gradle.kts
@@ -114,6 +114,8 @@ tasks.register("uploadIosIpaQR") {
 val zipDesktopDistribution = tasks.register("zipDesktopDistribution", Zip::class) {
     dependsOn(":app:desktop:createReleaseDistributable")
     from(project(":app:desktop").layout.buildDirectory.dir("compose/binaries/main-release/app"))
+    // Preserve launchers and bundled runtime helpers that must remain executable.
+    useFileSystemPermissions()
     archiveBaseName.set("ani")
     archiveVersion.set(ciReleaseFullVersion)
     destinationDirectory.set(layout.buildDirectory.dir("distributions"))


### PR DESCRIPTION
Closes #2956

## Summary

- preserve source filesystem permissions when creating the portable desktop ZIP
- keep the macOS launcher and bundled JBR/JCEF/CEF helpers executable after extraction
- fix the Intel-only release failure because macOS x86 is distributed through this ZIP path, while Apple silicon uses a DMG

## Verification

- `./gradlew :ci-helper:zipDesktopDistribution --no-daemon --no-configuration-cache --console=plain` using the CI JBR 21: passed
- `./gradlew :ci-helper:check --no-daemon --no-configuration-cache --console=plain`: passed
- inspected the generated ZIP central directory and extracted the 12 executable paths reported in the issue; the Ani launcher, jspawnhelper, all JCEF/CEF helpers, and Chromium framework binary were all `0755` after extraction