### PR TITLE
fix(desktop): skip restoring WndProc when the window is already destroyed

### DIFF
--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
@@ -65,8 +65,10 @@ import me.him188.ani.app.platform.window.ExtendedUser32.Companion.WM_SETTINGCHAN
 import me.him188.ani.app.platform.window.ExtendedUser32.MENUITEMINFO
 import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.layout.LocalPlatformWindow
+import me.him188.ani.utils.logging.debug
 import me.him188.ani.utils.logging.error
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.isWindows
 import org.jetbrains.skiko.SkiaLayer
 import java.awt.Window
@@ -105,11 +107,10 @@ internal open class BasicWindowProc(
     private val _accentColor: MutableStateFlow<Color> = MutableStateFlow(currentAccentColor())
     val accentColor: StateFlow<Color> = _accentColor.asStateFlow()
 
+    private val ownWindowProc: Pointer = CallbackReference.getFunctionPointer(this)
+
     private val defaultWindowProc =
-        user32.installWindowProc(
-            windowHandle,
-            CallbackReference.getFunctionPointer(this),
-        )
+        user32.installWindowProc(windowHandle, ownWindowProc)
 
     private val touchBridge = if (installTouchBridge) ComposeSceneTouchBridge.create(window) else null
     private val touchInputHandler = touchBridge?.let { bridge ->
@@ -196,7 +197,7 @@ internal open class BasicWindowProc(
     override fun close() {
         touchInputHandler?.close()
         touchBridge?.close()
-        user32.restoreWindowProc(windowHandle, defaultWindowProc)
+        user32.restoreWindowProc(windowHandle, defaultWindowProc, ownWindowProc)
     }
 }
 
@@ -551,7 +552,11 @@ internal class ExtendedTitleBarWindowProc(
 
     override fun close() {
         skiaLayerWindowProc?.close()
-        windowHandle.updateWindowStyle { it or WS_SYSMENU }
+        if (user32.IsWindow(windowHandle)) {
+            // 自 Compose Desktop 1.10 起, ComposeWindow.dispose() 先销毁原生窗口再 dispose
+            // composition, 执行到这里时窗口可能已经被销毁, 此时无须也不应再修改窗口样式.
+            windowHandle.updateWindowStyle { it or WS_SYSMENU }
+        }
         super.close()
     }
 }
@@ -570,8 +575,10 @@ internal class SkiaLayerHitTestWindowProc(
     private val windowHandle = HWND(Pointer(skiaLayer.windowHandle))
     internal val contentHandle = HWND(skiaLayer.canvas.let(Native::getComponentPointer))
 
+    private val ownWindowProc: Pointer = CallbackReference.getFunctionPointer(this)
+
     private val defaultWindowProc =
-        user32.installWindowProc(contentHandle, CallbackReference.getFunctionPointer(this))
+        user32.installWindowProc(contentHandle, ownWindowProc)
 
     private val touchBridge = ComposeSceneTouchBridge.create(window)
     private val touchInputHandler = touchBridge?.let { bridge ->
@@ -670,7 +677,7 @@ internal class SkiaLayerHitTestWindowProc(
     override fun close() {
         touchInputHandler?.close()
         touchBridge?.close()
-        user32.restoreWindowProc(contentHandle, defaultWindowProc)
+        user32.restoreWindowProc(contentHandle, defaultWindowProc, ownWindowProc)
     }
 }
 
@@ -682,7 +689,24 @@ private fun ExtendedUser32.installWindowProc(windowHandle: HWND, callback: Point
     }
 }
 
-private fun ExtendedUser32.restoreWindowProc(windowHandle: HWND, previousWindowProc: Pointer) {
+private fun ExtendedUser32.restoreWindowProc(
+    windowHandle: HWND,
+    previousWindowProc: Pointer,
+    ownWindowProc: Pointer,
+) {
+    val currentWindowProc = GetWindowLongPtr(windowHandle, WinUser.GWL_WNDPROC)
+    if (currentWindowProc == null || currentWindowProc.toLong() == 0L) {
+        // 自 Compose Desktop 1.10 起, ComposeWindow.dispose() 先销毁原生窗口再 dispose
+        // composition, 执行到这里时窗口可能已经被销毁 (lastError=1400), 此时无须恢复.
+        logger.debug { "Windows 窗口已销毁, 无须恢复 WndProc: hwnd=$windowHandle" }
+        return
+    }
+    if (currentWindowProc.toPointer() != ownWindowProc) {
+        // 窗口仍有效但 WndProc 不是我们的 hook: 可能是重复 close, 或被其他代码再次 hook.
+        // 此时不能写回 previousWindowProc, 否则会破坏他人的 hook 链.
+        logger.warn("跳过恢复 Windows WndProc: hwnd=$windowHandle 的 WndProc 已不属于当前 hook")
+        return
+    }
     val restored = SetWindowLongPtr(windowHandle, WinUser.GWL_WNDPROC, previousWindowProc)
     if (restored == null) {
         logger.error("恢复 Windows WndProc 失败: hwnd=$windowHandle, lastError=${Native.getLastError()}")


### PR DESCRIPTION
## 概述

修复 Windows 桌面端每次退出时 `HandleWindowsWindowProc` 报两条 `恢复 Windows WndProc 失败: hwnd=..., lastError=1400`（`ERROR_INVALID_WINDOW_HANDLE`）的问题。

## 根因

自 CMP 1.10.0 起（[compose-multiplatform-core#2403](https://github.com/JetBrains/compose-multiplatform-core/pull/2403)，release note 条目为 "Fixed background flashing when a window or dialog are closed"），`ComposeWindow.dispose()` 的执行顺序从「先 dispose composition」翻转为「先销毁原生窗口」：

```kotlin
override fun dispose() {
    super.dispose()        // 先销毁原生窗口, HWND 失效
    composePanel.dispose() // 后 dispose composition → DisposableEffect.onDispose
}
```

因此 `onDispose` 里 `close()` 恢复 WndProc 时 HWND 已失效，`SetWindowLongPtr` 必然失败。该行为自升级到 CMP 1.10 起一直存在（之前静默失败），#3169 补充错误日志后暴露出来。窗口已销毁时恢复失败本身无害，但旧实现仍有两个隐患：

- 若 HWND 值在窗口销毁后被系统复用，`SetWindowLongPtr` 可能「成功」地把失效的旧 WndProc 地址写进无关窗口；
- 若失败发生在窗口存活的路径上，未恢复的窗口会继续把消息发送到随时可能被 GC 的 JNA 回调，trampoline 释放后即为 native crash。

## 变更

- `restoreWindowProc` 先用 `GetWindowLongPtr` 探测当前 WndProc，再决定是否写回：
  - 返回 0 → 窗口已销毁，无须恢复（debug 日志跳过）；
  - 不等于本实例的 hook 指针 → 重复 close / 被他人再次 hook / HWND 复用，warn 并跳过，不破坏他人 hook 链；
  - 仅在窗口存活且仍挂着本实例 hook 时才写回，此时失败才报 error。
- `BasicWindowProc` / `SkiaLayerHitTestWindowProc` 各自保存 hook 回调指针（`ownWindowProc`）用于上述所有权判断。
- `ExtendedTitleBarWindowProc.close()` 恢复 `WS_SYSMENU` 样式前增加 `IsWindow` 检查。

## 验证

- `./gradlew :app:shared:ui-foundation:compileKotlinDesktop` 编译通过。
- Windows 实机运行后关闭窗口退出：日志中两处 `close()` 均命中新增的「窗口已销毁, 无须恢复 WndProc」debug 分支，不再出现 1400 ERROR。