### PR TITLE
feat(jellyfin): 支持 Jellyfin 原生进度条缩略图 (Trickplay)

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/MediaSourceManager.kt
@@ -78,6 +78,13 @@ interface MediaSourceManager { // available by inject
      */
     val allInstances: Flow<List<MediaSourceInstance>>
 
+    suspend fun fetchPreviewThumbnail(mediaSourceId: String, url: String): ByteArray? {
+        val matches = allInstances.first()
+            .filter { it.mediaSourceId == mediaSourceId }
+        check(matches.size <= 1) { "Duplicate media source id: $mediaSourceId" }
+        return matches.singleOrNull()?.source?.fetchPreviewThumbnail(url)
+    }
+
     /**
      * 全部的 [MediaSource], 包括那些设置里关闭的, 包括本地的.
      */

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/fetch/MediaSourceManagerFetchSessionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/fetch/MediaSourceManagerFetchSessionTest.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import me.him188.ani.app.domain.media.selector.MediaSelectorSourceTiers
+import me.him188.ani.app.domain.mediasource.instance.MediaSourceInstance
+import me.him188.ani.app.domain.mediasource.instance.createTestMediaSourceInstance
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.matcher.MediaSourceWebVideoMatcherLoader
 import me.him188.ani.datasources.api.source.FactoryId
@@ -22,7 +24,11 @@ import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
+import me.him188.ani.datasources.api.source.TestHttpMediaSource
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 class MediaSourceManagerFetchSessionTest {
@@ -63,13 +69,47 @@ class MediaSourceManagerFetchSessionTest {
         assertSame(fetcher2, recreated.owner)
     }
 
+    @Test
+    fun `preview thumbnail request uses the current matching source`() = kotlinx.coroutines.test.runTest {
+        val manager = TestMediaSourceManager(TestMediaFetcher("fetcher"))
+        manager.allInstancesState.value = listOf(
+            createTestMediaSourceInstance(ThumbnailSource("source", byteArrayOf(1))),
+        )
+        assertContentEquals(
+            byteArrayOf(1),
+            manager.fetchPreviewThumbnail("source", "https://example.com/first"),
+        )
+
+        manager.allInstancesState.value = listOf(
+            createTestMediaSourceInstance(ThumbnailSource("source", byteArrayOf(2))),
+        )
+        assertContentEquals(
+            byteArrayOf(2),
+            manager.fetchPreviewThumbnail("source", "https://example.com/second"),
+        )
+    }
+
+    @Test
+    fun `preview thumbnail request handles missing and duplicate sources`() = kotlinx.coroutines.test.runTest {
+        val manager = TestMediaSourceManager(TestMediaFetcher("fetcher"))
+        assertNull(manager.fetchPreviewThumbnail("missing", "https://example.com/tile"))
+
+        manager.allInstancesState.value = listOf(
+            createTestMediaSourceInstance(ThumbnailSource("duplicate", byteArrayOf(1))),
+            createTestMediaSourceInstance(ThumbnailSource("duplicate", byteArrayOf(2))),
+        )
+        assertFailsWith<IllegalStateException> {
+            manager.fetchPreviewThumbnail("duplicate", "https://example.com/tile")
+        }
+    }
+
     private class TestMediaSourceManager(
         initialFetcher: MediaFetcher,
     ) : MediaSourceManager {
         val mediaFetcherState = MutableStateFlow(initialFetcher)
+        val allInstancesState = MutableStateFlow<List<MediaSourceInstance>>(emptyList())
 
-        override val allInstances: Flow<List<me.him188.ani.app.domain.mediasource.instance.MediaSourceInstance>> =
-            flowOf(emptyList())
+        override val allInstances: Flow<List<MediaSourceInstance>> = allInstancesState
         override val allFactories: List<MediaSourceFactory> = emptyList()
         override val allFactoryIds: List<FactoryId> = emptyList()
         override val mediaFetcher: Flow<MediaFetcher> = mediaFetcherState
@@ -91,6 +131,13 @@ class MediaSourceManagerFetchSessionTest {
         override suspend fun setEnabled(instanceId: String, enabled: Boolean) = error("Not needed in test")
         override suspend fun removeInstance(instanceId: String) = error("Not needed in test")
         override fun mediaSourceTiersFlow(): Flow<MediaSelectorSourceTiers> = flowOf(MediaSelectorSourceTiers.Empty)
+    }
+
+    private class ThumbnailSource(
+        mediaSourceId: String,
+        private val response: ByteArray,
+    ) : TestHttpMediaSource(mediaSourceId) {
+        override suspend fun fetchPreviewThumbnail(url: String): ByteArray = response
     }
 
     private class TestMediaFetcher(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -84,6 +84,8 @@ import kotlinx.coroutines.launch
 import me.him188.ani.app.data.models.preference.DarkMode
 import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
 import me.him188.ani.app.domain.comment.CommentContext
+import me.him188.ani.app.domain.episode.UnsafeEpisodeSessionApi
+import me.him188.ani.datasources.api.Media
 import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.platform.features.StreamType
@@ -922,8 +924,15 @@ private fun EpisodeVideo(
             vm.player.seekTo(it)
         },
     )
+    @OptIn(UnsafeEpisodeSessionApi::class)
+    val selectedMedia by vm.selectedMediaFlow.collectAsStateWithLifecycle(null)
     val framePreview = if (vm.videoScaffoldConfig.enableFramePreview) {
-        rememberMediaProgressFramePreviewState(vm.player)
+        rememberMediaProgressFramePreviewState(
+            vm.player,
+            httpClient = vm.framePreviewHttpClient,
+            previewThumbnails = selectedMedia?.extraFiles?.previewThumbnails,
+            requestThumbnail = vm.fetchPreviewThumbnail,
+        )
     } else {
         null
     }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -188,8 +188,8 @@ internal fun EpisodeVideoImpl(
     onClickNextEpisode: () -> Unit,
     playerControllerState: PlayerControllerState,
     opEdSkipDuration: Duration = DEFAULT_OP_ED_SKIP_DURATION,
-    onClickSkipOpEd: (currentPositionMillis: Long) -> Unit = {
-        playerState.skip(opEdSkipDuration.inWholeMilliseconds)
+    onClickSkipOpEd: (currentPositionMillis: Long) -> Unit = remember(playerState, opEdSkipDuration) {
+        { playerState.skip(opEdSkipDuration.inWholeMilliseconds) }
     },
     title: @Composable () -> Unit,
     danmakuHost: @Composable () -> Unit,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -79,7 +79,10 @@ import me.him188.ani.app.domain.episode.getCurrentEpisodeId
 import me.him188.ani.app.domain.episode.infoBundleFlow
 import me.him188.ani.app.domain.episode.infoLoadErrorFlow
 import me.him188.ani.app.domain.episode.mediaSelectorFlow
+import me.him188.ani.app.domain.foundation.HttpClientProvider
 import me.him188.ani.app.domain.foundation.LoadError
+import me.him188.ani.app.domain.foundation.get
+import me.him188.ani.datasources.api.Media
 import me.him188.ani.app.domain.media.cache.EpisodeCacheStatus
 import me.him188.ani.app.domain.media.cache.MediaCacheManager
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
@@ -256,6 +259,7 @@ class EpisodeViewModel(
 ) : KoinComponent, AbstractViewModel(), HasBackgroundScope {
     // region dependencies
     private val playerStateFactory: MediampPlayerFactory<*> by inject()
+    private val httpClientProvider: HttpClientProvider by inject()
     private val episodeCollectionRepository: EpisodeCollectionRepository by inject()
     private val mediaCacheManager: MediaCacheManager by inject()
     private val danmakuRepository: DanmakuRepository by inject()
@@ -283,6 +287,9 @@ class EpisodeViewModel(
 
     val player: MediampPlayer =
         playerStateFactory.create(context, backgroundScope.coroutineContext)
+    internal val framePreviewHttpClient = httpClientProvider.get()
+    internal val fetchPreviewThumbnail: suspend (String, String) -> ByteArray? =
+        mediaSourceManager::fetchPreviewThumbnail
 
     /** `null` 表示本次播放尚未调整过倍速, 此时跟随配置. */
     private val playbackSpeedOverride = MutableStateFlow<Float?>(null)
@@ -340,6 +347,10 @@ class EpisodeViewModel(
     )
 
     val mediaResolver: MediaResolver get() = fetchPlayState.playerSession.mediaResolver
+
+    @UnsafeEpisodeSessionApi
+    val selectedMediaFlow: Flow<Media?> = fetchPlayState.mediaSelectorFlow
+        .flatMapLatest { it?.selected ?: flowOfNull() }
 
     // region Subject and episode data info flows
     @UnsafeEpisodeSessionApi

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -759,6 +759,20 @@ class EpisodeViewModel(
     }
 
 
+    @OptIn(UnsafeEpisodeSessionApi::class, InternalMediampApi::class)
+    private val mediaChaptersFlow: Flow<List<Chapter>> = fetchPlayState.episodeSessionFlow.flatMapLatest { session ->
+        session.fetchSelectFlow.flatMapLatest { fetchSelect ->
+            fetchSelect?.mediaSelector?.selected?.map { media ->
+                media?.extraFiles?.chapters?.map {
+                    Chapter(it.name, it.durationMillis, it.offsetMillis)
+                } ?: emptyList()
+            } ?: flowOf(emptyList())
+        }
+    }.catch {
+        logger.warn(it) { "Failed to fetch media chapters" }
+    }
+
+    @OptIn(InternalMediampApi::class)
     private val combinedChaptersFlow: Flow<List<Chapter>> =
         combine(
             (player.chapters ?: flowOf(emptyList())),
@@ -766,7 +780,14 @@ class EpisodeViewModel(
                 emit(emptyList()) // 先给个空列表, 避免刚开始时因为等待网络而没有进度
                 emitAll(autoSkipChaptersFlow)
             },
-        ) { a, b -> if (b.isEmpty()) a else (a + b) }
+            flow {
+                emit(emptyList())
+                emitAll(mediaChaptersFlow)
+            },
+        ) { a, b, c ->
+            val extraChapters = if (c.isNotEmpty()) c else b
+            (a + extraChapters).distinctBy { Pair(it.name, it.offsetMillis) }
+        }
 
     // Chapters to be displayed on progress slider (merged with AutoSkip rules)
     val progressChaptersFlow: Flow<List<Chapter>> = combinedChaptersFlow

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -146,7 +145,11 @@ import me.him188.ani.app.ui.subject.episode.statistics.DanmakuStatistics
 import me.him188.ani.app.ui.subject.episode.statistics.VideoStatistics
 import me.him188.ani.app.ui.subject.episode.statistics.VideoStatisticsCollector
 import me.him188.ani.app.ui.subject.episode.video.PlayerSkipOpEdState
+import me.him188.ani.app.ui.subject.episode.video.SkipChapterCandidate
+import me.him188.ani.app.ui.subject.episode.video.isLikelyOpEdChapter
+import me.him188.ani.app.ui.subject.episode.video.mergeSkipChapterCandidates
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.EpisodeSelectorState
+import me.him188.ani.app.ui.subject.episode.video.toSkipChapterCandidateOrNull
 import me.him188.ani.app.ui.user.SelfInfoStateProducer
 import me.him188.ani.app.ui.user.SelfInfoUiState
 import me.him188.ani.app.videoplayer.ui.ControllerVisibility
@@ -161,6 +164,8 @@ import me.him188.ani.danmaku.ui.DanmakuConfig
 import me.him188.ani.danmaku.ui.DanmakuHostState
 import me.him188.ani.danmaku.ui.DanmakuPresentation
 import me.him188.ani.danmaku.ui.DanmakuTrackProperties
+import me.him188.ani.datasources.api.MediaChapter
+import me.him188.ani.datasources.api.MediaChapterKind
 import me.him188.ani.datasources.api.PackedDate
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSourceKind
@@ -717,13 +722,19 @@ class EpisodeViewModel(
         backgroundScope = backgroundScope,
     )
 
-    // Combine original chapters with AutoSkip rules fetched from server
+    @OptIn(InternalMediampApi::class)
+    private val playerChaptersFlow: Flow<List<Chapter>> = player.chapters ?: flowOf(emptyList())
+
+    private val playerVideoLengthFlow = player.mediaProperties
+        .map { it?.durationMillis?.milliseconds ?: 0.milliseconds }
+        .distinctUntilChanged()
+
     @OptIn(UnsafeEpisodeSessionApi::class, InternalMediampApi::class)
-    private val autoSkipChaptersFlow: Flow<List<Chapter>> = combine(
+    private val autoSkipChaptersFlow: Flow<List<SkipChapterCandidate>> = combine(
         fetchPlayState.episodeSessionFlow.flatMapLatest { session ->
             autoSkipRepository.rulesFlow(session.episodeId)
         },
-        player.mediaProperties.mapNotNull { it?.durationMillis?.milliseconds },
+        playerVideoLengthFlow,
         settingsRepository.videoScaffoldConfig.flow
             .map { it.opEdSkipDuration }
             .distinctUntilChanged(),
@@ -736,21 +747,23 @@ class EpisodeViewModel(
         if (durationMillis == 0L) {
             emptyList()
         } else {
-            millisecondTimes.mapIndexed { index, t ->
-                val name = if (millisecondTimes.size == 2) {
-                    val anotherIndex = if (index == 0) 1 else 0
-                    if (t <= millisecondTimes[anotherIndex]) {
-                        "OP"
-                    } else {
-                        "ED"
-                    }
+            millisecondTimes.sorted().mapIndexed { index, timeMillis ->
+                val kind = if (millisecondTimes.size == 2) {
+                    if (index == 0) MediaChapterKind.OPENING else MediaChapterKind.ENDING
                 } else {
-                    "Ch ${index + 1}"
+                    null
                 }
-                Chapter(
-                    name,
-                    durationMillis,
-                    t,
+                SkipChapterCandidate(
+                    chapter = Chapter(
+                        name = when (kind) {
+                            MediaChapterKind.OPENING -> "OP"
+                            MediaChapterKind.ENDING -> "ED"
+                            else -> "Ch ${index + 1}"
+                        },
+                        durationMillis = durationMillis,
+                        offsetMillis = timeMillis,
+                    ),
+                    kind = kind,
                 )
             }
         }
@@ -759,13 +772,11 @@ class EpisodeViewModel(
     }
 
 
-    @OptIn(UnsafeEpisodeSessionApi::class, InternalMediampApi::class)
-    private val mediaChaptersFlow: Flow<List<Chapter>> = fetchPlayState.episodeSessionFlow.flatMapLatest { session ->
+    @OptIn(UnsafeEpisodeSessionApi::class)
+    private val mediaChaptersFlow: Flow<List<MediaChapter>> = fetchPlayState.episodeSessionFlow.flatMapLatest { session ->
         session.fetchSelectFlow.flatMapLatest { fetchSelect ->
             fetchSelect?.mediaSelector?.selected?.map { media ->
-                media?.extraFiles?.chapters?.map {
-                    Chapter(it.name, it.durationMillis, it.offsetMillis)
-                } ?: emptyList()
+                media?.extraFiles?.chapters ?: emptyList()
             } ?: flowOf(emptyList())
         }
     }.catch {
@@ -773,34 +784,54 @@ class EpisodeViewModel(
     }
 
     @OptIn(InternalMediampApi::class)
-    private val combinedChaptersFlow: Flow<List<Chapter>> =
-        combine(
-            (player.chapters ?: flowOf(emptyList())),
-            flow {
-                emit(emptyList()) // 先给个空列表, 避免刚开始时因为等待网络而没有进度
-                emitAll(autoSkipChaptersFlow)
-            },
-            flow {
-                emit(emptyList())
-                emitAll(mediaChaptersFlow)
-            },
-        ) { a, b, c ->
-            val extraChapters = if (c.isNotEmpty()) c else b
-            (a + extraChapters).distinctBy { Pair(it.name, it.offsetMillis) }
-        }
+    private val explicitSkipChaptersFlow: Flow<List<SkipChapterCandidate>> = combine(
+        autoSkipChaptersFlow.onStart { emit(emptyList()) },
+        mediaChaptersFlow.onStart { emit(emptyList()) },
+    ) { autoSkipChapters, mediaChapters ->
+        mergeSkipChapterCandidates(
+            primary = mediaChapters.mapNotNull { it.toSkipChapterCandidateOrNull() },
+            fallback = autoSkipChapters,
+        )
+    }
 
-    // Chapters to be displayed on progress slider (merged with AutoSkip rules)
-    val progressChaptersFlow: Flow<List<Chapter>> = combinedChaptersFlow
+    @OptIn(InternalMediampApi::class)
+    private val playerSkipChaptersFlow: Flow<List<SkipChapterCandidate>> = combine(
+        playerChaptersFlow,
+        playerVideoLengthFlow,
+    ) { chapters, videoLength ->
+        chapters.mapNotNull { chapter ->
+            chapter.takeIf { isLikelyOpEdChapter(it, videoLength) }
+                ?.let { SkipChapterCandidate(it) }
+        }
+    }
+
+    private val skipChaptersFlow: Flow<List<Chapter>> = combine(
+        explicitSkipChaptersFlow,
+        playerSkipChaptersFlow,
+    ) { explicitChapters, playerChapters ->
+        mergeSkipChapterCandidates(explicitChapters, playerChapters).map { it.chapter }
+    }
+
+    @OptIn(InternalMediampApi::class)
+    val progressChaptersFlow: Flow<List<Chapter>> = combine(
+        playerChaptersFlow,
+        mediaChaptersFlow.onStart { emit(emptyList()) },
+        explicitSkipChaptersFlow,
+    ) { playerChapters, mediaChapters, skipChapters ->
+        val regularMediaChapters = mediaChapters
+            .filter { it.kind == MediaChapterKind.CHAPTER }
+            .map { Chapter(it.name, it.durationMillis, it.offsetMillis) }
+        (playerChapters + regularMediaChapters + skipChapters.map { it.chapter })
+            .distinctBy { Pair(it.name, it.offsetMillis) }
+    }
 
     val playerSkipOpEdState: PlayerSkipOpEdState = PlayerSkipOpEdState(
-        chapters = combinedChaptersFlow.produceState(emptyList()),
+        chapters = skipChaptersFlow.produceState(emptyList()),
         onSkip = {
             launchInBackground(Dispatchers.Main) {
                 player.seekTo(it)
             }
         },
-        videoLength = player.mediaProperties.mapNotNull { it?.durationMillis?.milliseconds }
-            .produceState(0.milliseconds),
     )
 
     private val matchingDanmakuProviderId = MutableStateFlow<DanmakuProviderId?>(null)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
@@ -90,9 +90,16 @@ private fun isOpEdChapter(chapter: Chapter, videoLength: Duration): Boolean {
 private fun isOpEdName(name: String): Boolean {
     val trimmed = name.trim().lowercase()
     if (trimmed.isEmpty()) return false
-    return trimmed == "op" || trimmed == "ed" ||
-            trimmed.contains("intro") || trimmed.contains("outro") ||
-            trimmed.contains("opening") || trimmed.contains("ending")
+    return trimmed == "op" ||
+            trimmed == "ed" ||
+            trimmed == "intro" ||
+            trimmed == "outro" ||
+            trimmed.contains("opening") ||
+            trimmed.contains("ending") ||
+            trimmed == "片头" ||
+            trimmed == "片尾" ||
+            trimmed == "片头曲" ||
+            trimmed == "片尾曲"
 }
 
 fun interface OpEdLength {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
@@ -16,6 +16,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
+import me.him188.ani.datasources.api.MediaChapter
+import me.him188.ani.datasources.api.MediaChapterKind
+import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.metadata.Chapter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -28,13 +31,10 @@ internal val DEFAULT_OP_ED_SKIP_DURATION = VideoScaffoldConfig.Default.opEdSkipD
 class PlayerSkipOpEdState(
     chapters: State<List<Chapter>>,
     private val onSkip: (targetMillis: Long) -> Unit,
-    videoLength: State<Duration>,
 ) {
     private var currentChapter: CurrentChapter? by mutableStateOf(null)
     private val opEdChapters by derivedStateOf {
-        chapters.value.filter { chapter ->
-            isOpEdChapter(chapter, videoLength.value)
-        }.map { CurrentChapter(chapter = it, false) }
+        chapters.value.map { CurrentChapter(chapter = it, false) }
     }
 
     val skipped: Boolean by derivedStateOf {
@@ -82,24 +82,42 @@ class CurrentChapter(val chapter: Chapter, skipped: Boolean) {
     var skipped by mutableStateOf(skipped)
 }
 
-private fun isOpEdChapter(chapter: Chapter, videoLength: Duration): Boolean {
-    if (isOpEdName(chapter.name)) return true
-    return OpEdLength.fromVideoLengthOrNull(videoLength)?.isOpEdChapter(chapter.durationMillis.milliseconds) == true
+internal data class SkipChapterCandidate(
+    val chapter: Chapter,
+    val kind: MediaChapterKind? = null,
+)
+
+@OptIn(InternalMediampApi::class)
+internal fun MediaChapter.toSkipChapterCandidateOrNull(): SkipChapterCandidate? {
+    if (kind == MediaChapterKind.CHAPTER) return null
+    return SkipChapterCandidate(
+        chapter = Chapter(name, durationMillis, offsetMillis),
+        kind = kind,
+    )
 }
 
-private fun isOpEdName(name: String): Boolean {
-    val trimmed = name.trim().lowercase()
-    if (trimmed.isEmpty()) return false
-    return trimmed == "op" ||
-            trimmed == "ed" ||
-            trimmed == "intro" ||
-            trimmed == "outro" ||
-            trimmed.contains("opening") ||
-            trimmed.contains("ending") ||
-            trimmed == "片头" ||
-            trimmed == "片尾" ||
-            trimmed == "片头曲" ||
-            trimmed == "片尾曲"
+internal fun mergeSkipChapterCandidates(
+    primary: List<SkipChapterCandidate>,
+    fallback: List<SkipChapterCandidate>,
+): List<SkipChapterCandidate> = buildList {
+    addAll(primary)
+    fallback.forEach { candidate ->
+        val alreadyCovered = candidate.kind?.let { kind ->
+            any { it.kind == kind }
+        } ?: any { chaptersOverlap(it.chapter, candidate.chapter) }
+        if (!alreadyCovered) add(candidate)
+    }
+}
+
+private fun chaptersOverlap(first: Chapter, second: Chapter): Boolean {
+    val firstEnd = first.offsetMillis + first.durationMillis
+    val secondEnd = second.offsetMillis + second.durationMillis
+    return first.offsetMillis < secondEnd && second.offsetMillis < firstEnd
+}
+
+internal fun isLikelyOpEdChapter(chapter: Chapter, videoLength: Duration): Boolean {
+    return OpEdLength.fromVideoLengthOrNull(videoLength)
+        ?.isOpEdChapter(chapter.durationMillis.milliseconds) == true
 }
 
 fun interface OpEdLength {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/PlayerSkipOpEdState.kt
@@ -32,9 +32,8 @@ class PlayerSkipOpEdState(
 ) {
     private var currentChapter: CurrentChapter? by mutableStateOf(null)
     private val opEdChapters by derivedStateOf {
-        chapters.value.filter {
-            OpEdLength.fromVideoLengthOrNull(videoLength.value)
-                ?.isOpEdChapter(it.durationMillis.milliseconds) == true
+        chapters.value.filter { chapter ->
+            isOpEdChapter(chapter, videoLength.value)
         }.map { CurrentChapter(chapter = it, false) }
     }
 
@@ -81,6 +80,19 @@ class PlayerSkipOpEdState(
 @Stable
 class CurrentChapter(val chapter: Chapter, skipped: Boolean) {
     var skipped by mutableStateOf(skipped)
+}
+
+private fun isOpEdChapter(chapter: Chapter, videoLength: Duration): Boolean {
+    if (isOpEdName(chapter.name)) return true
+    return OpEdLength.fromVideoLengthOrNull(videoLength)?.isOpEdChapter(chapter.durationMillis.milliseconds) == true
+}
+
+private fun isOpEdName(name: String): Boolean {
+    val trimmed = name.trim().lowercase()
+    if (trimmed.isEmpty()) return false
+    return trimmed == "op" || trimmed == "ed" ||
+            trimmed.contains("intro") || trimmed.contains("outro") ||
+            trimmed.contains("opening") || trimmed.contains("ending")
 }
 
 fun interface OpEdLength {

--- a/app/shared/src/commonTest/kotlin/ui/subject/episode/video/PlayerSkipOpEdStateTest.kt
+++ b/app/shared/src/commonTest/kotlin/ui/subject/episode/video/PlayerSkipOpEdStateTest.kt
@@ -10,10 +10,14 @@
 package me.him188.ani.app.ui.subject.episode.video
 
 import me.him188.ani.app.ui.foundation.stateOf
+import me.him188.ani.datasources.api.MediaChapter
+import me.him188.ani.datasources.api.MediaChapterKind
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.metadata.Chapter
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 
 @OptIn(InternalMediampApi::class)
@@ -21,17 +25,12 @@ class PlayerSkipOpEdStateTest {
     class `OP chapter on start` {
         private val opChapterOnStart = listOf(
             Chapter("chapter1 op", 80_000L, 0),
-            Chapter("chapter2", 10_000L, 100_000L),
-            Chapter("chapter3", 10_000L, 110_000L),
         )
-
-        private val videoLength = 24.minutes
 
         private fun createState_opChapterOnStart_24minutes(onSkip: (targetMillis: Long) -> Unit = {}): PlayerSkipOpEdState {
             return PlayerSkipOpEdState(
                 stateOf(opChapterOnStart),
                 onSkip = onSkip,
-                stateOf(videoLength),
             )
         }
 
@@ -117,18 +116,13 @@ class PlayerSkipOpEdStateTest {
     class `OP chapter on chapter 2` {
 
         private val opChapterOnChapter2 = listOf(
-            Chapter("chapter1", 10_000L, 0),
             Chapter("chapter2 op", 90_000L, 10_000L),
-            Chapter("chapter3", 10_000L, 110_000L),
         )
-
-        private val videoLength = 24.minutes
 
         private fun createState_opChapterOnChapter2_24minutes(onSkip: (targetMillis: Long) -> Unit = {}): PlayerSkipOpEdState {
             return PlayerSkipOpEdState(
                 stateOf(opChapterOnChapter2),
                 onSkip = onSkip,
-                stateOf(videoLength),
             )
         }
 
@@ -415,9 +409,9 @@ class PlayerSkipOpEdStateTest {
         }
     }
 
-    class `OP chapter recognized by name` {
+    class `explicit OP chapter` {
         @Test
-        fun `intro chapter with non-standard duration is recognized`() {
+        fun `chapter with non-standard duration is skipped`() {
             val chapters = listOf(
                 Chapter("Intro", 70_000L, 10_000L),
                 Chapter("Outro", 60_000L, 1_000_000L),
@@ -426,13 +420,77 @@ class PlayerSkipOpEdStateTest {
             val state = PlayerSkipOpEdState(
                 stateOf(chapters),
                 onSkip = { skippedMillis = it },
-                stateOf(24.minutes),
             )
             state.update(7_000L)
             assertEquals(true, state.showSkipTips)
 
             state.update(10_000L)
             assertEquals(80_000L, skippedMillis)
+        }
+    }
+
+    class `chapter candidate selection` {
+        @Test
+        fun `regular media chapter is never a skip candidate regardless of name or duration`() {
+            val chapter = MediaChapter(
+                name = "Opening Scene",
+                durationMillis = 85_000L,
+                offsetMillis = 10_000L,
+            )
+
+            assertEquals(null, chapter.toSkipChapterCandidateOrNull())
+            assertEquals(null, chapter.copy(name = "Intro").toSkipChapterCandidateOrNull())
+        }
+
+        @Test
+        fun `typed media opening is a skip candidate regardless of duration`() {
+            val chapter = MediaChapter(
+                name = "OP",
+                durationMillis = 70_000L,
+                offsetMillis = 10_000L,
+                kind = MediaChapterKind.OPENING,
+            )
+
+            assertEquals(MediaChapterKind.OPENING, chapter.toSkipChapterCandidateOrNull()?.kind)
+        }
+
+        @Test
+        fun `player chapter heuristic uses duration but never name`() {
+            assertTrue(
+                isLikelyOpEdChapter(
+                    Chapter("Anything", 85_000L, 10_000L),
+                    24.minutes,
+                ),
+            )
+            assertFalse(
+                isLikelyOpEdChapter(
+                    Chapter("Opening Scene", 7 * 60_000L, 10_000L),
+                    24.minutes,
+                ),
+            )
+        }
+
+        @Test
+        fun `media opening only replaces online opening`() {
+            val mediaOpening = SkipChapterCandidate(
+                Chapter("OP", 70_000L, 10_000L),
+                MediaChapterKind.OPENING,
+            )
+            val onlineOpening = SkipChapterCandidate(
+                Chapter("OP", 85_000L, 12_000L),
+                MediaChapterKind.OPENING,
+            )
+            val onlineEnding = SkipChapterCandidate(
+                Chapter("ED", 85_000L, 1_200_000L),
+                MediaChapterKind.ENDING,
+            )
+
+            val merged = mergeSkipChapterCandidates(
+                primary = listOf(mediaOpening),
+                fallback = listOf(onlineOpening, onlineEnding),
+            )
+
+            assertEquals(listOf(mediaOpening, onlineEnding), merged)
         }
     }
 }

--- a/app/shared/src/commonTest/kotlin/ui/subject/episode/video/PlayerSkipOpEdStateTest.kt
+++ b/app/shared/src/commonTest/kotlin/ui/subject/episode/video/PlayerSkipOpEdStateTest.kt
@@ -414,4 +414,25 @@ class PlayerSkipOpEdStateTest {
             assertEquals(true, localState.skipped)
         }
     }
+
+    class `OP chapter recognized by name` {
+        @Test
+        fun `intro chapter with non-standard duration is recognized`() {
+            val chapters = listOf(
+                Chapter("Intro", 70_000L, 10_000L),
+                Chapter("Outro", 60_000L, 1_000_000L),
+            )
+            var skippedMillis = 0L
+            val state = PlayerSkipOpEdState(
+                stateOf(chapters),
+                onSkip = { skippedMillis = it },
+                stateOf(24.minutes),
+            )
+            state.update(7_000L)
+            assertEquals(true, state.showSkipTips)
+
+            state.update(10_000L)
+            assertEquals(80_000L, skippedMillis)
+        }
+    }
 }

--- a/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/ImageIO.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/ImageIO.android.kt
@@ -36,4 +36,3 @@ actual fun cropImageToSquare(imageData: ByteArray, crop: CropRect, outputSize: I
     scaled.compress(Bitmap.CompressFormat.JPEG, jpegQuality.coerceIn(1, 100), baos)
     return baos.toByteArray()
 }
-

--- a/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/ImageUtils.android.kt
+++ b/app/shared/ui-foundation/src/androidMain/kotlin/ui/foundation/ImageUtils.android.kt
@@ -26,3 +26,12 @@ actual fun ImageBitmap.resize(
 ): ImageBitmap {
     return this.asAndroidBitmap().scale(width, height).asImageBitmap()
 }
+
+actual fun ImageBitmap.crop(
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+): ImageBitmap {
+    return android.graphics.Bitmap.createBitmap(this.asAndroidBitmap(), x, y, width, height).asImageBitmap()
+}

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageIO.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageIO.kt
@@ -22,4 +22,3 @@ data class CropRect(val x: Int, val y: Int, val size: Int)
  * Crop a square region from [imageData] and return JPEG bytes of [outputSize] x [outputSize].
  */
 expect fun cropImageToSquare(imageData: ByteArray, crop: CropRect, outputSize: Int, jpegQuality: Int = 90): ByteArray
-

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageUtils.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageUtils.kt
@@ -20,6 +20,13 @@ expect fun ImageBitmap.resize(
     height: Int,
 ): ImageBitmap
 
+expect fun ImageBitmap.crop(
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+): ImageBitmap
+
 /**
  * Determine the main color in a [ImageBitmap].
  *

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/ImageIODesktopTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/ImageIODesktopTest.kt
@@ -91,4 +91,5 @@ class ImageIODesktopTest {
         val b = color and 0xFF
         assertTrue(r > 200 && g < 80 && b < 80, "Center pixel not red-ish after clamp: r=$r g=$g b=$b")
     }
+
 }

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/ImageUtilsTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/ImageUtilsTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.foundation
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.toPixelMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImageUtilsTest {
+    @Test
+    fun testImageBitmapCropCoordinatesAndDimensions() {
+        val original = ImageBitmap(width = 4, height = 2)
+        val canvas = Canvas(original)
+        canvas.drawRect(Rect(Offset.Zero, Size(2f, 2f)), Paint().apply { color = Color.Red })
+        canvas.drawRect(Rect(Offset(2f, 0f), Size(2f, 2f)), Paint().apply { color = Color.Blue })
+
+        val cropped = original.crop(x = 2, y = 0, width = 2, height = 2)
+        assertEquals(2, cropped.width)
+        assertEquals(2, cropped.height)
+        assertEquals(Color.Blue, cropped.toPixelMap()[0, 0])
+        assertEquals(Color.Blue, cropped.toPixelMap()[1, 1])
+    }
+}

--- a/app/shared/ui-foundation/src/skikoMain/kotlin/ui/foundation/ImageUtils.skiko.kt
+++ b/app/shared/ui-foundation/src/skikoMain/kotlin/ui/foundation/ImageUtils.skiko.kt
@@ -51,3 +51,39 @@ actual fun ImageBitmap.resize(
     // 获取缩放后图片的快照，并转换为 Compose 的 ImageBitmap
     return surface.makeImageSnapshot().toComposeImageBitmap()
 }
+
+actual fun ImageBitmap.crop(
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+): ImageBitmap {
+    val skiaBitmap = this.asSkiaBitmap()
+
+    val imageInfo = ImageInfo.makeN32Premul(width, height)
+    val surface = Surface.makeRaster(imageInfo)
+    try {
+        val originalImage = SkiaImage.makeFromBitmap(skiaBitmap)
+        try {
+            val paint = Paint()
+            try {
+                val srcRect = Rect(x.toFloat(), y.toFloat(), (x + width).toFloat(), (y + height).toFloat())
+                val destRect = Rect(0f, 0f, width.toFloat(), height.toFloat())
+                surface.canvas.drawImageRect(originalImage, srcRect, destRect, paint)
+            } finally {
+                paint.close()
+            }
+        } finally {
+            originalImage.close()
+        }
+
+        val snapshot = surface.makeImageSnapshot()
+        try {
+            return snapshot.toComposeImageBitmap()
+        } finally {
+            snapshot.close()
+        }
+    } finally {
+        surface.close()
+    }
+}

--- a/app/shared/video-player/build.gradle.kts
+++ b/app/shared/video-player/build.gradle.kts
@@ -30,10 +30,13 @@ kotlin {
         api(libs.mediamp.api)
         api(libs.kotlinx.coroutines.core)
         api(projects.utils.coroutines)
+        api(projects.utils.ktorClient)
+        api(libs.ktor.client.core)
         api(projects.danmaku.danmakuApi)
     }
     sourceSets.commonTest.dependencies {
         implementation(projects.utils.uiTesting)
+        implementation(libs.ktor.client.mock)
     }
     sourceSets.androidMain.dependencies {
         implementation(libs.compose.material3.adaptive.core)

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressFramePreview.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressFramePreview.kt
@@ -20,7 +20,17 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.prepareGet
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import me.him188.ani.app.ui.foundation.crop
+import me.him188.ani.app.ui.foundation.decodeImageBitmap
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
+import me.him188.ani.utils.ktor.ScopedHttpClient
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.PreviewFrame
@@ -59,6 +69,7 @@ class MediaProgressFramePreviewState(
         private set
 
     private var frameGridKey = Long.MIN_VALUE
+    private var mediaGeneration = 0L
     private val cache = androidx.collection.LruCache<Long, ImageBitmap>(cacheSize)
 
     private fun gridKeyOf(positionMillis: Long): Long =
@@ -69,6 +80,7 @@ class MediaProgressFramePreviewState(
      * 缓存命中立即显示; 加载成功前保留上一帧, 避免闪烁.
      */
     internal suspend fun requestFrame(positionMillis: Long) {
+        val generation = mediaGeneration
         val key = gridKeyOf(positionMillis)
         if (key == frameGridKey && frame != null) return
         cache[key]?.let {
@@ -78,6 +90,7 @@ class MediaProgressFramePreviewState(
         }
         delay(debounceMillis) // debounce: 快速滑动时, 更新的位置会取消本次请求
         val newFrame = fetchFrame(alignToGrid(key, positionMillis)) ?: return
+        if (generation != mediaGeneration) return
         cache.put(key, newFrame)
         frame = newFrame
         frameGridKey = key
@@ -88,9 +101,11 @@ class MediaProgressFramePreviewState(
      * 用于播放开始时提前启动预览解码器.
      */
     suspend fun prewarm(positionMillis: Long) {
+        val generation = mediaGeneration
         val key = gridKeyOf(positionMillis)
         if (cache[key] != null) return
         val newFrame = fetchFrame(alignToGrid(key, positionMillis)) ?: return
+        if (generation != mediaGeneration) return
         cache.put(key, newFrame)
     }
 
@@ -109,6 +124,7 @@ class MediaProgressFramePreviewState(
      * 媒体切换时清空缓存, 避免展示上一个视频的帧.
      */
     fun onMediaChanged() {
+        mediaGeneration++
         cache.evictAll()
         frame = null
         frameGridKey = Long.MIN_VALUE
@@ -116,38 +132,153 @@ class MediaProgressFramePreviewState(
 }
 
 /**
- * 从 [player] 的 [FramePreview] feature 创建 [MediaProgressFramePreviewState].
+ * 从 [player] 的 [FramePreview] feature 或 [previewThumbnails] 创建 [MediaProgressFramePreviewState].
  *
- * 当播放器后端不支持取帧时返回 `null`, 此时进度条浮窗只显示时间.
+ * 优先使用数据源提供的 [previewThumbnails]（如 Jellyfin/Emby 的 Trickplay 拼图大图），
+ * 避免在 HTTP 播放时进行二次视频解码；若无预生成缩略图，则回退到播放器解码器 [FramePreview]。
  */
 @Composable
 fun rememberMediaProgressFramePreviewState(
     player: MediampPlayer,
+    httpClient: ScopedHttpClient,
+    previewThumbnails: MediaPreviewThumbnails? = null,
+    requestThumbnail: (suspend (mediaSourceId: String, url: String) -> ByteArray?)? = null,
     maxWidth: Dp = 192.dp,
     maxHeight: Dp = 128.dp,
 ): MediaProgressFramePreviewState? {
-    val framePreview = remember(player) { player.features[FramePreview] } ?: return null
     val density = LocalDensity.current
-    val state = remember(framePreview, density, maxWidth, maxHeight) {
+    val framePreviewFeature = remember(player) { player.features[FramePreview] }
+    val tileFetcher = remember(previewThumbnails, httpClient, requestThumbnail) {
+        previewThumbnails?.let { MediaPreviewThumbnailsTileFetcher(it, httpClient, requestThumbnail) }
+    }
+
+    if (tileFetcher == null && framePreviewFeature == null) return null
+
+    val state = remember(tileFetcher, framePreviewFeature, density, maxWidth, maxHeight) {
         val maxWidthPx = with(density) { maxWidth.roundToPx() }
         val maxHeightPx = with(density) { maxHeight.roundToPx() }
         MediaProgressFramePreviewState(
             fetchFrame = { positionMillis ->
-                framePreview.getPreviewFrame(positionMillis, maxWidthPx, maxHeightPx)?.toImageBitmap()
+                tileFetcher?.fetchFrame(positionMillis)
+                    ?: framePreviewFeature?.getPreviewFrame(positionMillis, maxWidthPx, maxHeightPx)?.toImageBitmap()
             },
         )
     }
     LaunchedEffect(state, player) {
         player.mediaData.collect { data ->
             state.onMediaChanged()
-            if (data != null) {
-                // 预热预览解码器 (第二个解码器实例启动需要秒级时间), 避免首次悬浮时长时间显示占位框.
-                // 取当前播放位置附近的帧: 该区域一定已在缓冲, 不会抢占下载优先级.
+            if (data != null && tileFetcher == null) {
+                // 预热预览解码器 (仅在无预生成缩略图时), 避免首次悬浮时长时间显示占位框.
                 runCatching { state.prewarm(player.getCurrentPositionMillis()) }
             }
         }
     }
     return state
+}
+
+/**
+ * 负责拉取和裁剪 [MediaPreviewThumbnails.Layout.SpriteTile] 精灵图网格缩略图。
+ */
+class MediaPreviewThumbnailsTileFetcher(
+    private val previewThumbnails: MediaPreviewThumbnails,
+    private val httpClient: ScopedHttpClient,
+    private val requestThumbnail: (suspend (mediaSourceId: String, url: String) -> ByteArray?)? = null,
+) {
+    private val tileCache = androidx.collection.LruCache<Int, ImageBitmap>(1)
+
+    suspend fun fetchFrame(positionMillis: Long): ImageBitmap? {
+        val layout = previewThumbnails.layout as? MediaPreviewThumbnails.Layout.SpriteTile ?: return null
+        val frame = calculateSpriteTileFrame(previewThumbnails, layout, positionMillis) ?: return null
+
+        val tileImage = getOrFetchTileImage(layout.urlPattern, frame.tileIndex) ?: return null
+
+        if (frame.cropX.toLong() + previewThumbnails.width > tileImage.width.toLong() ||
+            frame.cropY.toLong() + previewThumbnails.height > tileImage.height.toLong()
+        ) {
+            return null
+        }
+
+        return try {
+            withContext(Dispatchers.Default) {
+                tileImage.crop(frame.cropX, frame.cropY, previewThumbnails.width, previewThumbnails.height)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private suspend fun getOrFetchTileImage(
+        urlPattern: String,
+        tileIndex: Int,
+    ): ImageBitmap? {
+        tileCache[tileIndex]?.let { return it }
+
+        val url = urlPattern.replace("{tileIndex}", tileIndex.toString())
+        val bytes = try {
+            val requesterMediaSourceId = previewThumbnails.requesterMediaSourceId
+            if (requesterMediaSourceId == null) {
+                httpClient.use {
+                    prepareGet(url) {
+                        previewThumbnails.headers.forEach { (key, value) ->
+                            header(key, value)
+                        }
+                    }.execute { response ->
+                        response.body<ByteArray>()
+                    }
+                }
+            } else {
+                requestThumbnail?.invoke(requesterMediaSourceId, url) ?: return null
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            return null
+        }
+
+        val bitmap = try {
+            withContext(Dispatchers.Default) {
+                decodeImageBitmap(bytes)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            return null
+        }
+        tileCache.put(tileIndex, bitmap)
+        return bitmap
+    }
+}
+
+internal data class SpriteTileFrame(
+    val tileIndex: Int,
+    val cropX: Int,
+    val cropY: Int,
+)
+
+internal fun calculateSpriteTileFrame(
+    previewThumbnails: MediaPreviewThumbnails,
+    layout: MediaPreviewThumbnails.Layout.SpriteTile,
+    positionMillis: Long,
+): SpriteTileFrame? {
+    if (previewThumbnails.width <= 0 || previewThumbnails.height <= 0 ||
+        previewThumbnails.intervalMillis <= 0 || previewThumbnails.totalCount <= 0 ||
+        layout.columns <= 0 || layout.rows <= 0
+    ) {
+        return null
+    }
+
+    val frameIndex = (positionMillis.coerceAtLeast(0) / previewThumbnails.intervalMillis)
+        .coerceAtMost(previewThumbnails.totalCount.toLong() - 1)
+    val tilesPerSheet = layout.columns.toLong() * layout.rows
+    val indexInTile = frameIndex % tilesPerSheet
+    val tileIndex = frameIndex / tilesPerSheet
+    val cropX = (indexInTile % layout.columns) * previewThumbnails.width
+    val cropY = (indexInTile / layout.columns) * previewThumbnails.height
+    if (tileIndex > Int.MAX_VALUE || cropX > Int.MAX_VALUE || cropY > Int.MAX_VALUE) return null
+
+    return SpriteTileFrame(tileIndex.toInt(), cropX.toInt(), cropY.toInt())
 }
 
 /**

--- a/app/shared/video-player/src/commonTest/kotlin/ui/progress/MediaPreviewThumbnailsTileFetcherTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/progress/MediaPreviewThumbnailsTileFetcherTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class MediaPreviewThumbnailsTileFetcherTest {
+    @Test
+    fun testTileIndexAndCoordinatesCalculation() {
+        val thumbnails = thumbnails(
+            width = 320,
+            height = 180,
+            intervalMillis = 10_000L,
+            totalCount = 240,
+        )
+        val layout = thumbnails.layout as MediaPreviewThumbnails.Layout.SpriteTile
+
+        assertEquals(SpriteTileFrame(tileIndex = 0, cropX = 0, cropY = 0), calculateSpriteTileFrame(thumbnails, layout, 0))
+        assertEquals(
+            SpriteTileFrame(tileIndex = 0, cropX = 1_600, cropY = 0),
+            calculateSpriteTileFrame(thumbnails, layout, 55_000),
+        )
+        assertEquals(
+            SpriteTileFrame(tileIndex = 1, cropX = 0, cropY = 0),
+            calculateSpriteTileFrame(thumbnails, layout, 1_000_000),
+        )
+        assertEquals(
+            SpriteTileFrame(tileIndex = 1, cropX = 1_600, cropY = 0),
+            calculateSpriteTileFrame(thumbnails, layout, 1_050_000),
+        )
+        assertEquals(
+            SpriteTileFrame(tileIndex = 2, cropX = 2_880, cropY = 540),
+            calculateSpriteTileFrame(thumbnails, layout, Long.MAX_VALUE),
+        )
+    }
+
+    @Test
+    fun testInvalidAndOverflowingMetadataIsRejected() {
+        val zeroCount = thumbnails(totalCount = 0)
+        assertNull(calculateSpriteTileFrame(zeroCount, zeroCount.layout as MediaPreviewThumbnails.Layout.SpriteTile, 0))
+
+        val overflowing = thumbnails(
+            width = Int.MAX_VALUE,
+            totalCount = 3,
+            columns = Int.MAX_VALUE,
+            rows = 1,
+        )
+        assertNull(
+            calculateSpriteTileFrame(
+                overflowing,
+                overflowing.layout as MediaPreviewThumbnails.Layout.SpriteTile,
+                20_000,
+            ),
+        )
+    }
+
+    @Test
+    fun testFetchPropagatesCancellation() = runTest {
+        val requestStarted = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine {
+            requestStarted.complete(Unit)
+            awaitCancellation()
+        })
+        try {
+            val fetcher = MediaPreviewThumbnailsTileFetcher(thumbnails(), client.asScopedHttpClient())
+            val fetch = async { fetcher.fetchFrame(0) }
+            requestStarted.await()
+            fetch.cancel()
+            assertFailsWith<CancellationException> { fetch.await() }
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun thumbnails(
+        width: Int = 320,
+        height: Int = 180,
+        intervalMillis: Long = 10_000,
+        totalCount: Int = 240,
+        columns: Int = 10,
+        rows: Int = 10,
+    ) = MediaPreviewThumbnails(
+        width = width,
+        height = height,
+        intervalMillis = intervalMillis,
+        totalCount = totalCount,
+        layout = MediaPreviewThumbnails.Layout.SpriteTile(
+            columns = columns,
+            rows = rows,
+            urlPattern = "https://example.com/tiles/{tileIndex}.jpg",
+        ),
+    )
+}

--- a/app/shared/video-player/src/desktopTest/kotlin/ui/progress/MediaPreviewThumbnailsTileFetcherTest.kt
+++ b/app/shared/video-player/src/desktopTest/kotlin/ui/progress/MediaPreviewThumbnailsTileFetcherTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import androidx.compose.ui.graphics.ImageBitmap
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class MediaPreviewThumbnailsTileFetcherDesktopTest {
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun testFetchUsesInjectedClientHeadersAndTileCache() = runTest {
+        var requestCount = 0
+        val client = HttpClient(MockEngine { request ->
+            requestCount++
+            assertEquals("https://example.com/tiles/0.jpg", request.url.toString())
+            assertEquals("token", request.headers["Authorization"])
+            respond(Base64.decode(ONE_PIXEL_PNG))
+        })
+        try {
+            val fetcher = MediaPreviewThumbnailsTileFetcher(
+                thumbnails(
+                    width = 1,
+                    height = 1,
+                    intervalMillis = 10_000,
+                    totalCount = 1,
+                    columns = 1,
+                    rows = 1,
+                    headers = mapOf("Authorization" to "token"),
+                ),
+                client.asScopedHttpClient(),
+            )
+
+            assertNotNull(fetcher.fetchFrame(0))
+            assertNotNull(fetcher.fetchFrame(0))
+            assertEquals(1, requestCount)
+        } finally {
+            client.close()
+        }
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun testFetchUsesMediaSourceRequesterAndTileCache() = runTest {
+        var requestCount = 0
+        val client = HttpClient(MockEngine { error("Direct HTTP request is not expected") })
+        try {
+            val fetcher = MediaPreviewThumbnailsTileFetcher(
+                thumbnails(
+                    width = 1,
+                    height = 1,
+                    intervalMillis = 10_000,
+                    totalCount = 1,
+                    columns = 1,
+                    rows = 1,
+                    requesterMediaSourceId = "jellyfin-instance",
+                ),
+                client.asScopedHttpClient(),
+            ) { mediaSourceId, url ->
+                requestCount++
+                assertEquals("jellyfin-instance", mediaSourceId)
+                assertEquals("https://example.com/tiles/0.jpg", url)
+                Base64.decode(ONE_PIXEL_PNG)
+            }
+
+            assertNotNull(fetcher.fetchFrame(0))
+            assertNotNull(fetcher.fetchFrame(0))
+            assertEquals(1, requestCount)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun testOldMediaRequestCannotRepopulateState() = runTest {
+        val firstRequest = CompletableDeferred<ImageBitmap?>()
+        val requestStarted = CompletableDeferred<Unit>()
+        val image = ImageBitmap(1, 1)
+        var requestCount = 0
+        val state = MediaProgressFramePreviewState(
+            fetchFrame = {
+                requestCount++
+                if (requestCount == 1) {
+                    requestStarted.complete(Unit)
+                    firstRequest.await()
+                } else {
+                    image
+                }
+            },
+            debounceMillis = 0,
+        )
+
+        val oldRequest = async { state.requestFrame(0) }
+        requestStarted.await()
+        state.onMediaChanged()
+        firstRequest.complete(image)
+        oldRequest.await()
+        assertNull(state.frame)
+
+        state.requestFrame(0)
+        assertEquals(2, requestCount)
+        assertEquals(image, state.frame)
+    }
+
+    private fun thumbnails(
+        width: Int = 320,
+        height: Int = 180,
+        intervalMillis: Long = 10_000,
+        totalCount: Int = 240,
+        columns: Int = 10,
+        rows: Int = 10,
+        headers: Map<String, String> = emptyMap(),
+        requesterMediaSourceId: String? = null,
+    ) = MediaPreviewThumbnails(
+        width = width,
+        height = height,
+        intervalMillis = intervalMillis,
+        totalCount = totalCount,
+        layout = MediaPreviewThumbnails.Layout.SpriteTile(
+            columns = columns,
+            rows = rows,
+            urlPattern = "https://example.com/tiles/{tileIndex}.jpg",
+        ),
+        headers = headers,
+        requesterMediaSourceId = requesterMediaSourceId,
+    )
+
+    private companion object {
+        const val ONE_PIXEL_PNG =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    }
+}

--- a/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
+++ b/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
@@ -18,9 +18,42 @@ import kotlinx.serialization.Serializable
 class MediaExtraFiles(
     val subtitles: List<Subtitle> = emptyList(),
     val chapters: List<MediaChapter> = emptyList(),
+    val previewThumbnails: MediaPreviewThumbnails? = null,
 ) {
     companion object {
         val EMPTY = MediaExtraFiles()
+    }
+}
+
+/**
+ * 通用的进度条预览缩略图信息，适用于 Jellyfin, Emby, Plex, YouTube Sprite Tiles 等各类视频数据源。
+ */
+@Serializable
+data class MediaPreviewThumbnails(
+    val width: Int,
+    val height: Int,
+    val intervalMillis: Long,
+    val totalCount: Int,
+    val layout: Layout,
+    val headers: Map<String, String> = emptyMap(),
+    val requesterMediaSourceId: String? = null,
+) {
+    @Serializable
+    sealed interface Layout {
+        /**
+         * 精灵图（Sprite Tile）拼图网格布局（如 Jellyfin/Emby/Plex/YouTube）。
+         * 每个大图包含 [columns] 列 x [rows] 行个小缩略图。
+         */
+        @Serializable
+        data class SpriteTile(
+            val columns: Int,
+            val rows: Int,
+            /**
+             * 拼图大图的 URL 模板，如 `https://example.com/tiles/{tileIndex}.jpg`。
+             * `{tileIndex}` 会被替换为 0, 1, 2...
+             */
+            val urlPattern: String,
+        ) : Layout
     }
 }
 

--- a/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
+++ b/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
@@ -17,11 +17,19 @@ import kotlinx.serialization.Serializable
 @Serializable
 class MediaExtraFiles(
     val subtitles: List<Subtitle> = emptyList(),
+    val chapters: List<MediaChapter> = emptyList(),
 ) {
     companion object {
         val EMPTY = MediaExtraFiles()
     }
 }
+
+@Serializable
+data class MediaChapter(
+    val name: String,
+    val durationMillis: Long,
+    val offsetMillis: Long,
+)
 
 @Serializable
 data class Subtitle(

--- a/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
+++ b/datasource/api/src/commonMain/kotlin/MediaExtraFiles.kt
@@ -29,7 +29,15 @@ data class MediaChapter(
     val name: String,
     val durationMillis: Long,
     val offsetMillis: Long,
+    val kind: MediaChapterKind = MediaChapterKind.CHAPTER,
 )
+
+@Serializable
+enum class MediaChapterKind {
+    CHAPTER,
+    OPENING,
+    ENDING,
+}
 
 @Serializable
 data class Subtitle(

--- a/datasource/api/src/commonMain/kotlin/source/MediaSource.kt
+++ b/datasource/api/src/commonMain/kotlin/source/MediaSource.kt
@@ -116,6 +116,13 @@ interface MediaSource : AutoCloseable {
      */
     suspend fun fetch(query: MediaFetchRequest): SizedSource<MediaMatch>
 
+    /**
+     * 下载由此数据源提供的进度预览缩略图资源.
+     *
+     * 数据源可覆写此方法以附加认证信息或刷新已过期的凭据.
+     */
+    suspend fun fetchPreviewThumbnail(url: String): ByteArray? = null
+
     override fun close() {}
 }
 

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -29,6 +29,7 @@ import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.MediaChapter
 import me.him188.ani.datasources.api.MediaChapterKind
 import me.him188.ani.datasources.api.MediaExtraFiles
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
 import me.him188.ani.datasources.api.MediaProperties
 import me.him188.ani.datasources.api.Subtitle
 import me.him188.ani.datasources.api.SubtitleKind
@@ -51,6 +52,7 @@ abstract class BaseJellyfinMediaSource(
     private val client: ScopedHttpClient,
 ) : HttpMediaSource() {
     abstract val baseUrl: String
+    protected open val itemFields: String = "MediaStreams,Chapters"
 
     protected data class Authorization(
         val userId: String,
@@ -66,6 +68,11 @@ abstract class BaseJellyfinMediaSource(
      * @return `true` when the request can be retried with a newly acquired authorization.
      */
     protected open suspend fun invalidateAuthorization(authorization: Authorization): Boolean = false
+
+    internal open fun createPreviewThumbnails(
+        itemId: String,
+        trickplay: Map<String, Map<String, JellyfinTrickplayManifestDto>>?,
+    ): MediaPreviewThumbnails? = null
 
     override suspend fun checkConnection(): ConnectionStatus {
         try {
@@ -163,6 +170,7 @@ abstract class BaseJellyfinMediaSource(
                             extraFiles = MediaExtraFiles(
                                 subtitles = getSubtitles(item.Id, item.MediaStreams),
                                 chapters = emptyList(),
+                                previewThumbnails = createPreviewThumbnails(item.Id, item.Trickplay),
                             ),
                             episodeRange = episodeRange,
                             location = MediaSourceLocation.Lan,
@@ -184,6 +192,7 @@ abstract class BaseJellyfinMediaSource(
                                 extraFiles = MediaExtraFiles(
                                     subtitles = media.extraFiles.subtitles,
                                     chapters = chapters,
+                                    previewThumbnails = media.extraFiles.previewThumbnails,
                                 ),
                             ),
                         )
@@ -341,7 +350,7 @@ abstract class BaseJellyfinMediaSource(
     private suspend fun doGetEpisodes(seriesId: String, seasonNum: Int): SearchResponse {
         return authorizedGet("$baseUrl/Shows/$seriesId/Episodes") {
             parameter("Season", seasonNum)
-            parameter("fields", "MediaStreams,Chapters")
+            parameter("fields", itemFields)
         }
     }
 
@@ -354,7 +363,7 @@ abstract class BaseJellyfinMediaSource(
             parameter("enableImages", false)
             parameter("recursive", recursive)
             parameter("searchTerm", subjectName)
-            parameter("fields", "MediaStreams,Chapters")
+            parameter("fields", itemFields)
             parameter("parentId", parentId)
         }
     }
@@ -413,6 +422,8 @@ abstract class BaseJellyfinMediaSource(
             authorization = getAuthorization()
         }
     }
+
+    override suspend fun fetchPreviewThumbnail(url: String): ByteArray = authorizedGet(url)
 }
 
 private class JellyfinAuthorizationException :
@@ -552,4 +563,5 @@ private data class Item(
     val MediaStreams: List<MediaStream> = emptyList(),
     val Chapters: List<ChapterInfoDto> = emptyList(),
     val RunTimeTicks: Long? = null,
+    val Trickplay: Map<String, Map<String, JellyfinTrickplayManifestDto>>? = null,
 )

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.Serializable
 import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.MediaChapter
+import me.him188.ani.datasources.api.MediaChapterKind
 import me.him188.ani.datasources.api.MediaExtraFiles
 import me.him188.ani.datasources.api.MediaProperties
 import me.him188.ani.datasources.api.Subtitle
@@ -218,35 +219,58 @@ abstract class BaseJellyfinMediaSource(
         val itemId = item.Id
 
         // 1. Try Jellyfin 10.10+ native MediaSegments API
-        val nativeSegments = runCatching { doGetMediaSegments(itemId) }.getOrNull()
-        if (nativeSegments != null && nativeSegments.Items.isNotEmpty()) {
-            val chapters = nativeSegments.Items.mapNotNull { segment ->
-                val name = when (segment.Type.lowercase()) {
-                    "intro" -> "OP"
-                    "outro" -> "ED"
-                    else -> return@mapNotNull null
-                }
-                val offsetMillis = segment.StartTicks / 10000
-                val durationMillis = (segment.EndTicks - segment.StartTicks) / 10000
-                MediaChapter(name = name, durationMillis = durationMillis, offsetMillis = offsetMillis)
+        val nativeSegments = fallbackOnFailure { doGetMediaSegments(itemId) }
+        val segments = nativeSegments?.Items.orEmpty().mapNotNull { segment ->
+            val kind = when (segment.Type.lowercase()) {
+                "intro" -> MediaChapterKind.OPENING
+                "outro" -> MediaChapterKind.ENDING
+                else -> return@mapNotNull null
             }
-            if (chapters.isNotEmpty()) return chapters
-        }
-
-        // 2. Try Intro Skipper plugin API (/Episode/{itemId}/IntroTimestamps)
-        val introTimestamps = runCatching { doGetIntroTimestamps(itemId) }.getOrNull()
-        if (introTimestamps != null && introTimestamps.Valid && introTimestamps.IntroEnd > introTimestamps.IntroStart) {
-            val offsetMillis = (introTimestamps.IntroStart * 1000).toLong()
-            val durationMillis = ((introTimestamps.IntroEnd - introTimestamps.IntroStart) * 1000).toLong()
-            return listOf(
-                MediaChapter(name = "OP", durationMillis = durationMillis, offsetMillis = offsetMillis),
+            val offsetMillis = segment.StartTicks / 10000
+            val durationMillis = (segment.EndTicks - segment.StartTicks) / 10000
+            if (offsetMillis < 0 || durationMillis <= 0) return@mapNotNull null
+            MediaChapter(
+                name = kind.displayName,
+                durationMillis = durationMillis,
+                offsetMillis = offsetMillis,
+                kind = kind,
             )
+        }.toMutableList()
+
+        // 2. Fill missing segment types from the Intro Skipper plugin.
+        if (segments.none { it.kind == MediaChapterKind.OPENING } ||
+            segments.none { it.kind == MediaChapterKind.ENDING }
+        ) {
+            val pluginSegments = fallbackOnFailure { doGetIntroSkipperSegments(itemId) }
+            pluginSegments?.toMediaChapters()?.forEach { chapter ->
+                if (segments.none { it.kind == chapter.kind }) {
+                    segments += chapter
+                }
+            }
         }
 
-        // 3. Fallback to Item embedded Chapters
-        if (item.Chapters.isNotEmpty()) {
+        // 3. Fall back to the legacy Intro Skipper API for any still-missing type.
+        if (segments.none { it.kind == MediaChapterKind.OPENING }) {
+            fallbackOnFailure { doGetIntroTimestamps(itemId) }
+                ?.toMediaChapter(MediaChapterKind.OPENING)
+                ?.let(segments::add)
+        }
+        if (segments.none { it.kind == MediaChapterKind.ENDING }) {
+            val opening = segments.firstOrNull { it.kind == MediaChapterKind.OPENING }
+            fallbackOnFailure { doGetIntroTimestamps(itemId, mode = "Credits") }
+                ?.toMediaChapter(MediaChapterKind.ENDING)
+                // Old plugin versions may ignore mode=Credits and return the intro again.
+                ?.takeIf { credits ->
+                    opening == null || credits.offsetMillis >= opening.offsetMillis + opening.durationMillis
+                }
+                ?.let(segments::add)
+        }
+
+        // 4. Keep embedded chapters alongside skip segments. Their explicit kind prevents them
+        // from being mistaken for OP/ED while still allowing the player to display them.
+        val embeddedChapters = if (item.Chapters.isNotEmpty()) {
             val sortedChapters = item.Chapters.sortedBy { it.StartPositionTicks }
-            return sortedChapters.mapIndexed { index, chapter ->
+            sortedChapters.mapIndexed { index, chapter ->
                 val startTicks = chapter.StartPositionTicks
                 val endTicks = sortedChapters.getOrNull(index + 1)?.StartPositionTicks ?: item.RunTimeTicks
                 val offsetMillis = startTicks / 10000
@@ -260,9 +284,11 @@ abstract class BaseJellyfinMediaSource(
                     ?: "Ch ${index + 1}"
                 MediaChapter(name = name, durationMillis = durationMillis, offsetMillis = offsetMillis)
             }
+        } else {
+            emptyList()
         }
 
-        return emptyList()
+        return embeddedChapters + segments
     }
 
     private data class ParsedSubjectName(
@@ -340,8 +366,14 @@ abstract class BaseJellyfinMediaSource(
         }
     }
 
-    private suspend fun doGetIntroTimestamps(itemId: String): IntroTimestampsDto {
-        return authorizedGet("$baseUrl/Episode/$itemId/IntroTimestamps")
+    private suspend fun doGetIntroSkipperSegments(itemId: String):IntroSkipperSegmentsDto {
+        return authorizedGet("$baseUrl/Episode/$itemId/IntroSkipperSegments")
+    }
+
+    private suspend fun doGetIntroTimestamps(itemId: String, mode: String? = null): IntroTimestampsDto {
+        return authorizedGet("$baseUrl/Episode/$itemId/IntroTimestamps") {
+            mode?.let { parameter("mode", it) }
+        }
     }
 
     private suspend inline fun <reified T> authorizedGet(
@@ -385,6 +417,16 @@ abstract class BaseJellyfinMediaSource(
 
 private class JellyfinAuthorizationException :
     IllegalStateException("Jellyfin rejected the configured authorization")
+
+internal suspend fun <T> fallbackOnFailure(block: suspend () -> T): T? {
+    return try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
+        null
+    }
+}
 
 @Serializable
 private class SearchResponse(
@@ -437,6 +479,64 @@ internal data class IntroTimestampsDto(
     val ShowSkipPromptAt: Double? = null,
     val HideSkipPromptAt: Double? = null,
 )
+
+@Serializable
+@Suppress("PropertyName")
+internal data class IntroSkipperSegmentsDto(
+    val Introduction: IntroSkipperSegmentDto? = null,
+    val Credits: IntroSkipperSegmentDto? = null,
+)
+
+@Serializable
+@Suppress("PropertyName")
+internal data class IntroSkipperSegmentDto(
+    val Valid: Boolean = false,
+    val Start: Double? = null,
+    val End: Double? = null,
+    val IntroStart: Double? = null,
+    val IntroEnd: Double? = null,
+) {
+    val resolvedStart: Double? get() = Start ?: IntroStart
+    val resolvedEnd: Double? get() = End ?: IntroEnd
+}
+
+internal fun IntroSkipperSegmentsDto.toMediaChapters(): List<MediaChapter> = listOfNotNull(
+    Introduction?.toMediaChapter(MediaChapterKind.OPENING),
+    Credits?.toMediaChapter(MediaChapterKind.ENDING),
+)
+
+private fun IntroSkipperSegmentDto.toMediaChapter(kind: MediaChapterKind): MediaChapter? {
+    val start = resolvedStart ?: return null
+    val end = resolvedEnd ?: return null
+    if (!Valid || start < 0.0 || end <= start) return null
+    val offsetMillis = (start * 1000).toLong()
+    val endMillis = (end * 1000).toLong()
+    return MediaChapter(
+        name = kind.displayName,
+        durationMillis = endMillis - offsetMillis,
+        offsetMillis = offsetMillis,
+        kind = kind,
+    )
+}
+
+private fun IntroTimestampsDto.toMediaChapter(kind: MediaChapterKind): MediaChapter? {
+    if (!Valid || IntroStart < 0.0 || IntroEnd <= IntroStart) return null
+    val offsetMillis = (IntroStart * 1000).toLong()
+    val endMillis = (IntroEnd * 1000).toLong()
+    return MediaChapter(
+        name = kind.displayName,
+        durationMillis = endMillis - offsetMillis,
+        offsetMillis = offsetMillis,
+        kind = kind,
+    )
+}
+
+private val MediaChapterKind.displayName: String
+    get() = when (this) {
+        MediaChapterKind.OPENING -> "OP"
+        MediaChapterKind.ENDING -> "ED"
+        MediaChapterKind.CHAPTER -> error("A regular chapter has no fixed display name")
+    }
 
 @Serializable
 @Suppress("PropertyName")

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -137,7 +137,7 @@ abstract class BaseJellyfinMediaSource(
                         else -> return@mapNotNull null
                     }
 
-                    MediaMatch(
+                    val match = MediaMatch(
                         media = DefaultMedia(
                             mediaId = item.Id,
                             mediaSourceId = mediaSourceId,
@@ -161,7 +161,7 @@ abstract class BaseJellyfinMediaSource(
                             ),
                             extraFiles = MediaExtraFiles(
                                 subtitles = getSubtitles(item.Id, item.MediaStreams),
-                                chapters = fetchChaptersAndSegments(item),
+                                chapters = emptyList(),
                             ),
                             episodeRange = episodeRange,
                             location = MediaSourceLocation.Lan,
@@ -169,8 +169,25 @@ abstract class BaseJellyfinMediaSource(
                         ),
                         kind = MatchKind.FUZZY,
                     )
+                    Pair(item, match)
                 }
-                .filter { it.matches(query) != false }
+                .filter { (_, match) -> match.matches(query) != false }
+                .map { (item, match) ->
+                    val chapters = fetchChaptersAndSegments(item)
+                    if (chapters.isEmpty()) {
+                        match
+                    } else {
+                        val media = match.media as DefaultMedia
+                        match.copy(
+                            media = media.copy(
+                                extraFiles = MediaExtraFiles(
+                                    subtitles = media.extraFiles.subtitles,
+                                    chapters = chapters,
+                                ),
+                            ),
+                        )
+                    }
+                }
                 .asFlow()
         }
     }
@@ -203,14 +220,14 @@ abstract class BaseJellyfinMediaSource(
         // 1. Try Jellyfin 10.10+ native MediaSegments API
         val nativeSegments = runCatching { doGetMediaSegments(itemId) }.getOrNull()
         if (nativeSegments != null && nativeSegments.Items.isNotEmpty()) {
-            val chapters = nativeSegments.Items.map { segment ->
-                val offsetMillis = segment.StartTicks / 10000
-                val durationMillis = (segment.EndTicks - segment.StartTicks) / 10000
+            val chapters = nativeSegments.Items.mapNotNull { segment ->
                 val name = when (segment.Type.lowercase()) {
                     "intro" -> "OP"
                     "outro" -> "ED"
-                    else -> segment.Type
+                    else -> return@mapNotNull null
                 }
+                val offsetMillis = segment.StartTicks / 10000
+                val durationMillis = (segment.EndTicks - segment.StartTicks) / 10000
                 MediaChapter(name = name, durationMillis = durationMillis, offsetMillis = offsetMillis)
             }
             if (chapters.isNotEmpty()) return chapters
@@ -317,7 +334,10 @@ abstract class BaseJellyfinMediaSource(
     }
 
     private suspend fun doGetMediaSegments(itemId: String): MediaSegmentQueryResult {
-        return authorizedGet("$baseUrl/MediaSegments/$itemId")
+        return authorizedGet("$baseUrl/MediaSegments/$itemId") {
+            url.parameters.append("includeSegmentTypes", "Intro")
+            url.parameters.append("includeSegmentTypes", "Outro")
+        }
     }
 
     private suspend fun doGetIntroTimestamps(itemId: String): IntroTimestampsDto {

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.Serializable
 import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.MediaChapter
 import me.him188.ani.datasources.api.MediaExtraFiles
 import me.him188.ani.datasources.api.MediaProperties
 import me.him188.ani.datasources.api.Subtitle
@@ -160,6 +161,7 @@ abstract class BaseJellyfinMediaSource(
                             ),
                             extraFiles = MediaExtraFiles(
                                 subtitles = getSubtitles(item.Id, item.MediaStreams),
+                                chapters = fetchChaptersAndSegments(item),
                             ),
                             episodeRange = episodeRange,
                             location = MediaSourceLocation.Lan,
@@ -195,6 +197,56 @@ abstract class BaseJellyfinMediaSource(
         return "$baseUrl/Videos/$itemId/$itemId/Subtitles/$index/0/Stream.$codec"
     }
 
+    private suspend fun fetchChaptersAndSegments(item: Item): List<MediaChapter> {
+        val itemId = item.Id
+
+        // 1. Try Jellyfin 10.10+ native MediaSegments API
+        val nativeSegments = runCatching { doGetMediaSegments(itemId) }.getOrNull()
+        if (nativeSegments != null && nativeSegments.Items.isNotEmpty()) {
+            val chapters = nativeSegments.Items.map { segment ->
+                val offsetMillis = segment.StartTicks / 10000
+                val durationMillis = (segment.EndTicks - segment.StartTicks) / 10000
+                val name = when (segment.Type.lowercase()) {
+                    "intro" -> "OP"
+                    "outro" -> "ED"
+                    else -> segment.Type
+                }
+                MediaChapter(name = name, durationMillis = durationMillis, offsetMillis = offsetMillis)
+            }
+            if (chapters.isNotEmpty()) return chapters
+        }
+
+        // 2. Try Intro Skipper plugin API (/Episode/{itemId}/IntroTimestamps)
+        val introTimestamps = runCatching { doGetIntroTimestamps(itemId) }.getOrNull()
+        if (introTimestamps != null && introTimestamps.Valid && introTimestamps.IntroEnd > introTimestamps.IntroStart) {
+            val offsetMillis = (introTimestamps.IntroStart * 1000).toLong()
+            val durationMillis = ((introTimestamps.IntroEnd - introTimestamps.IntroStart) * 1000).toLong()
+            return listOf(
+                MediaChapter(name = "OP", durationMillis = durationMillis, offsetMillis = offsetMillis),
+            )
+        }
+
+        // 3. Fallback to Item embedded Chapters
+        if (item.Chapters.isNotEmpty()) {
+            val sortedChapters = item.Chapters.sortedBy { it.StartPositionTicks }
+            return sortedChapters.mapIndexed { index, chapter ->
+                val startTicks = chapter.StartPositionTicks
+                val endTicks = sortedChapters.getOrNull(index + 1)?.StartPositionTicks ?: item.RunTimeTicks
+                val offsetMillis = startTicks / 10000
+                val durationMillis = if (endTicks != null && endTicks > startTicks) {
+                    (endTicks - startTicks) / 10000
+                } else {
+                    0L
+                }
+                val name = chapter.Name?.takeIf { it.isNotBlank() }
+                    ?: chapter.MarkerType?.takeIf { it.isNotBlank() }
+                    ?: "Ch ${index + 1}"
+                MediaChapter(name = name, durationMillis = durationMillis, offsetMillis = offsetMillis)
+            }
+        }
+
+        return emptyList()
+    }
 
     private data class ParsedSubjectName(
         val baseName: String,
@@ -246,7 +298,7 @@ abstract class BaseJellyfinMediaSource(
     private suspend fun doGetEpisodes(seriesId: String, seasonNum: Int): SearchResponse {
         return authorizedGet("$baseUrl/Shows/$seriesId/Episodes") {
             parameter("Season", seasonNum)
-            parameter("fields", "MediaStreams")
+            parameter("fields", "MediaStreams,Chapters")
         }
     }
 
@@ -259,9 +311,17 @@ abstract class BaseJellyfinMediaSource(
             parameter("enableImages", false)
             parameter("recursive", recursive)
             parameter("searchTerm", subjectName)
-            parameter("fields", "MediaStreams")
+            parameter("fields", "MediaStreams,Chapters")
             parameter("parentId", parentId)
         }
+    }
+
+    private suspend fun doGetMediaSegments(itemId: String): MediaSegmentQueryResult {
+        return authorizedGet("$baseUrl/MediaSegments/$itemId")
+    }
+
+    private suspend fun doGetIntroTimestamps(itemId: String): IntroTimestampsDto {
+        return authorizedGet("$baseUrl/Episode/$itemId/IntroTimestamps")
     }
 
     private suspend inline fun <reified T> authorizedGet(
@@ -325,6 +385,41 @@ private data class MediaStream(
 
 @Serializable
 @Suppress("PropertyName")
+internal data class ChapterInfoDto(
+    val StartPositionTicks: Long,
+    val Name: String? = null,
+    val MarkerType: String? = null,
+)
+
+@Serializable
+@Suppress("PropertyName")
+internal data class MediaSegmentDto(
+    val Id: String? = null,
+    val ItemId: String? = null,
+    val Type: String, // "Intro", "Outro", "Recap", "Preview", "Commercial"
+    val StartTicks: Long,
+    val EndTicks: Long,
+)
+
+@Serializable
+@Suppress("PropertyName")
+internal data class MediaSegmentQueryResult(
+    val Items: List<MediaSegmentDto> = emptyList(),
+)
+
+@Serializable
+@Suppress("PropertyName")
+internal data class IntroTimestampsDto(
+    val EpisodeId: String? = null,
+    val Valid: Boolean = false,
+    val IntroStart: Double = 0.0,
+    val IntroEnd: Double = 0.0,
+    val ShowSkipPromptAt: Double? = null,
+    val HideSkipPromptAt: Double? = null,
+)
+
+@Serializable
+@Suppress("PropertyName")
 private data class Item(
     val Name: String,
     val SeasonName: String? = null,
@@ -335,4 +430,6 @@ private data class Item(
     val ParentIndexNumber: Int? = null,
     val Type: String, // "Episode", "Series", ...
     val MediaStreams: List<MediaStream> = emptyList(),
+    val Chapters: List<ChapterInfoDto> = emptyList(),
+    val RunTimeTicks: Long? = null,
 )

--- a/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
@@ -23,6 +23,7 @@ import me.him188.ani.utils.ktor.ScopedHttpClient
 class EmbyMediaSource(
     config: MediaSourceConfig,
     client: ScopedHttpClient,
+    override val mediaSourceId: String = ID,
 ) : BaseJellyfinMediaSource(client) {
     companion object {
         const val ID = "emby"
@@ -60,12 +61,11 @@ class EmbyMediaSource(
             mediaSourceId: String,
             config: MediaSourceConfig,
             client: ScopedHttpClient
-        ): MediaSource = EmbyMediaSource(config, client)
+        ): MediaSource = EmbyMediaSource(config, client, mediaSourceId)
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB
     override val info: MediaSourceInfo get() = INFO
-    override val mediaSourceId: String get() = ID
     override val baseUrl = config[Parameters.baseUrl].removeSuffix("/")
     private val userId = config[Parameters.userId]
     private val apiKey = config[Parameters.apikey]

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -9,6 +9,8 @@
 
 package me.him188.ani.datasources.jellyfin
 
+import kotlinx.serialization.Serializable
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
 import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -24,7 +26,7 @@ import me.him188.ani.utils.ktor.ScopedHttpClient
 class JellyfinMediaSource(
     config: MediaSourceConfig,
     client: ScopedHttpClient,
-    instanceId: String = ID,
+    override val mediaSourceId: String = ID,
 ) : BaseJellyfinMediaSource(client) {
     companion object {
         const val ID = "jellyfin"
@@ -89,13 +91,13 @@ class JellyfinMediaSource(
             mediaSourceId: String,
             config: MediaSourceConfig,
             client: ScopedHttpClient
-        ): MediaSource = JellyfinMediaSource(config, client, instanceId = mediaSourceId)
+        ): MediaSource = JellyfinMediaSource(config, client, mediaSourceId = mediaSourceId)
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB
     override val info: MediaSourceInfo = INFO
-    override val mediaSourceId: String get() = ID
     override val baseUrl = config[Parameters.baseUrl].removeSuffix("/")
+    override val itemFields: String = "MediaStreams,Chapters,Trickplay"
     private val authMode = config[Parameters.authMode]
     private val userId = config[Parameters.userId]
     private val apiKey = config[Parameters.apikey]
@@ -104,12 +106,17 @@ class JellyfinMediaSource(
             baseUrl = baseUrl,
             username = config[Parameters.username],
             password = config[Parameters.password],
-            deviceId = "animeko-$instanceId",
+            deviceId = "animeko-$mediaSourceId",
             client = client,
         )
     } else {
         null
     }
+
+    internal override fun createPreviewThumbnails(
+        itemId: String,
+        trickplay: Map<String, Map<String, JellyfinTrickplayManifestDto>>?,
+    ) = createJellyfinPreviewThumbnails(baseUrl, mediaSourceId, itemId, trickplay)
 
     override suspend fun getAuthorization(): Authorization {
         return when (authMode) {
@@ -145,4 +152,49 @@ class JellyfinMediaSource(
     override fun getDownloadUri(itemId: String, accessToken: String): String {
         return "$baseUrl/Items/$itemId/Download?ApiKey=$accessToken"
     }
+}
+
+@Serializable
+@Suppress("PropertyName")
+internal data class JellyfinTrickplayManifestDto(
+    val Width: Int = 0,
+    val Height: Int = 0,
+    val TileWidth: Int = 0,  // columns
+    val TileHeight: Int = 0, // rows
+    val ThumbnailCount: Int = 0,
+    val Interval: Long = 0,  // in milliseconds
+)
+
+internal fun createJellyfinPreviewThumbnails(
+    baseUrl: String,
+    requesterMediaSourceId: String,
+    itemId: String,
+    trickplay: Map<String, Map<String, JellyfinTrickplayManifestDto>>?,
+): MediaPreviewThumbnails? {
+    val validMediaSources = trickplay.orEmpty().mapNotNull { (mediaSourceId, manifests) ->
+        val validManifests = manifests.values.filter {
+            it.Width > 0 && it.Height > 0 && it.TileWidth > 0 && it.TileHeight > 0 &&
+                it.ThumbnailCount > 0 && it.Interval > 0
+        }
+        val manifest = validManifests.firstOrNull { it.Width == 320 }
+            ?: validManifests.minByOrNull { it.Width }
+            ?: return@mapNotNull null
+        mediaSourceId to manifest
+    }
+    val (mediaSourceId, manifest) = validMediaSources.firstOrNull { (mediaSourceId) -> mediaSourceId == itemId }
+        ?: validMediaSources.singleOrNull()
+        ?: return null
+    return MediaPreviewThumbnails(
+        width = manifest.Width,
+        height = manifest.Height,
+        intervalMillis = manifest.Interval,
+        totalCount = manifest.ThumbnailCount,
+        layout = MediaPreviewThumbnails.Layout.SpriteTile(
+            columns = manifest.TileWidth,
+            rows = manifest.TileHeight,
+            urlPattern =
+                "$baseUrl/Videos/$itemId/Trickplay/${manifest.Width}/{tileIndex}.jpg?MediaSourceId=$mediaSourceId",
+        ),
+        requesterMediaSourceId = requesterMediaSourceId,
+    )
 }

--- a/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
@@ -2,12 +2,16 @@ package me.him188.ani.datasources.jellyfin
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import me.him188.ani.datasources.api.MediaChapter
 import me.him188.ani.datasources.api.MediaChapterKind
+import me.him188.ani.datasources.api.MediaPreviewThumbnails
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BaseJellyfinMediaSourceTest {
@@ -132,4 +136,129 @@ class BaseJellyfinMediaSourceTest {
         assertEquals(MediaChapterKind.ENDING, chapters[1].kind)
         assertEquals(1_329_040L, chapters[1].offsetMillis)
     }
+
+    @Test
+    fun testJellyfinTrickplayMetadataDeserializationAndMapping() {
+        val itemId = "item1"
+        val rawJson = """
+            {
+              "Trickplay": {
+                "$itemId": {
+                  "640": {
+                    "Width": 640,
+                    "Height": 360,
+                    "TileWidth": 5,
+                    "TileHeight": 5,
+                    "ThumbnailCount": 120,
+                    "Interval": 20000
+                  },
+                  "320": {
+                    "Width": 320,
+                    "Height": 180,
+                    "TileWidth": 10,
+                    "TileHeight": 10,
+                    "ThumbnailCount": 240,
+                    "Interval": 10000
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<TrickplayItemDto>(rawJson)
+        val thumbnails = assertNotNull(
+            createJellyfinPreviewThumbnails("https://example.com", "jellyfin-instance", itemId, parsed.Trickplay),
+        )
+        assertEquals(320, thumbnails.width)
+        assertEquals(180, thumbnails.height)
+        assertEquals(10_000L, thumbnails.intervalMillis)
+        assertEquals(240, thumbnails.totalCount)
+        assertEquals(
+            "https://example.com/Videos/item1/Trickplay/320/{tileIndex}.jpg?MediaSourceId=item1",
+            (thumbnails.layout as MediaPreviewThumbnails.Layout.SpriteTile).urlPattern,
+        )
+        assertEquals("jellyfin-instance", thumbnails.requesterMediaSourceId)
+        assertEquals(emptyMap(), thumbnails.headers)
+    }
+
+    @Test
+    fun testJellyfinTrickplayUsesSoleAlternativeMediaSource() {
+        val manifest = JellyfinTrickplayManifestDto(
+            Width = 320,
+            Height = 180,
+            TileWidth = 10,
+            TileHeight = 10,
+            ThumbnailCount = 240,
+            Interval = 10_000,
+        )
+        val thumbnails = assertNotNull(
+            createJellyfinPreviewThumbnails(
+                "https://example.com",
+                "jellyfin-instance",
+                "item1",
+                mapOf("another-version" to mapOf("320" to manifest)),
+            ),
+        )
+        assertEquals(
+            "https://example.com/Videos/item1/Trickplay/320/{tileIndex}.jpg?MediaSourceId=another-version",
+            (thumbnails.layout as MediaPreviewThumbnails.Layout.SpriteTile).urlPattern,
+        )
+    }
+
+    @Test
+    fun testJellyfinTrickplayDoesNotGuessBetweenAlternativeMediaSources() {
+        val manifest = JellyfinTrickplayManifestDto(
+            Width = 320,
+            Height = 180,
+            TileWidth = 10,
+            TileHeight = 10,
+            ThumbnailCount = 240,
+            Interval = 10_000,
+        )
+        assertNull(
+            createJellyfinPreviewThumbnails(
+                "https://example.com",
+                "jellyfin-instance",
+                "item1",
+                mapOf(
+                    "version-1" to mapOf("320" to manifest),
+                    "version-2" to mapOf("320" to manifest),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun testJellyfinTrickplaySelectsSmallestValidFallback() {
+        fun manifest(width: Int, height: Int = width / 2) = JellyfinTrickplayManifestDto(
+            Width = width,
+            Height = height,
+            TileWidth = 10,
+            TileHeight = 10,
+            ThumbnailCount = 100,
+            Interval = 10_000,
+        )
+
+        val thumbnails = assertNotNull(
+            createJellyfinPreviewThumbnails(
+                "https://example.com",
+                "jellyfin-instance",
+                "item1",
+                mapOf(
+                    "item1" to mapOf(
+                        "1280" to manifest(1280),
+                        "160" to manifest(160),
+                        "320" to manifest(320, height = 0),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(160, thumbnails.width)
+    }
+
+    @Serializable
+    @Suppress("PropertyName")
+    private data class TrickplayItemDto(
+        val Trickplay: Map<String, Map<String, JellyfinTrickplayManifestDto>> = emptyMap(),
+    )
 }

--- a/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
@@ -1,12 +1,28 @@
 package me.him188.ani.datasources.jellyfin
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import me.him188.ani.datasources.api.MediaChapter
+import me.him188.ani.datasources.api.MediaChapterKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class BaseJellyfinMediaSourceTest {
+    @Test
+    fun fallbackRequestPropagatesCancellation() = runTest {
+        assertFailsWith<CancellationException> {
+            fallbackOnFailure<Unit> { throw CancellationException("cancelled") }
+        }
+    }
+
+    @Test
+    fun fallbackRequestIgnoresRegularFailure() = runTest {
+        assertEquals(null, fallbackOnFailure<Unit> { error("not supported") })
+    }
+
     @Test
     fun testMediaChapterMapping() {
         val chapter = MediaChapter(name = "OP", durationMillis = 90_000L, offsetMillis = 10_000L)
@@ -62,5 +78,58 @@ class BaseJellyfinMediaSourceTest {
         assertTrue(parsed.Valid)
         assertEquals(55.48, parsed.IntroStart)
         assertEquals(146.02, parsed.IntroEnd)
+    }
+
+    @Test
+    fun testCurrentIntroSkipperSegmentsDeserialization() {
+        val rawJson = """
+            {
+              "Introduction": {
+                "Start": 55.48,
+                "End": 146.02,
+                "Valid": true
+              },
+              "Credits": {
+                "Start": 1329.04,
+                "End": 1414.66,
+                "Valid": true
+              }
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<IntroSkipperSegmentsDto>(rawJson)
+        val chapters = parsed.toMediaChapters()
+
+        assertEquals(2, chapters.size)
+        assertEquals(MediaChapter("OP", 90_540L, 55_480L, MediaChapterKind.OPENING), chapters[0])
+        assertEquals(MediaChapter("ED", 85_620L, 1_329_040L, MediaChapterKind.ENDING), chapters[1])
+    }
+
+    @Test
+    fun testLegacyIntroSkipperSegmentsDeserialization() {
+        val rawJson = """
+            {
+              "Introduction": {
+                "IntroStart": 55.48,
+                "IntroEnd": 146.02,
+                "Valid": true
+              },
+              "Credits": {
+                "IntroStart": 1329.04,
+                "IntroEnd": 1414.66,
+                "Valid": true
+              }
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<IntroSkipperSegmentsDto>(rawJson)
+        val chapters = parsed.toMediaChapters()
+
+        assertEquals(2, chapters.size)
+        assertEquals("OP", chapters[0].name)
+        assertEquals(MediaChapterKind.OPENING, chapters[0].kind)
+        assertEquals("ED", chapters[1].name)
+        assertEquals(MediaChapterKind.ENDING, chapters[1].kind)
+        assertEquals(1_329_040L, chapters[1].offsetMillis)
     }
 }

--- a/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/BaseJellyfinMediaSourceTest.kt
@@ -1,0 +1,66 @@
+package me.him188.ani.datasources.jellyfin
+
+import kotlinx.serialization.json.Json
+import me.him188.ani.datasources.api.MediaChapter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BaseJellyfinMediaSourceTest {
+    @Test
+    fun testMediaChapterMapping() {
+        val chapter = MediaChapter(name = "OP", durationMillis = 90_000L, offsetMillis = 10_000L)
+        assertEquals("OP", chapter.name)
+        assertEquals(90_000L, chapter.durationMillis)
+        assertEquals(10_000L, chapter.offsetMillis)
+    }
+
+    @Test
+    fun testMediaSegmentQueryResultDeserialization() {
+        val rawJson = """
+            {
+              "Items": [
+                {
+                  "Id": "seg1",
+                  "ItemId": "item1",
+                  "Type": "Intro",
+                  "StartTicks": 554802116,
+                  "EndTicks": 1460208374
+                },
+                {
+                  "Id": "seg2",
+                  "ItemId": "item1",
+                  "Type": "Outro",
+                  "StartTicks": 13290383643,
+                  "EndTicks": 14146631118
+                }
+              ],
+              "TotalRecordCount": 2,
+              "StartIndex": 0
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<MediaSegmentQueryResult>(rawJson)
+        assertEquals(2, parsed.Items.size)
+        assertEquals("Intro", parsed.Items[0].Type)
+        assertEquals(554802116L, parsed.Items[0].StartTicks)
+        assertEquals(1460208374L, parsed.Items[0].EndTicks)
+        assertEquals("Outro", parsed.Items[1].Type)
+    }
+
+    @Test
+    fun testIntroTimestampsDtoDeserialization() {
+        val rawJson = """
+            {
+              "IntroStart": 55.48,
+              "IntroEnd": 146.02,
+              "Valid": true
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<IntroTimestampsDto>(rawJson)
+        assertTrue(parsed.Valid)
+        assertEquals(55.48, parsed.IntroStart)
+        assertEquals(146.02, parsed.IntroEnd)
+    }
+}

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -24,6 +24,7 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -114,7 +115,7 @@ class JellyfinMediaSourceAuthenticationTest {
                     else -> error("Unexpected request: ${request.url}")
                 }
             },
-            instanceId = "source-instance",
+            mediaSourceId = "source-instance",
         )
 
         assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
@@ -344,6 +345,7 @@ class JellyfinMediaSourceAuthenticationTest {
             client = mockClient { request ->
                 assertEquals("/Items", request.url.encodedPath)
                 itemsCount++
+                assertEquals("MediaStreams,Chapters", request.url.parameters["fields"])
                 assertEquals("emby-user-id", request.url.parameters["userId"])
                 assertEquals(
                     """MediaBrowser Token="emby-api-key"""",
@@ -358,7 +360,7 @@ class JellyfinMediaSourceAuthenticationTest {
     }
 
     @Test
-    fun `fetch creates a playable download url from the session token`() = runTest {
+    fun `fetch uses the login session for downloads and trickplay thumbnails`() = runTest {
         var loginCount = 0
         val source = JellyfinMediaSource(
             config = passwordConfig(),
@@ -376,8 +378,10 @@ class JellyfinMediaSourceAuthenticationTest {
                         )
                     }
 
-                    "/Items" -> respondJson(
-                        """
+                    "/Items" -> {
+                        assertEquals("MediaStreams,Chapters,Trickplay", request.url.parameters["fields"])
+                        respondJson(
+                            """
                         {
                           "Items": [
                             {
@@ -385,12 +389,25 @@ class JellyfinMediaSourceAuthenticationTest {
                               "SeriesName": "Test Anime",
                               "Id": "episode-1",
                               "IndexNumber": 1,
-                              "Type": "Episode"
+                              "Type": "Episode",
+                              "Trickplay": {
+                                "episode-1": {
+                                  "320": {
+                                    "Width": 320,
+                                    "Height": 180,
+                                    "TileWidth": 10,
+                                    "TileHeight": 10,
+                                    "ThumbnailCount": 100,
+                                    "Interval": 10000
+                                  }
+                                }
+                              }
                             }
                           ]
                         }
-                        """.trimIndent(),
-                    )
+                            """.trimIndent(),
+                        )
+                    }
 
                     else -> error("Unexpected request: ${request.url}")
                 }
@@ -406,7 +423,126 @@ class JellyfinMediaSourceAuthenticationTest {
             "$TEST_BASE_URL/Items/episode-1/Download?ApiKey=playback-session-token",
             download.uri,
         )
+        val previewThumbnails = assertNotNull(media.extraFiles.previewThumbnails)
+        assertEquals(JellyfinMediaSource.ID, previewThumbnails.requesterMediaSourceId)
+        assertEquals(emptyMap(), previewThumbnails.headers)
         assertEquals(1, loginCount)
+    }
+
+    @Test
+    fun `trickplay request reauthenticates once after an unauthorized response`() = runTest {
+        var loginCount = 0
+        var trickplayCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token-$loginCount",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Videos/episode-1/Trickplay/320/0.jpg" -> {
+                        trickplayCount++
+                        assertEquals("session-user-id", request.url.parameters["userId"])
+                        assertTrue(
+                            request.headers[HttpHeaders.Authorization]
+                                .orEmpty()
+                                .contains("""Token="session-token-$trickplayCount""""),
+                        )
+                        if (trickplayCount == 1) {
+                            respondJson("""{"error":"invalid token"}""", HttpStatusCode.Unauthorized)
+                        } else {
+                            respond("thumbnail")
+                        }
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        val bytes = source.fetchPreviewThumbnail(
+            "$TEST_BASE_URL/Videos/episode-1/Trickplay/320/0.jpg?MediaSourceId=episode-1",
+        )
+
+        assertEquals("thumbnail", bytes.decodeToString())
+        assertEquals(2, loginCount)
+        assertEquals(2, trickplayCount)
+    }
+
+    @Test
+    fun `concurrent trickplay requests share one session refresh`() = runTest {
+        val requestCount = 4
+        var loginCount = 0
+        var firstWaveCount = 0
+        var trickplayCount = 0
+        val firstWaveReady = CompletableDeferred<Unit>()
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """{"AccessToken":"session-token-$loginCount","User":{"Id":"session-user-id"}}""",
+                        )
+                    }
+
+                    else -> {
+                        check(request.url.encodedPath.startsWith("/Videos/episode-1/Trickplay/320/"))
+                        trickplayCount++
+                        val authorization = request.headers[HttpHeaders.Authorization].orEmpty()
+                        if ("""Token="session-token-1"""" in authorization) {
+                            firstWaveCount++
+                            if (firstWaveCount == requestCount) firstWaveReady.complete(Unit)
+                            firstWaveReady.await()
+                            respondJson("""{"error":"invalid token"}""", HttpStatusCode.Unauthorized)
+                        } else {
+                            assertTrue("""Token="session-token-2"""" in authorization)
+                            respond("thumbnail")
+                        }
+                    }
+                }
+            },
+        )
+
+        coroutineScope {
+            List(requestCount) { tileIndex ->
+                async {
+                    source.fetchPreviewThumbnail(
+                        "$TEST_BASE_URL/Videos/episode-1/Trickplay/320/$tileIndex.jpg?MediaSourceId=episode-1",
+                    )
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(2, loginCount)
+        assertEquals(requestCount * 2, trickplayCount)
+    }
+
+    @Test
+    fun `factories preserve unique media source ids`() {
+        val client = mockClient { error("No request expected") }
+        assertEquals(
+            "jellyfin-instance",
+            JellyfinMediaSource.Factory()
+                .create("jellyfin-instance", passwordConfig(), client)
+                .mediaSourceId,
+        )
+        assertEquals(
+            "emby-instance",
+            EmbyMediaSource.Factory()
+                .create("emby-instance", MediaSourceConfig.Default, client)
+                .mediaSourceId,
+        )
     }
 
     @Test
@@ -431,9 +567,9 @@ class JellyfinMediaSourceAuthenticationTest {
         }
     }
 
-    private fun passwordConfig() = MediaSourceConfig(
+    private fun passwordConfig(baseUrl: String = TEST_BASE_URL) = MediaSourceConfig(
         arguments = mapOf(
-            "baseUrl" to TEST_BASE_URL,
+            "baseUrl" to baseUrl,
             "authMode" to JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD,
             "username" to "test-user",
             "password" to "test-password",


### PR DESCRIPTION
### 📌 背景 (Context)

Jellyfin 10.9+ 原生提供进度条 Hover/Seek 缩略图（Trickplay Sprite Sheet）。此前播放器在 seek 时需要实时解码视频帧，存在额外解码开销和首次预览延迟。

本 PR 为 Animeko 引入通用的进度条缩略图模型，并对接 Jellyfin 原生 Trickplay API。播放 Jellyfin 媒体时优先使用服务器预生成的缩略图；不可用或加载失败时仍回退到播放器 `FramePreview`。

---

### 🛠️ 主要变更 (Changes)

1. **`datasource/api`**
   - 在 `MediaExtraFiles` 中新增 `previewThumbnails: MediaPreviewThumbnails?`。
   - 使用 `sealed interface Layout` 描述缩略图布局，当前实现 `Layout.SpriteTile`，可供后续其他数据源或格式扩展。
   - `MediaPreviewThumbnails` 保存无密钥的 `requesterMediaSourceId`，不在可序列化 DTO 中保存 Jellyfin token。
   - `MediaSource` 提供可选的缩略图请求能力，由数据源自行处理认证和凭据刷新。

2. **`datasource/jellyfin`**
   - 仅 `JellyfinMediaSource` 请求 `Trickplay` 字段；共享基类和 `EmbyMediaSource` 保持原有 `MediaStreams,Chapters` 查询，不假设 Emby 支持 Jellyfin Trickplay API。
   - 从 Jellyfin 响应读取拼图尺寸、行列数、帧间隔和总帧数，无需额外请求描述文件。
   - manifest 优先选择 320 宽度，否则选择最小的有效宽度。
   - 外层 Trickplay key 按 Jellyfin `MediaSourceInfo.Id` 处理：优先匹配 item ID；否则仅在唯一有效候选时使用该 media-source ID；多个无法判断的版本则不猜测并回退播放器取帧。
   - 缩略图通过当前 live Jellyfin 数据源实例请求，复用现有 `authorizedGet` 策略。用户名/密码 session 返回 401 时会失效旧 session、重新登录，并只重试一次；并发 401 共享同一次 session refresh。
   - Jellyfin/Emby factory 保留实际的唯一实例 ID，避免多实例路由回固定 `jellyfin` / `emby` ID。

3. **`app/shared/app-data` 与页面接线**
   - `MediaSourceManager` 按 `requesterMediaSourceId` 从当前 `allInstances` 动态查找数据源，使配置更新或重新登录后请求仍使用当前实例。
   - `EpisodeViewModel` / `EpisodePage` 将缩略图请求能力与当前选中媒体的元数据注入播放器预览状态。

4. **`app/shared/ui-foundation`**
   - 增加跨平台 `ImageBitmap.crop(x, y, width, height)`：
     - Android：基于 `Bitmap.createBitmap`；
     - Desktop / Skiko：基于 Skia `Surface` 与 `drawImageRect`，并主动释放原生图像资源。

5. **`app/shared/video-player`**
   - 实现 `MediaPreviewThumbnailsTileFetcher`，负责帧索引计算、精灵图请求、图片解码及单帧裁切。
   - 仅缓存最近 1 张精灵图，控制内存占用。
   - 无 `requesterMediaSourceId` 时保留通用 URL + headers 请求路径；Jellyfin 则交由 live media source 完成认证请求。
   - 图片解码和裁切在后台 dispatcher 执行并正确传播取消。
   - 媒体切换后，旧请求无法回写上一媒体的预览帧。
   - Trickplay 缺失或请求、解码、裁切失败时回退到播放器 `FramePreview`。

---

### 🧪 测试与验证 (Testing & Verification)

- [x] **Jellyfin 数据源测试**
  - Trickplay DTO 与 sprite manifest 映射；
  - item ID、唯一替代 media-source ID、多候选回退及无效元数据；
  - API key / 用户名密码认证；
  - 缩略图 401 后单次重认证重试；
  - 并发请求共享 session refresh；
  - Jellyfin 查询 Trickplay、Emby 不查询 Trickplay；
  - 多实例 ID 保留。
- [x] **播放器与图像测试**
  - 帧/精灵图坐标与溢出边界；
  - 通用 headers 路径和 media-source requester 路径；
  - 图片裁切、tile cache、取消传播及媒体切换竞态；
  - Skiko `ImageBitmap.crop` 尺寸与像素结果。
- [x] **执行过的聚焦验证**
  - `./gradlew :datasource:jellyfin:desktopTest`
  - `./gradlew :app:shared:app-data:desktopTest --tests me.him188.ani.app.domain.media.fetch.MediaSourceManagerFetchSessionTest`
  - `./gradlew :app:shared:video-player:desktopTest :app:shared:compileKotlinDesktop`
  - `./gradlew :app:shared:ui-foundation:compileAndroidMain :app:shared:video-player:compileAndroidMain :app:shared:compileAndroidMain`
- [x] **真实服务器只读验证**
  - 使用已配置的 Jellyfin 查询 343 个 Episode，均返回 Trickplay 元数据。
  - 实际请求 320 宽度第 0 张精灵图返回 HTTP 200、`image/jpeg`；尺寸为 `3200x1800`（`10x10` 个 `320x180` 帧），与服务器元数据一致。
