### PR TITLE
feat(jellyfin): 支持用户名和密码登录

### DIFF
--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import io.ktor.utils.io.core.Closeable
@@ -110,7 +111,17 @@ class EditingMediaSource(
     }.stateInBackground(null, started = SharingStarted.Eagerly)
 
     val isLoading = persistLoader.map { it != null }
-    val hasError by derivedStateOf { arguments.any { it.isError } }
+    val visibleArguments by derivedStateOf {
+        arguments.filter { argument ->
+            val condition = argument.visibleWhen ?: return@filter true
+            val controllingValue = arguments
+                .firstOrNull { it.name == condition.parameterName }
+                ?.toPersisted()
+                ?: return@filter true
+            controllingValue in condition.acceptedValues
+        }
+    }
+    val hasError by derivedStateOf { visibleArguments.any { it.isError } }
 
     override fun close() {
         backgroundScope.cancel()
@@ -131,6 +142,7 @@ sealed class ArgumentState(
 ) {
     val name: String get() = parameter.name
     val description: String? get() = parameter.description
+    val visibleWhen get() = parameter.visibleWhen
 
     abstract val isError: Boolean
 
@@ -242,7 +254,7 @@ internal fun EditMediaSourceDialog(
                     Modifier.verticalScroll(rememberScrollState()).padding(top = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    for (argument in state.arguments) {
+                    for (argument in state.visibleArguments) {
                         when (argument) {
                             is BooleanArgumentState -> {
                                 BooleanArgument(argument)
@@ -254,6 +266,7 @@ internal fun EditMediaSourceDialog(
 
                             is StringArgumentState -> {
                                 OutlinedTextField(
+                                    modifier = Modifier.testTag(EditMediaSourceTestTags.argument(argument.name)),
                                     value = argument.value,
                                     onValueChange = { argument.value = argument.parameter.sanitize(it) },
                                     label = { Text(argument.name) },
@@ -308,7 +321,9 @@ private fun SimpleEnumArgument(argument: SimpleEnumArgumentState, modifier: Modi
                 // The `menuAnchor` modifier must be passed to the text field to handle
                 // expanding/collapsing the menu on click. A read-only text field has
                 // the anchor type `PrimaryNotEditable`.
-                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                modifier = Modifier
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                    .testTag(EditMediaSourceTestTags.argument(argument.name)),
                 value = argument.value,
                 onValueChange = {},
                 readOnly = true,
@@ -325,6 +340,7 @@ private fun SimpleEnumArgument(argument: SimpleEnumArgumentState, modifier: Modi
             ) {
                 argument.options.forEach { option ->
                     DropdownMenuItem(
+                        modifier = Modifier.testTag(EditMediaSourceTestTags.enumOption(argument.name, option)),
                         text = { Text(option) },
                         onClick = {
                             argument.value = option
@@ -364,6 +380,11 @@ private fun BooleanArgument(argument: BooleanArgumentState, modifier: Modifier =
             },
         )
     }
+}
+
+internal object EditMediaSourceTestTags {
+    fun argument(name: String) = "edit_media_source_argument_$name"
+    fun enumOption(name: String, option: String) = "edit_media_source_argument_${name}_option_$option"
 }
 
 @TestOnly

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -40,6 +41,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import io.ktor.utils.io.core.Closeable
@@ -274,6 +278,16 @@ internal fun EditMediaSourceDialog(
                                     supportingText = argument.description?.let { { Text(it) } },
                                     isError = argument.isError,
                                     shape = MaterialTheme.shapes.medium,
+                                    visualTransformation = if (argument.parameter.isSensitive) {
+                                        PasswordVisualTransformation()
+                                    } else {
+                                        VisualTransformation.None
+                                    },
+                                    keyboardOptions = if (argument.parameter.isSensitive) {
+                                        KeyboardOptions(keyboardType = KeyboardType.Password)
+                                    } else {
+                                        KeyboardOptions.Default
+                                    },
                                 )
                             }
                         }
@@ -426,7 +440,7 @@ private fun PreviewEditMediaSourceDialog() {
             ),
             parameters = buildMediaSourceParameters {
                 string("username", description = "用户名")
-                string("password", description = "密码")
+                string("password", description = "密码", isSensitive = true)
                 boolean("Switch", true, description = "这是一个开关")
                 boolean("开关", false, description = "This is a switch")
                 boolean("开关", false, description = "This is a switch.".repeat(10))

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -41,9 +40,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import io.ktor.utils.io.core.Closeable
@@ -278,16 +274,6 @@ internal fun EditMediaSourceDialog(
                                     supportingText = argument.description?.let { { Text(it) } },
                                     isError = argument.isError,
                                     shape = MaterialTheme.shapes.medium,
-                                    visualTransformation = if (argument.parameter.isSensitive) {
-                                        PasswordVisualTransformation()
-                                    } else {
-                                        VisualTransformation.None
-                                    },
-                                    keyboardOptions = if (argument.parameter.isSensitive) {
-                                        KeyboardOptions(keyboardType = KeyboardType.Password)
-                                    } else {
-                                        KeyboardOptions.Default
-                                    },
                                 )
                             }
                         }
@@ -440,7 +426,7 @@ private fun PreviewEditMediaSourceDialog() {
             ),
             parameters = buildMediaSourceParameters {
                 string("username", description = "用户名")
-                string("password", description = "密码", isSensitive = true)
+                string("password", description = "密码")
                 boolean("Switch", true, description = "这是一个开关")
                 boolean("开关", false, description = "This is a switch")
                 boolean("开关", false, description = "This is a switch.".repeat(10))

--- a/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
+++ b/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
@@ -9,13 +9,9 @@
 
 package me.him188.ani.app.ui.settings.tabs.media.source
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
@@ -40,7 +36,7 @@ class EditMediaSourceDialogTest {
             string("userId", visibleWhen = authMode.hasValue(apiKeyMode))
             string("apikey", visibleWhen = authMode.hasValue(apiKeyMode))
             string("username", visibleWhen = authMode.hasValue(passwordMode))
-            string("password", visibleWhen = authMode.hasValue(passwordMode), isSensitive = true)
+            string("password", visibleWhen = authMode.hasValue(passwordMode))
         }
         val state = EditingMediaSource(
             editingMediaSourceId = "test",
@@ -87,12 +83,6 @@ class EditMediaSourceDialogTest {
 
         onNodeWithTag(EditMediaSourceTestTags.argument("username")).performTextInput("test-user")
         onNodeWithTag(EditMediaSourceTestTags.argument("password")).performTextInput("test-password")
-        onNodeWithTag(EditMediaSourceTestTags.argument("password")).assert(
-            SemanticsMatcher.expectValue(
-                SemanticsProperties.EditableText,
-                AnnotatedString("•".repeat("test-password".length)),
-            ),
-        )
         assertFalse(state.hasError)
 
         state.close()

--- a/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
+++ b/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.settings.tabs.media.source
+
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.flow.flowOf
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.datasources.api.source.FactoryId
+import me.him188.ani.datasources.api.source.MediaSourceConfig
+import me.him188.ani.datasources.api.source.MediaSourceInfo
+import me.him188.ani.datasources.api.source.parameter.buildMediaSourceParameters
+import me.him188.ani.datasources.api.source.parameter.hasValue
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+
+class EditMediaSourceDialogTest {
+    @Test
+    fun `switching authentication mode shows only its credential fields`() = runAniComposeUiTest {
+        val apiKeyMode = "apiKey"
+        val passwordMode = "usernamePassword"
+        val parameters = buildMediaSourceParameters {
+            string("baseUrl", defaultProvider = { "http://localhost:8096" })
+            val authMode = simpleEnum("authMode", apiKeyMode, passwordMode, default = apiKeyMode)
+            string("userId", defaultProvider = { "" }, visibleWhen = authMode.hasValue(apiKeyMode))
+            string("apikey", defaultProvider = { "" }, visibleWhen = authMode.hasValue(apiKeyMode))
+            string("username", defaultProvider = { "" }, visibleWhen = authMode.hasValue(passwordMode))
+            string("password", defaultProvider = { "" }, visibleWhen = authMode.hasValue(passwordMode))
+        }
+        val state = EditingMediaSource(
+            editingMediaSourceId = "test",
+            factoryId = FactoryId("test"),
+            info = MediaSourceInfo(
+                displayName = "Conditional source",
+                description = "Test data source",
+            ),
+            parameters = parameters,
+            persistedArguments = flowOf(MediaSourceConfig.Default),
+            editMediaSourceMode = EditMediaSourceMode.Add(FactoryId("test")),
+            onSave = {},
+            parentCoroutineContext = EmptyCoroutineContext,
+        )
+
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                EditMediaSourceDialog(state, onDismissRequest = {})
+            }
+        }
+
+        onNodeWithTag(EditMediaSourceTestTags.argument("baseUrl")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("authMode")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("userId")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("apikey")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("username")).assertDoesNotExist()
+        onNodeWithTag(EditMediaSourceTestTags.argument("password")).assertDoesNotExist()
+
+        onNodeWithTag(EditMediaSourceTestTags.argument("authMode")).performClick()
+        onNodeWithTag(EditMediaSourceTestTags.enumOption("authMode", passwordMode)).performClick()
+
+        onNodeWithTag(EditMediaSourceTestTags.argument("baseUrl")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("authMode")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("userId")).assertDoesNotExist()
+        onNodeWithTag(EditMediaSourceTestTags.argument("apikey")).assertDoesNotExist()
+        onNodeWithTag(EditMediaSourceTestTags.argument("username")).assertExists()
+        onNodeWithTag(EditMediaSourceTestTags.argument("password")).assertExists()
+
+        state.close()
+    }
+}

--- a/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
+++ b/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
@@ -9,9 +9,13 @@
 
 package me.him188.ani.app.ui.settings.tabs.media.source
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
@@ -36,7 +40,7 @@ class EditMediaSourceDialogTest {
             string("userId", visibleWhen = authMode.hasValue(apiKeyMode))
             string("apikey", visibleWhen = authMode.hasValue(apiKeyMode))
             string("username", visibleWhen = authMode.hasValue(passwordMode))
-            string("password", visibleWhen = authMode.hasValue(passwordMode))
+            string("password", visibleWhen = authMode.hasValue(passwordMode), isSensitive = true)
         }
         val state = EditingMediaSource(
             editingMediaSourceId = "test",
@@ -83,6 +87,12 @@ class EditMediaSourceDialogTest {
 
         onNodeWithTag(EditMediaSourceTestTags.argument("username")).performTextInput("test-user")
         onNodeWithTag(EditMediaSourceTestTags.argument("password")).performTextInput("test-password")
+        onNodeWithTag(EditMediaSourceTestTags.argument("password")).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.EditableText,
+                AnnotatedString("•".repeat("test-password".length)),
+            ),
+        )
         assertFalse(state.hasError)
 
         state.close()

--- a/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
+++ b/app/shared/ui-settings/src/desktopTest/kotlin/ui/settings/tabs/media/source/EditMediaSourceDialogTest.kt
@@ -11,6 +11,7 @@ package me.him188.ani.app.ui.settings.tabs.media.source
 
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
@@ -21,6 +22,8 @@ import me.him188.ani.datasources.api.source.parameter.buildMediaSourceParameters
 import me.him188.ani.datasources.api.source.parameter.hasValue
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class EditMediaSourceDialogTest {
     @Test
@@ -30,10 +33,10 @@ class EditMediaSourceDialogTest {
         val parameters = buildMediaSourceParameters {
             string("baseUrl", defaultProvider = { "http://localhost:8096" })
             val authMode = simpleEnum("authMode", apiKeyMode, passwordMode, default = apiKeyMode)
-            string("userId", defaultProvider = { "" }, visibleWhen = authMode.hasValue(apiKeyMode))
-            string("apikey", defaultProvider = { "" }, visibleWhen = authMode.hasValue(apiKeyMode))
-            string("username", defaultProvider = { "" }, visibleWhen = authMode.hasValue(passwordMode))
-            string("password", defaultProvider = { "" }, visibleWhen = authMode.hasValue(passwordMode))
+            string("userId", visibleWhen = authMode.hasValue(apiKeyMode))
+            string("apikey", visibleWhen = authMode.hasValue(apiKeyMode))
+            string("username", visibleWhen = authMode.hasValue(passwordMode))
+            string("password", visibleWhen = authMode.hasValue(passwordMode))
         }
         val state = EditingMediaSource(
             editingMediaSourceId = "test",
@@ -61,6 +64,11 @@ class EditMediaSourceDialogTest {
         onNodeWithTag(EditMediaSourceTestTags.argument("apikey")).assertExists()
         onNodeWithTag(EditMediaSourceTestTags.argument("username")).assertDoesNotExist()
         onNodeWithTag(EditMediaSourceTestTags.argument("password")).assertDoesNotExist()
+        assertTrue(state.hasError)
+
+        onNodeWithTag(EditMediaSourceTestTags.argument("userId")).performTextInput("test-user-id")
+        onNodeWithTag(EditMediaSourceTestTags.argument("apikey")).performTextInput("test-api-key")
+        assertFalse(state.hasError)
 
         onNodeWithTag(EditMediaSourceTestTags.argument("authMode")).performClick()
         onNodeWithTag(EditMediaSourceTestTags.enumOption("authMode", passwordMode)).performClick()
@@ -71,6 +79,11 @@ class EditMediaSourceDialogTest {
         onNodeWithTag(EditMediaSourceTestTags.argument("apikey")).assertDoesNotExist()
         onNodeWithTag(EditMediaSourceTestTags.argument("username")).assertExists()
         onNodeWithTag(EditMediaSourceTestTags.argument("password")).assertExists()
+        assertTrue(state.hasError)
+
+        onNodeWithTag(EditMediaSourceTestTags.argument("username")).performTextInput("test-user")
+        onNodeWithTag(EditMediaSourceTestTags.argument("password")).performTextInput("test-password")
+        assertFalse(state.hasError)
 
         state.close()
     }

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
@@ -45,6 +45,10 @@ class StringParameter(
      */
     val sanitize: (String) -> String = NoopSanitizer,
     override val visibleWhen: MediaSourceParameterVisibilityCondition? = null,
+    /**
+     * Whether editing UIs should treat this value as sensitive and conceal it from view.
+     */
+    val isSensitive: Boolean = false,
 ) : MediaSourceParameter<String> {
     val validate: (String) -> Boolean = {
         if (isRequired && it.isBlank()) {

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
@@ -4,9 +4,28 @@ sealed interface MediaSourceParameter<T> {
     val name: String
     val description: String?  // todo: how to localize?
     val default: () -> T
+    val visibleWhen: MediaSourceParameterVisibilityCondition?
+        get() = null
 
     fun parseFromString(value: String): T
 }
+
+/**
+ * Shows a parameter only while [parameterName] has one of [acceptedValues].
+ * A `null` condition means the parameter is always visible.
+ */
+data class MediaSourceParameterVisibilityCondition(
+    val parameterName: String,
+    val acceptedValues: Set<String>,
+) {
+    init {
+        require(parameterName.isNotEmpty()) { "parameterName must not be empty" }
+        require(acceptedValues.isNotEmpty()) { "acceptedValues must not be empty" }
+    }
+}
+
+fun MediaSourceParameter<*>.hasValue(vararg acceptedValues: String): MediaSourceParameterVisibilityCondition =
+    MediaSourceParameterVisibilityCondition(name, acceptedValues.toSet())
 
 private val TrueValidator: (String) -> Boolean = { true }
 private val NoopSanitizer: (String) -> String = { it }
@@ -25,6 +44,7 @@ class StringParameter(
      * 用户每输入一个字都会用整个编辑框的值调用这个函数, 可用于自动清除首尾空格等
      */
     val sanitize: (String) -> String = NoopSanitizer,
+    override val visibleWhen: MediaSourceParameterVisibilityCondition? = null,
 ) : MediaSourceParameter<String> {
     val validate: (String) -> Boolean = {
         if (isRequired && it.isBlank()) {
@@ -47,6 +67,7 @@ data class BooleanParameter(
     override val name: String,
     override val description: String? = null,
     override val default: () -> Boolean,
+    override val visibleWhen: MediaSourceParameterVisibilityCondition? = null,
 ) : MediaSourceParameter<Boolean> {
     init {
         require(name.isNotEmpty()) { "name must not be empty" }
@@ -62,6 +83,7 @@ data class SimpleEnumParameter(
     val oneOf: List<String>,
     override val description: String? = null,
     override val default: () -> String,
+    override val visibleWhen: MediaSourceParameterVisibilityCondition? = null,
 ) : MediaSourceParameter<String> {
     init {
         require(name.isNotEmpty()) { "name must not be empty" }

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
@@ -45,10 +45,6 @@ class StringParameter(
      */
     val sanitize: (String) -> String = NoopSanitizer,
     override val visibleWhen: MediaSourceParameterVisibilityCondition? = null,
-    /**
-     * Whether editing UIs should treat this value as sensitive and conceal it from view.
-     */
-    val isSensitive: Boolean = false,
 ) : MediaSourceParameter<String> {
     val validate: (String) -> Boolean = {
         if (isRequired && it.isBlank()) {

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
@@ -29,7 +29,6 @@ open class MediaSourceParametersBuilder {
         description: String? = null,
         placeholder: String? = null,
         visibleWhen: MediaSourceParameterVisibilityCondition? = null,
-        isSensitive: Boolean = false,
     ): StringParameter {
         val param = StringParameter(
             name, description,
@@ -37,7 +36,6 @@ open class MediaSourceParametersBuilder {
             isRequired = defaultProvider == null,
             placeholder = placeholder,
             visibleWhen = visibleWhen,
-            isSensitive = isSensitive,
         )
         add(param)
         return param

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
@@ -28,12 +28,14 @@ open class MediaSourceParametersBuilder {
         defaultProvider: (() -> String)? = null,
         description: String? = null,
         placeholder: String? = null,
+        visibleWhen: MediaSourceParameterVisibilityCondition? = null,
     ): StringParameter {
         val param = StringParameter(
             name, description,
             default = defaultProvider ?: { "" },
             isRequired = defaultProvider == null,
             placeholder = placeholder,
+            visibleWhen = visibleWhen,
         )
         add(param)
         return param
@@ -46,8 +48,14 @@ open class MediaSourceParametersBuilder {
         name: String,
         default: Boolean,
         description: String? = null,
+        visibleWhen: MediaSourceParameterVisibilityCondition? = null,
     ): BooleanParameter {
-        val param = BooleanParameter(name, description) { default }
+        val param = BooleanParameter(
+            name = name,
+            description = description,
+            default = { default },
+            visibleWhen = visibleWhen,
+        )
         add(param)
         return param
     }
@@ -60,8 +68,15 @@ open class MediaSourceParametersBuilder {
         oneOf: List<String>,
         default: String,
         description: String? = null,
+        visibleWhen: MediaSourceParameterVisibilityCondition? = null,
     ): SimpleEnumParameter {
-        val param = SimpleEnumParameter(name, oneOf, description) { default }
+        val param = SimpleEnumParameter(
+            name = name,
+            oneOf = oneOf,
+            description = description,
+            default = { default },
+            visibleWhen = visibleWhen,
+        )
         add(param)
         return param
     }
@@ -74,7 +89,8 @@ open class MediaSourceParametersBuilder {
         vararg oneOf: String,
         default: String,
         description: String? = null,
-    ) = simpleEnum(name, oneOf.toList(), default, description)
+        visibleWhen: MediaSourceParameterVisibilityCondition? = null,
+    ) = simpleEnum(name, oneOf.toList(), default, description, visibleWhen)
 
     fun <T> add(parameter: MediaSourceParameter<T>): MediaSourceParameter<T> {
         list.add(parameter)

--- a/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
+++ b/datasource/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
@@ -29,6 +29,7 @@ open class MediaSourceParametersBuilder {
         description: String? = null,
         placeholder: String? = null,
         visibleWhen: MediaSourceParameterVisibilityCondition? = null,
+        isSensitive: Boolean = false,
     ): StringParameter {
         val param = StringParameter(
             name, description,
@@ -36,6 +37,7 @@ open class MediaSourceParametersBuilder {
             isRequired = defaultProvider == null,
             placeholder = placeholder,
             visibleWhen = visibleWhen,
+            isSensitive = isSensitive,
         )
         add(param)
         return param

--- a/datasource/jellyfin/build.gradle.kts
+++ b/datasource/jellyfin/build.gradle.kts
@@ -20,6 +20,12 @@ kotlin {
     androidLibrary {
         namespace = "me.him188.ani.datasources.jellyfin"
     }
+    sourceSets.commonTest {
+        dependencies {
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
+        }
+    }
 }
 
 dependencies {

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -10,11 +10,13 @@
 package me.him188.ani.datasources.jellyfin
 
 import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -47,8 +49,21 @@ abstract class BaseJellyfinMediaSource(
     private val client: ScopedHttpClient,
 ) : HttpMediaSource() {
     abstract val baseUrl: String
-    abstract val userId: String
-    abstract val apiKey: String
+
+    protected data class Authorization(
+        val userId: String,
+        val accessToken: String,
+        val headerValue: String,
+    )
+
+    protected abstract suspend fun getAuthorization(): Authorization
+
+    /**
+     * Invalidates [authorization] after the server rejects it.
+     *
+     * @return `true` when the request can be retried with a newly acquired authorization.
+     */
+    protected open suspend fun invalidateAuthorization(authorization: Authorization): Boolean = false
 
     override suspend fun checkConnection(): ConnectionStatus {
         try {
@@ -63,7 +78,7 @@ abstract class BaseJellyfinMediaSource(
 
     override suspend fun fetch(query: MediaFetchRequest): SizedSource<MediaMatch> {
         return SinglePagePagedSource {
-            query.subjectNames
+            val items = query.subjectNames
                 .asFlow()
                 .flatMapConcat { subjectName ->
                     val (baseName, targetSeason) = parseSubjectName(subjectName)
@@ -100,6 +115,9 @@ abstract class BaseJellyfinMediaSource(
                 .filter { (it.Type == "Episode" || it.Type == "Movie") }
                 .toList()
                 .distinctBy { it.Id }
+
+            val authorization = getAuthorization()
+            items
                 .mapNotNull { item ->
                     val (originalTitle, episodeRange) = when (item.Type) {
                         "Episode" -> {
@@ -124,7 +142,7 @@ abstract class BaseJellyfinMediaSource(
                             mediaSourceId = mediaSourceId,
                             originalUrl = "$baseUrl/Items/${item.Id}",
                             download = ResourceLocation.HttpStreamingFile(
-                                uri = getDownloadUri(item.Id),
+                                uri = getDownloadUri(item.Id, authorization.accessToken),
                             ),
                             originalTitle = originalTitle,
                             publishedTime = 0,
@@ -155,7 +173,7 @@ abstract class BaseJellyfinMediaSource(
         }
     }
 
-    protected abstract fun getDownloadUri(itemId: String): String
+    protected abstract fun getDownloadUri(itemId: String, accessToken: String): String
 
     private fun getSubtitles(itemId: String, mediaStreams: List<MediaStream>): List<Subtitle> {
         return mediaStreams
@@ -221,45 +239,67 @@ abstract class BaseJellyfinMediaSource(
         }
     }
 
-    private suspend fun doGetSeasons(seriesId: String) = client.use {
-        get("$baseUrl/Shows/$seriesId/Seasons") {
-            configureAuthorizationHeaders()
-            parameter("userId", userId)
-        }.body<SearchResponse>()
+    private suspend fun doGetSeasons(seriesId: String): SearchResponse {
+        return authorizedGet("$baseUrl/Shows/$seriesId/Seasons")
     }
 
-    private suspend fun doGetEpisodes(seriesId: String, seasonNum: Int) = client.use {
-        get("$baseUrl/Shows/$seriesId/Episodes") {
-            configureAuthorizationHeaders()
-            parameter("userId", userId)
+    private suspend fun doGetEpisodes(seriesId: String, seasonNum: Int): SearchResponse {
+        return authorizedGet("$baseUrl/Shows/$seriesId/Episodes") {
             parameter("Season", seasonNum)
             parameter("fields", "MediaStreams")
-        }.body<SearchResponse>()
+        }
     }
 
     private suspend fun doSearch(
         subjectName: String? = null,
         recursive: Boolean = true,
         parentId: String? = null,
-    ) = client.use {
-        get("$baseUrl/Items") {
-            configureAuthorizationHeaders()
-            parameter("userId", userId)
+    ): SearchResponse {
+        return authorizedGet("$baseUrl/Items") {
             parameter("enableImages", false)
             parameter("recursive", recursive)
             parameter("searchTerm", subjectName)
             parameter("fields", "MediaStreams")
             parameter("parentId", parentId)
-        }.body<SearchResponse>()
+        }
     }
 
-    private fun HttpRequestBuilder.configureAuthorizationHeaders() {
-        header(
-            HttpHeaders.Authorization,
-            "MediaBrowser Token=\"$apiKey\"",
-        )
+    private suspend inline fun <reified T> authorizedGet(
+        url: String,
+        crossinline configure: HttpRequestBuilder.() -> Unit = {},
+    ): T {
+        var authorization = getAuthorization()
+        var hasRetried = false
+
+        while (true) {
+            try {
+                return client.use {
+                    val response = get(url) {
+                        header(HttpHeaders.Authorization, authorization.headerValue)
+                        parameter("userId", authorization.userId)
+                        configure()
+                    }
+                    if (response.status == HttpStatusCode.Unauthorized) {
+                        throw JellyfinAuthorizationException()
+                    }
+                    response.body()
+                }
+            } catch (e: Throwable) {
+                val isUnauthorized = e is JellyfinAuthorizationException ||
+                        (e is ClientRequestException && e.response.status == HttpStatusCode.Unauthorized)
+                if (!isUnauthorized || hasRetried || !invalidateAuthorization(authorization)) {
+                    throw e
+                }
+
+                hasRetried = true
+                authorization = getAuthorization()
+            }
+        }
     }
 }
+
+private class JellyfinAuthorizationException :
+    IllegalStateException("Jellyfin rejected the configured authorization")
 
 @Serializable
 private class SearchResponse(

--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -284,16 +284,21 @@ abstract class BaseJellyfinMediaSource(
                     }
                     response.body()
                 }
-            } catch (e: Throwable) {
-                val isUnauthorized = e is JellyfinAuthorizationException ||
-                        (e is ClientRequestException && e.response.status == HttpStatusCode.Unauthorized)
-                if (!isUnauthorized || hasRetried || !invalidateAuthorization(authorization)) {
+            } catch (e: JellyfinAuthorizationException) {
+                if (hasRetried || !invalidateAuthorization(authorization)) {
                     throw e
                 }
-
-                hasRetried = true
-                authorization = getAuthorization()
+            } catch (e: ClientRequestException) {
+                if (e.response.status != HttpStatusCode.Unauthorized ||
+                    hasRetried ||
+                    !invalidateAuthorization(authorization)
+                ) {
+                    throw e
+                }
             }
+
+            hasRetried = true
+            authorization = getAuthorization()
         }
     }
 }

--- a/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
@@ -51,7 +51,7 @@ class EmbyMediaSource(
     }
 
     class Factory : MediaSourceFactory {
-        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+        override val factoryId: FactoryId get() = FactoryId(ID)
 
         override val parameters: MediaSourceParameters = Parameters.build()
         override val info: MediaSourceInfo get() = INFO

--- a/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/EmbyMediaSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -67,10 +67,18 @@ class EmbyMediaSource(
     override val info: MediaSourceInfo get() = INFO
     override val mediaSourceId: String get() = ID
     override val baseUrl = config[Parameters.baseUrl].removeSuffix("/")
-    override val userId = config[Parameters.userId]
-    override val apiKey = config[Parameters.apikey]
+    private val userId = config[Parameters.userId]
+    private val apiKey = config[Parameters.apikey]
 
-    override fun getDownloadUri(itemId: String): String {
-        return "$baseUrl/Items/$itemId/Download?api_key=$apiKey"
+    override suspend fun getAuthorization(): Authorization {
+        return Authorization(
+            userId = userId,
+            accessToken = apiKey,
+            headerValue = """MediaBrowser Token="$apiKey"""",
+        )
+    }
+
+    override fun getDownloadUri(itemId: String, accessToken: String): String {
+        return "$baseUrl/Items/$itemId/Download?api_key=$accessToken"
     }
 }

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinAuthentication.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinAuthentication.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.datasources.jellyfin
+
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.him188.ani.utils.ktor.ScopedHttpClient
+
+internal data class JellyfinLoginSession(
+    val userId: String,
+    val accessToken: String,
+    val authorizationHeader: String,
+)
+
+internal class JellyfinPasswordAuthenticator(
+    private val baseUrl: String,
+    private val username: String,
+    private val password: String,
+    private val deviceId: String,
+    private val client: ScopedHttpClient,
+) {
+    private val sessionMutex = Mutex()
+    private var session: JellyfinLoginSession? = null
+
+    suspend fun getSession(): JellyfinLoginSession = sessionMutex.withLock {
+        session ?: authenticate().also { session = it }
+    }
+
+    suspend fun invalidate(accessToken: String) {
+        sessionMutex.withLock {
+            if (session?.accessToken == accessToken) {
+                session = null
+            }
+        }
+    }
+
+    private suspend fun authenticate(): JellyfinLoginSession {
+        require(username.isNotBlank()) {
+            "Jellyfin username must not be blank when username/password authentication is selected"
+        }
+
+        val authorizationHeader = buildAuthorizationHeader(accessToken = null)
+        val result = try {
+            client.use {
+                val response = post("$baseUrl/Users/AuthenticateByName") {
+                    header(HttpHeaders.Authorization, authorizationHeader)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        AuthenticateUserByNameRequest(
+                            username = username,
+                            password = password,
+                        ),
+                    )
+                }
+                if (response.status == HttpStatusCode.Unauthorized) {
+                    throw JellyfinLoginException()
+                }
+                response.body<AuthenticationResult>()
+            }
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Unauthorized) {
+                throw JellyfinLoginException()
+            }
+            throw e
+        }
+
+        val accessToken = result.accessToken?.takeIf { it.isNotBlank() }
+            ?: throw JellyfinLoginException("Jellyfin login response did not include an access token")
+        val userId = result.user?.id?.takeIf { it.isNotBlank() }
+            ?: throw JellyfinLoginException("Jellyfin login response did not include a user id")
+
+        return JellyfinLoginSession(
+            userId = userId,
+            accessToken = accessToken,
+            authorizationHeader = buildAuthorizationHeader(accessToken),
+        )
+    }
+
+    private fun buildAuthorizationHeader(accessToken: String?): String {
+        val values = buildList {
+            add("""Client="Animeko"""")
+            add("""Device="Animeko"""")
+            add("""DeviceId="$deviceId"""")
+            add("""Version="1.0"""")
+            if (accessToken != null) {
+                add("""Token="$accessToken"""")
+            }
+        }
+        return values.joinToString(separator = ", ", prefix = "MediaBrowser ")
+    }
+}
+
+internal class JellyfinLoginException(
+    message: String = "Jellyfin rejected the username or password",
+) : IllegalStateException(message)
+
+@Serializable
+private data class AuthenticateUserByNameRequest(
+    @SerialName("Username")
+    val username: String,
+    @SerialName("Pw")
+    val password: String,
+)
+
+@Serializable
+private data class AuthenticationResult(
+    @SerialName("AccessToken")
+    val accessToken: String? = null,
+    @SerialName("User")
+    val user: AuthenticationUser? = null,
+)
+
+@Serializable
+private data class AuthenticationUser(
+    @SerialName("Id")
+    val id: String? = null,
+)

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinAuthentication.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinAuthentication.kt
@@ -70,13 +70,13 @@ internal class JellyfinPasswordAuthenticator(
                         ),
                     )
                 }
-                if (response.status == HttpStatusCode.Unauthorized) {
+                if (response.status.isLoginRejected()) {
                     throw JellyfinLoginException()
                 }
                 response.body<AuthenticationResult>()
             }
         } catch (e: ClientRequestException) {
-            if (e.response.status == HttpStatusCode.Unauthorized) {
+            if (e.response.status.isLoginRejected()) {
                 throw JellyfinLoginException()
             }
             throw e
@@ -109,8 +109,12 @@ internal class JellyfinPasswordAuthenticator(
 }
 
 internal class JellyfinLoginException(
-    message: String = "Jellyfin rejected the username or password",
+    message: String = "Jellyfin rejected the login request",
 ) : IllegalStateException(message)
+
+private fun HttpStatusCode.isLoginRejected(): Boolean {
+    return this == HttpStatusCode.Unauthorized || this == HttpStatusCode.Forbidden
+}
 
 @Serializable
 private data class AuthenticateUserByNameRequest(

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -76,7 +76,6 @@ class JellyfinMediaSource(
             "password",
             description = "仅用户名密码模式使用",
             visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
-            isSensitive = true,
         )
     }
 

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -18,6 +18,7 @@ import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.source.get
 import me.him188.ani.datasources.api.source.parameter.MediaSourceParameters
 import me.him188.ani.datasources.api.source.parameter.MediaSourceParametersBuilder
+import me.him188.ani.datasources.api.source.parameter.hasValue
 import me.him188.ani.utils.ktor.ScopedHttpClient
 
 class JellyfinMediaSource(
@@ -55,11 +56,13 @@ class JellyfinMediaSource(
             "userId",
             defaultProvider = { "" },
             description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - 用户\" 中选择一个用户, 在浏览器地址栏找到 \"userId=\" 后面的内容",
+            visibleWhen = authMode.hasValue(AUTH_MODE_API_KEY),
         )
         val apikey = string(
             "apikey",
             defaultProvider = { "" },
             description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - API 秘钥\" 中添加",
+            visibleWhen = authMode.hasValue(AUTH_MODE_API_KEY),
         )
         // SECURITY: Legacy media-source parameters are serialized as plain text in
         // MediaSourceConfig.arguments. Password authentication intentionally uses the same local
@@ -70,11 +73,13 @@ class JellyfinMediaSource(
             "username",
             defaultProvider = { "" },
             description = "仅用户名密码模式使用",
+            visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
         )
         val password = string(
             "password",
             defaultProvider = { "" },
             description = "仅用户名密码模式使用",
+            visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
         )
     }
 

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -54,13 +54,11 @@ class JellyfinMediaSource(
         )
         val userId = string(
             "userId",
-            defaultProvider = { "" },
             description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - 用户\" 中选择一个用户, 在浏览器地址栏找到 \"userId=\" 后面的内容",
             visibleWhen = authMode.hasValue(AUTH_MODE_API_KEY),
         )
         val apikey = string(
             "apikey",
-            defaultProvider = { "" },
             description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - API 秘钥\" 中添加",
             visibleWhen = authMode.hasValue(AUTH_MODE_API_KEY),
         )
@@ -71,13 +69,11 @@ class JellyfinMediaSource(
         // Code handling logs, exports, or diagnostics must redact both secrets.
         val username = string(
             "username",
-            defaultProvider = { "" },
             description = "仅用户名密码模式使用",
             visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
         )
         val password = string(
             "password",
-            defaultProvider = { "" },
             description = "仅用户名密码模式使用",
             visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
         )

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -76,6 +76,7 @@ class JellyfinMediaSource(
             "password",
             description = "仅用户名密码模式使用",
             visibleWhen = authMode.hasValue(AUTH_MODE_USERNAME_PASSWORD),
+            isSensitive = true,
         )
     }
 

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -20,10 +20,16 @@ import me.him188.ani.datasources.api.source.parameter.MediaSourceParameters
 import me.him188.ani.datasources.api.source.parameter.MediaSourceParametersBuilder
 import me.him188.ani.utils.ktor.ScopedHttpClient
 
-class JellyfinMediaSource(config: MediaSourceConfig, client: ScopedHttpClient) :
-    BaseJellyfinMediaSource(client) {
+class JellyfinMediaSource(
+    config: MediaSourceConfig,
+    client: ScopedHttpClient,
+    instanceId: String = ID,
+) : BaseJellyfinMediaSource(client) {
     companion object {
         const val ID = "jellyfin"
+        const val AUTH_MODE_API_KEY = "apiKey"
+        const val AUTH_MODE_USERNAME_PASSWORD = "usernamePassword"
+
         val INFO = MediaSourceInfo(
             displayName = "Jellyfin",
             description = "Jellyfin Media Server",
@@ -38,13 +44,32 @@ class JellyfinMediaSource(config: MediaSourceConfig, client: ScopedHttpClient) :
             defaultProvider = { "http://localhost:8096" },
             description = "服务器地址\n示例: http://localhost:8096",
         )
+        val authMode = simpleEnum(
+            "authMode",
+            AUTH_MODE_API_KEY,
+            AUTH_MODE_USERNAME_PASSWORD,
+            default = AUTH_MODE_API_KEY,
+            description = "认证方式: apiKey 使用 User ID 与 API Key; usernamePassword 使用用户名与密码登录",
+        )
         val userId = string(
             "userId",
-            description = "User ID, 可在 Jellyfin \"控制台 - 用户\" 中选择一个用户, 在浏览器地址栏找到 \"userId=\" 后面的内容\n示例: cc91f58d951648829c90115520f6adec",
+            defaultProvider = { "" },
+            description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - 用户\" 中选择一个用户, 在浏览器地址栏找到 \"userId=\" 后面的内容",
         )
         val apikey = string(
             "apikey",
-            description = "API Key, 可在 Jellyfin \"控制台 - API 秘钥\" 中添加\n示例: b7292a71d51a6bf3a31036086a6d2e23",
+            defaultProvider = { "" },
+            description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - API 秘钥\" 中添加",
+        )
+        val username = string(
+            "username",
+            defaultProvider = { "" },
+            description = "仅用户名密码模式使用",
+        )
+        val password = string(
+            "password",
+            defaultProvider = { "" },
+            description = "仅用户名密码模式使用。当前可行性实现会将密码随数据源配置保存",
         )
     }
 
@@ -58,17 +83,60 @@ class JellyfinMediaSource(config: MediaSourceConfig, client: ScopedHttpClient) :
             mediaSourceId: String,
             config: MediaSourceConfig,
             client: ScopedHttpClient
-        ): MediaSource = JellyfinMediaSource(config, client)
+        ): MediaSource = JellyfinMediaSource(config, client, instanceId = mediaSourceId)
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB
     override val info: MediaSourceInfo = INFO
     override val mediaSourceId: String get() = ID
     override val baseUrl = config[Parameters.baseUrl].removeSuffix("/")
-    override val userId = config[Parameters.userId]
-    override val apiKey = config[Parameters.apikey]
+    private val authMode = config[Parameters.authMode]
+    private val userId = config[Parameters.userId]
+    private val apiKey = config[Parameters.apikey]
+    private val passwordAuthenticator = if (authMode == AUTH_MODE_USERNAME_PASSWORD) {
+        JellyfinPasswordAuthenticator(
+            baseUrl = baseUrl,
+            username = config[Parameters.username],
+            password = config[Parameters.password],
+            deviceId = "animeko-$instanceId",
+            client = client,
+        )
+    } else {
+        null
+    }
 
-    override fun getDownloadUri(itemId: String): String {
-        return "$baseUrl/Items/$itemId/Download?ApiKey=$apiKey"
+    override suspend fun getAuthorization(): Authorization {
+        return when (authMode) {
+            AUTH_MODE_API_KEY -> {
+                require(userId.isNotBlank()) { "Jellyfin userId must not be blank in API Key mode" }
+                require(apiKey.isNotBlank()) { "Jellyfin API Key must not be blank in API Key mode" }
+                Authorization(
+                    userId = userId,
+                    accessToken = apiKey,
+                    headerValue = """MediaBrowser Token="$apiKey"""",
+                )
+            }
+
+            AUTH_MODE_USERNAME_PASSWORD -> {
+                val session = checkNotNull(passwordAuthenticator).getSession()
+                Authorization(
+                    userId = session.userId,
+                    accessToken = session.accessToken,
+                    headerValue = session.authorizationHeader,
+                )
+            }
+
+            else -> error("Unknown Jellyfin authentication mode: $authMode")
+        }
+    }
+
+    override suspend fun invalidateAuthorization(authorization: Authorization): Boolean {
+        val authenticator = passwordAuthenticator ?: return false
+        authenticator.invalidate(authorization.accessToken)
+        return true
+    }
+
+    override fun getDownloadUri(itemId: String, accessToken: String): String {
+        return "$baseUrl/Items/$itemId/Download?ApiKey=$accessToken"
     }
 }

--- a/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/JellyfinMediaSource.kt
@@ -61,6 +61,11 @@ class JellyfinMediaSource(
             defaultProvider = { "" },
             description = "仅 API Key 模式使用。可在 Jellyfin \"控制台 - API 秘钥\" 中添加",
         )
+        // SECURITY: Legacy media-source parameters are serialized as plain text in
+        // MediaSourceConfig.arguments. Password authentication intentionally uses the same local
+        // storage path as API-key authentication; neither secret is protected by an OS credential
+        // store. An HTTP base URL also sends the login password without transport encryption.
+        // Code handling logs, exports, or diagnostics must redact both secrets.
         val username = string(
             "username",
             defaultProvider = { "" },
@@ -69,7 +74,7 @@ class JellyfinMediaSource(
         val password = string(
             "password",
             defaultProvider = { "" },
-            description = "仅用户名密码模式使用。当前可行性实现会将密码随数据源配置保存",
+            description = "仅用户名密码模式使用",
         )
     }
 

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -69,6 +69,7 @@ class JellyfinMediaSourceAuthenticationTest {
             setOf(JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD),
             JellyfinMediaSource.Parameters.password.visibleWhen?.acceptedValues,
         )
+        assertTrue(JellyfinMediaSource.Parameters.password.isSensitive)
     }
 
     @Test

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -48,6 +48,30 @@ import kotlin.test.assertTrue
 
 class JellyfinMediaSourceAuthenticationTest {
     @Test
+    fun `authentication parameters are visible only for their mode`() {
+        assertEquals(
+            JellyfinMediaSource.Parameters.authMode.name,
+            JellyfinMediaSource.Parameters.userId.visibleWhen?.parameterName,
+        )
+        assertEquals(
+            setOf(JellyfinMediaSource.AUTH_MODE_API_KEY),
+            JellyfinMediaSource.Parameters.userId.visibleWhen?.acceptedValues,
+        )
+        assertEquals(
+            setOf(JellyfinMediaSource.AUTH_MODE_API_KEY),
+            JellyfinMediaSource.Parameters.apikey.visibleWhen?.acceptedValues,
+        )
+        assertEquals(
+            setOf(JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD),
+            JellyfinMediaSource.Parameters.username.visibleWhen?.acceptedValues,
+        )
+        assertEquals(
+            setOf(JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD),
+            JellyfinMediaSource.Parameters.password.visibleWhen?.acceptedValues,
+        )
+    }
+
+    @Test
     fun `password mode logs in once and reuses the returned session`() = runTest {
         var loginCount = 0
         var itemsCount = 0

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -23,6 +23,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -37,6 +40,7 @@ import me.him188.ani.datasources.api.topic.ResourceLocation
 import me.him188.ani.utils.ktor.asScopedHttpClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -92,6 +96,48 @@ class JellyfinMediaSourceAuthenticationTest {
         assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
         assertEquals(1, loginCount)
         assertEquals(2, itemsCount)
+    }
+
+    @Test
+    fun `concurrent requests share one login session`() = runTest {
+        var loginCount = 0
+        var itemsCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> {
+                        itemsCount++
+                        respondJson("""{"Items":[]}""")
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        coroutineScope {
+            List(8) {
+                async { source.checkConnection() }
+            }.awaitAll().forEach { status ->
+                assertEquals(ConnectionStatus.SUCCESS, status)
+            }
+        }
+
+        assertEquals(1, loginCount)
+        assertEquals(8, itemsCount)
     }
 
     @Test
@@ -291,19 +337,25 @@ class JellyfinMediaSourceAuthenticationTest {
     }
 
     @Test
-    fun `invalid password reports a failed connection without querying items`() = runTest {
-        var loginCount = 0
-        val source = JellyfinMediaSource(
-            config = passwordConfig(),
-            client = mockClient { request ->
-                assertEquals("/Users/AuthenticateByName", request.url.encodedPath)
-                loginCount++
-                respondJson("""{"error":"invalid credentials"}""", HttpStatusCode.Unauthorized)
-            },
-        )
+    fun `rejected login reports a failed connection without querying items`() = runTest {
+        for (status in listOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden)) {
+            var loginCount = 0
+            val source = JellyfinMediaSource(
+                config = passwordConfig(),
+                client = mockClient { request ->
+                    assertEquals("/Users/AuthenticateByName", request.url.encodedPath)
+                    loginCount++
+                    respondJson("""{"error":"invalid credentials"}""", status)
+                },
+            )
 
-        assertEquals(ConnectionStatus.FAILED, source.checkConnection())
-        assertEquals(1, loginCount)
+            assertEquals(ConnectionStatus.FAILED, source.checkConnection())
+            val pagedSource = assertIs<PagedSource<MediaMatch>>(source.fetch(testRequest()))
+            assertFailsWith<JellyfinLoginException> {
+                pagedSource.nextPageOrNull()
+            }
+            assertEquals(2, loginCount)
+        }
     }
 
     private fun passwordConfig() = MediaSourceConfig(

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -1,0 +1,352 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.datasources.jellyfin
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.paging.PagedSource
+import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.api.source.MediaFetchRequest
+import me.him188.ani.datasources.api.source.MediaMatch
+import me.him188.ani.datasources.api.source.MediaSourceConfig
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class JellyfinMediaSourceAuthenticationTest {
+    @Test
+    fun `password mode logs in once and reuses the returned session`() = runTest {
+        var loginCount = 0
+        var itemsCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        assertEquals(HttpMethod.Post, request.method)
+                        assertEquals(
+                            """MediaBrowser Client="Animeko", Device="Animeko", DeviceId="animeko-source-instance", Version="1.0"""",
+                            request.headers[HttpHeaders.Authorization],
+                        )
+                        assertFalse(request.url.toString().contains("test-password"))
+                        val body = request.jsonBody()
+                        assertEquals("test-user", body.getValue("Username").jsonPrimitive.content)
+                        assertEquals("test-password", body.getValue("Pw").jsonPrimitive.content)
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> {
+                        itemsCount++
+                        assertEquals("session-user-id", request.url.parameters["userId"])
+                        assertEquals(
+                            """MediaBrowser Client="Animeko", Device="Animeko", DeviceId="animeko-source-instance", Version="1.0", Token="session-token"""",
+                            request.headers[HttpHeaders.Authorization],
+                        )
+                        respondJson("""{"Items":[]}""")
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+            instanceId = "source-instance",
+        )
+
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(1, loginCount)
+        assertEquals(2, itemsCount)
+    }
+
+    @Test
+    fun `password mode reauthenticates once after an unauthorized response`() = runTest {
+        var loginCount = 0
+        var itemsCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token-$loginCount",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> {
+                        itemsCount++
+                        when (itemsCount) {
+                            1 -> {
+                                assertTrue(
+                                    request.headers[HttpHeaders.Authorization]
+                                        .orEmpty()
+                                        .contains("""Token="session-token-1""""),
+                                )
+                                respondJson("""{"error":"invalid token"}""", HttpStatusCode.Unauthorized)
+                            }
+
+                            2 -> {
+                                assertTrue(
+                                    request.headers[HttpHeaders.Authorization]
+                                        .orEmpty()
+                                        .contains("""Token="session-token-2""""),
+                                )
+                                respondJson("""{"Items":[]}""")
+                            }
+
+                            else -> error("Unexpected Items request #$itemsCount")
+                        }
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(2, loginCount)
+        assertEquals(2, itemsCount)
+    }
+
+    @Test
+    fun `password mode does not retry indefinitely when reauthentication is rejected`() = runTest {
+        var loginCount = 0
+        var itemsCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token-$loginCount",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> {
+                        itemsCount++
+                        respondJson("""{"error":"not authorized"}""", HttpStatusCode.Unauthorized)
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        assertEquals(ConnectionStatus.FAILED, source.checkConnection())
+        assertEquals(2, loginCount)
+        assertEquals(2, itemsCount)
+    }
+
+    @Test
+    fun `legacy configuration keeps using api key mode without login`() = runTest {
+        var itemsCount = 0
+        val source = JellyfinMediaSource(
+            config = MediaSourceConfig(
+                arguments = mapOf(
+                    "baseUrl" to TEST_BASE_URL,
+                    "userId" to "legacy-user-id",
+                    "apikey" to "legacy-api-key",
+                ),
+            ),
+            client = mockClient { request ->
+                assertEquals("/Items", request.url.encodedPath)
+                itemsCount++
+                assertEquals("legacy-user-id", request.url.parameters["userId"])
+                assertEquals(
+                    """MediaBrowser Token="legacy-api-key"""",
+                    request.headers[HttpHeaders.Authorization],
+                )
+                respondJson("""{"Items":[]}""")
+            },
+        )
+
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(1, itemsCount)
+    }
+
+    @Test
+    fun `emby keeps its existing api key authorization`() = runTest {
+        var itemsCount = 0
+        val source = EmbyMediaSource(
+            config = MediaSourceConfig(
+                arguments = mapOf(
+                    "baseUrl" to TEST_BASE_URL,
+                    "userId" to "emby-user-id",
+                    "apikey" to "emby-api-key",
+                ),
+            ),
+            client = mockClient { request ->
+                assertEquals("/Items", request.url.encodedPath)
+                itemsCount++
+                assertEquals("emby-user-id", request.url.parameters["userId"])
+                assertEquals(
+                    """MediaBrowser Token="emby-api-key"""",
+                    request.headers[HttpHeaders.Authorization],
+                )
+                respondJson("""{"Items":[]}""")
+            },
+        )
+
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(1, itemsCount)
+    }
+
+    @Test
+    fun `fetch creates a playable download url from the session token`() = runTest {
+        var loginCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "playback-session-token",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> respondJson(
+                        """
+                        {
+                          "Items": [
+                            {
+                              "Name": "Episode 1",
+                              "SeriesName": "Test Anime",
+                              "Id": "episode-1",
+                              "IndexNumber": 1,
+                              "Type": "Episode"
+                            }
+                          ]
+                        }
+                        """.trimIndent(),
+                    )
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        val pagedSource = assertIs<PagedSource<MediaMatch>>(source.fetch(testRequest()))
+        val results = assertNotNull(pagedSource.nextPageOrNull())
+        val media = results.single().media
+        val download = assertIs<ResourceLocation.HttpStreamingFile>(media.download)
+
+        assertEquals(
+            "$TEST_BASE_URL/Items/episode-1/Download?ApiKey=playback-session-token",
+            download.uri,
+        )
+        assertEquals(1, loginCount)
+    }
+
+    @Test
+    fun `invalid password reports a failed connection without querying items`() = runTest {
+        var loginCount = 0
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                assertEquals("/Users/AuthenticateByName", request.url.encodedPath)
+                loginCount++
+                respondJson("""{"error":"invalid credentials"}""", HttpStatusCode.Unauthorized)
+            },
+        )
+
+        assertEquals(ConnectionStatus.FAILED, source.checkConnection())
+        assertEquals(1, loginCount)
+    }
+
+    private fun passwordConfig() = MediaSourceConfig(
+        arguments = mapOf(
+            "baseUrl" to TEST_BASE_URL,
+            "authMode" to JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD,
+            "username" to "test-user",
+            "password" to "test-password",
+        ),
+    )
+
+    private fun testRequest() = MediaFetchRequest(
+        subjectId = "1",
+        episodeId = "1",
+        subjectNameCN = "Test Anime",
+        subjectNames = listOf("Test Anime"),
+        episodeSort = EpisodeSort(1),
+        episodeName = "Episode 1",
+    )
+
+    private fun mockClient(
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+    ) = HttpClient(MockEngine(handler)) {
+        expectSuccess = true
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }.asScopedHttpClient()
+
+    private fun HttpRequestData.jsonBody() = Json.parseToJsonElement(
+        assertIs<OutgoingContent.ByteArrayContent>(body).bytes().decodeToString(),
+    ).jsonObject
+
+    private fun MockRequestHandleScope.respondJson(
+        content: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ) = respond(
+        content = content,
+        status = status,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+    )
+
+    private companion object {
+        const val TEST_BASE_URL = "https://jellyfin.example.test"
+    }
+}

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -23,6 +23,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -217,6 +218,54 @@ class JellyfinMediaSourceAuthenticationTest {
 
         assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
         assertEquals(2, loginCount)
+        assertEquals(2, itemsCount)
+    }
+
+    @Test
+    fun `cancellation propagates without reauthentication or retry`() = runTest {
+        var loginCount = 0
+        var itemsCount = 0
+        val cancellation = CancellationException("test cancellation")
+        val source = JellyfinMediaSource(
+            config = passwordConfig(),
+            client = mockClient { request ->
+                when (request.url.encodedPath) {
+                    "/Users/AuthenticateByName" -> {
+                        loginCount++
+                        respondJson(
+                            """
+                            {
+                              "AccessToken": "session-token",
+                              "User": { "Id": "session-user-id" }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    "/Items" -> {
+                        itemsCount++
+                        if (itemsCount == 1) {
+                            throw cancellation
+                        }
+                        respondJson("""{"Items":[]}""")
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            },
+        )
+
+        val pagedSource = assertIs<PagedSource<MediaMatch>>(source.fetch(testRequest()))
+        val thrown = assertFailsWith<CancellationException> {
+            pagedSource.nextPageOrNull()
+        }
+
+        assertEquals(cancellation.message, thrown.message)
+        assertEquals(1, loginCount)
+        assertEquals(1, itemsCount)
+
+        assertEquals(ConnectionStatus.SUCCESS, source.checkConnection())
+        assertEquals(1, loginCount)
         assertEquals(2, itemsCount)
     }
 

--- a/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/JellyfinMediaSourceAuthenticationTest.kt
@@ -70,7 +70,6 @@ class JellyfinMediaSourceAuthenticationTest {
             setOf(JellyfinMediaSource.AUTH_MODE_USERNAME_PASSWORD),
             JellyfinMediaSource.Parameters.password.visibleWhen?.acceptedValues,
         )
-        assertTrue(JellyfinMediaSource.Parameters.password.isSensitive)
     }
 
     @Test


### PR DESCRIPTION
## 为什么修改

Animeko 当前配置 Jellyfin 数据源时，只支持填写 User ID 和 API Key。

这两个值需要用户进入 Jellyfin 管理后台分别查找或创建，配置步骤较多，也不符合普通用户使用媒体服务器时习惯的用户名和密码登录方式。

Jellyfin 提供了 `/Users/AuthenticateByName` 接口，可以通过用户名和密码获取当前用户 ID 与访问令牌。因此本 PR 在保留原有 API Key 认证方式的基础上，增加用户名密码认证模式。

## 做了什么

- 为 Jellyfin 数据源增加 `apiKey` 和 `usernamePassword` 两种认证模式。
- 调用 Jellyfin `Users/AuthenticateByName` 接口获取 User ID 和 Access Token。
- 缓存登录会话，多个并发请求共用一次登录过程。
- 请求返回 401 时清除失效会话，重新登录并仅重试一次。
- 查询媒体和生成播放地址时使用当前会话的 User ID 和 Access Token。
- 为数据源参数增加 `visibleWhen` 条件，设置界面只显示并校验当前认证模式所需字段。
- 在代码中记录当前凭据存储方式的安全风险，不在应用界面增加额外提示。

## 影响范围与兼容性

- 已有 Jellyfin 配置未包含 `authMode` 时，仍默认使用原有 API Key 模式，不需要迁移。
- Emby 继续使用原有 User ID 和 API Key 认证，不会调用用户名密码登录接口。
- `visibleWhen` 默认值为空，未使用该条件的其他数据源保持原有显示和校验行为。
- 本 PR 不修改 Jellyfin 的媒体检索、候选匹配和播放器逻辑。
- 用户名和密码当前与 API Key 一样保存在 `MediaSourceConfig.arguments` 中，不受操作系统凭据存储保护。
- 使用 HTTP 地址连接 Jellyfin 时，登录密码不受传输加密保护；建议使用可信局域网或 HTTPS。
- 令牌失效时会自动重新认证一次；如果凭据失效则正常返回失败，不会无限重试。

## 测试情况

自动化测试覆盖：

- 用户名密码登录及会话复用。
- 并发请求只触发一次登录。
- 401 后重新认证并重试一次。
- 重新认证仍失败时不无限重试。
- 旧配置继续使用 API Key。
- Emby 继续使用原有 API Key。
- 使用登录令牌生成播放地址。
- 登录失败时不继续查询媒体。
- 切换认证模式时只显示并校验对应字段。

实机测试环境：

- Jellyfin Server `10.11.11`

### Android 实机验证

#### Jellyfin 连接测试

Jellyfin Server `10.11.11` 连接测试通过。Jellyfin 条目右侧蓝色对勾表示该数据源已返回连接成功；截图时其他数据源仍在批量测试。

<p align="center">
  <img src="https://raw.githubusercontent.com/IT-BillDeng/animeko/pr-assets/jellyfin-user-login/pr-assets/jellyfin-user-login/android-connection-test.jpg" width="320" alt="Jellyfin 数据源连接测试成功">
</p>

#### 认证模式界面

API Key 与用户名密码模式可正常切换，界面仅显示并校验当前认证模式所需字段。

<p align="center">
  <img src="https://raw.githubusercontent.com/IT-BillDeng/animeko/pr-assets/jellyfin-user-login/pr-assets/jellyfin-user-login/android-api-key-mode.jpg" width="30%" alt="API Key 认证模式">
  <img src="https://raw.githubusercontent.com/IT-BillDeng/animeko/pr-assets/jellyfin-user-login/pr-assets/jellyfin-user-login/android-auth-mode-menu.jpg" width="30%" alt="认证模式选择">
  <img src="https://raw.githubusercontent.com/IT-BillDeng/animeko/pr-assets/jellyfin-user-login/pr-assets/jellyfin-user-login/android-username-password-mode.jpg" width="30%" alt="用户名密码认证模式">
</p>

已通过：

- `./gradlew check`
- macOS 应用手动测试
- Android APK 真机测试
- 登录令牌失效后的自动重新认证测试
- `:datasource:jellyfin:desktopTest`
- `:app:shared:ui-settings:desktopTest`
- `:datasource:jellyfin:compileAndroidMain`
- `:app:shared:ui-settings:compileAndroidMain`
