### PR TITLE
fix(danmaku): 手动匹配的弹幕源因 flow 重新订阅而丢失

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/danmaku/DanmakuLoader.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/danmaku/DanmakuLoader.kt
@@ -35,7 +35,7 @@ import me.him188.ani.danmaku.api.provider.DanmakuFetchResult
 import me.him188.ani.danmaku.api.provider.DanmakuMatchMethod
 import me.him188.ani.danmaku.api.provider.DanmakuProviderId
 import me.him188.ani.utils.coroutines.SingleTaskExecutor
-import me.him188.ani.utils.platform.collections.tupleOf
+import kotlin.concurrent.Volatile
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -75,7 +75,13 @@ class DanmakuLoaderImpl internal constructor(
     override val danmakuLoadingStateFlow: MutableStateFlow<DanmakuLoadingState> =
         MutableStateFlow(DanmakuLoadingState.Idle)
 
-    private val overrideResultsFlow = MutableStateFlow<Map<DanmakuProviderId, List<DanmakuFetchResult>>>(emptyMap())
+    private val overrideResultsFlow = MutableStateFlow(OverrideResults.Empty)
+
+    /**
+     * [fetchResultFlow] 正在加载的剧集, 用于标记 [overrideResults] 属于哪一集.
+     */
+    @Volatile
+    private var currentRequestKey: DanmakuRequestKey? = null
 
     private val originalFetchResultFlow = requestFlow.distinctUntilChanged().transformLatest { request ->
         emit(null) // 每次更换 mediaFetchSession 时 (ep 变更), 首先清空历史弹幕
@@ -117,13 +123,19 @@ class DanmakuLoaderImpl internal constructor(
     }.shareIn(flowScope, started = sharingStarted, replay = 1)
 
     override val fetchResultFlow: Flow<List<DanmakuFetchResult>?> = requestFlow
-        .distinctUntilChangedBy {
-            tupleOf(it?.subjectInfo?.subjectId, it?.episodeInfo?.episodeId)
-        }.flatMapLatest { req ->
-            // 每次切换剧集时, 这里会重新执行.
-            overrideResultsFlow.value = emptyMap() // 清空覆盖
+        .distinctUntilChangedBy { DanmakuRequestKey(it) }
+        .flatMapLatest { req ->
+            val requestKey = DanmakuRequestKey(req)
+            currentRequestKey = requestKey
 
-            combine(originalFetchResultFlow, overrideResultsFlow) { original, overrideResults ->
+            combine(originalFetchResultFlow, overrideResultsFlow) { original, override ->
+                // 手动匹配的结果只对执行匹配的那一集生效, 换集后自动作废.
+                //
+                // 这里不能直接清空 [overrideResultsFlow]: 本 flow 不只在切换剧集时执行, 每次
+                // 重新订阅都会重新执行 (切换全屏、进出内嵌详情页导致 UI 短暂停止收集, 或者调整
+                // 弹幕源开关/时间轴导致 DanmakuSession 重建), 清空会让手动匹配的弹幕源退回自动
+                // 匹配的结果. #2801
+                val overrideResults = if (override.requestKey == requestKey) override.results else emptyMap()
                 val accumulatedResults = computeFinalDanmakuResult(original, overrideResults)
                 if (accumulatedResults.isNotEmpty()) {
                     val subjectId = req?.subjectInfo?.subjectId
@@ -139,7 +151,7 @@ class DanmakuLoaderImpl internal constructor(
                 }
                 accumulatedResults
             }
-        }
+        }.shareIn(flowScope, started = sharingStarted, replay = 1)
 
     private fun computeFinalDanmakuResult(
         original: List<DanmakuFetchResult>?,
@@ -161,9 +173,38 @@ class DanmakuLoaderImpl internal constructor(
     }
 
     fun overrideResults(provider: DanmakuProviderId, result: List<DanmakuFetchResult>) {
+        val requestKey = currentRequestKey
         overrideResultsFlow.update {
-            it + (provider to result)
+            // 上一集的覆盖不再累加, 避免换集后残留
+            val existing = if (it.requestKey == requestKey) it.results else emptyMap()
+            OverrideResults(requestKey, existing + (provider to result))
         }
+    }
+
+    /**
+     * 手动匹配得到的弹幕结果, 以及它属于哪一集.
+     */
+    private class OverrideResults(
+        val requestKey: DanmakuRequestKey?,
+        val results: Map<DanmakuProviderId, List<DanmakuFetchResult>>,
+    ) {
+        companion object {
+            val Empty = OverrideResults(null, emptyMap())
+        }
+    }
+
+    /**
+     * 标识一次弹幕加载请求对应的剧集. 同一集内 [SearchDanmakuRequest] 还会因为视频文件名、时长等
+     * 变化而变化, 这些不影响手动匹配结果的有效性.
+     */
+    private data class DanmakuRequestKey(
+        val subjectId: Int?,
+        val episodeId: Int?,
+    ) {
+        constructor(request: SearchDanmakuRequest?) : this(
+            request?.subjectInfo?.subjectId,
+            request?.episodeInfo?.episodeId,
+        )
     }
 
     private fun List<DanmakuFetchResult>?.hasDisplayableDanmakus(): Boolean {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/danmaku/DanmakuLoader.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/danmaku/DanmakuLoader.kt
@@ -184,7 +184,7 @@ class DanmakuLoaderImpl internal constructor(
     /**
      * 手动匹配得到的弹幕结果, 以及它属于哪一集.
      */
-    private class OverrideResults(
+    private data class OverrideResults(
         val requestKey: DanmakuRequestKey?,
         val results: Map<DanmakuProviderId, List<DanmakuFetchResult>>,
     ) {

--- a/app/shared/app-data/src/commonTest/kotlin/domain/danmaku/DanmakuLoaderTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/danmaku/DanmakuLoaderTest.kt
@@ -9,6 +9,7 @@
 
 package me.him188.ani.app.domain.danmaku
 
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,6 +29,7 @@ import me.him188.ani.danmaku.api.provider.DanmakuMatchMethod
 import me.him188.ani.danmaku.api.provider.DanmakuProviderId
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class DanmakuLoaderTest {
     @Test
@@ -81,12 +83,55 @@ class DanmakuLoaderTest {
         }
     }
 
+    @Test
+    fun `manual override survives resubscription`() = runTest {
+        val localResults = MutableSharedFlow<List<DanmakuFetchResult>>()
+        val remoteResults = MutableSharedFlow<List<DanmakuFetchResult>>()
+        val loader = createLoader(localResults, remoteResults)
+
+        loader.fetchResultFlow.test {
+            assertEquals(emptyList(), awaitItem())
+
+            remoteResults.emit(listOf(remoteResult()))
+            assertResultIds(listOf("remote"), awaitItem())
+
+            loader.overrideResults(DanmakuProviderId.Animeko, listOf(overrideResult()))
+            assertResultIds(listOf("override"), awaitItem())
+        }
+
+        // UI 停止收集后重新订阅 (切换全屏、进出内嵌详情页等), 手动匹配的结果不应丢失
+        loader.fetchResultFlow.test {
+            awaitResultIds(listOf("override"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `manual override is dropped after switching episode`() = runTest {
+        val localResults = MutableSharedFlow<List<DanmakuFetchResult>>()
+        val remoteResults = MutableSharedFlow<List<DanmakuFetchResult>>()
+        val requestFlow = MutableStateFlow(createRequest())
+        val loader = createLoader(localResults, remoteResults, requestFlow)
+
+        loader.fetchResultFlow.test {
+            assertEquals(emptyList(), awaitItem())
+
+            loader.overrideResults(DanmakuProviderId.Animeko, listOf(overrideResult()))
+            assertResultIds(listOf("override"), awaitItem())
+
+            requestFlow.value = createRequest(episodeId = OTHER_EPISODE_ID)
+            awaitResultIds(emptyList())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun TestScope.createLoader(
         localResults: Flow<List<DanmakuFetchResult>>,
         remoteResults: Flow<List<DanmakuFetchResult>>,
+        requestFlow: Flow<SearchDanmakuRequest?> = MutableStateFlow(createRequest()),
     ): DanmakuLoaderImpl {
         return DanmakuLoaderImpl(
-            requestFlow = MutableStateFlow(createRequest()),
+            requestFlow = requestFlow,
             flowScope = backgroundScope,
             fetchFromLocal = { localResults },
             fetchFromAllRemotes = { remoteResults },
@@ -98,11 +143,22 @@ class DanmakuLoaderTest {
         assertEquals(expected, actual.orEmpty().flatMap { result -> result.list.map { it.id } })
     }
 
-    private fun createRequest(): SearchDanmakuRequest {
+    /**
+     * 等待直到收到 [expected]. 切换剧集与重新订阅都可能先重放上一个状态, 这些中间值不是本测试关心的.
+     */
+    private suspend fun ReceiveTurbine<List<DanmakuFetchResult>?>.awaitResultIds(expected: List<String>) {
+        repeat(10) {
+            val actual = awaitItem().orEmpty().flatMap { result -> result.list.map { it.id } }
+            if (actual == expected) return
+        }
+        fail("Expected $expected but never received it")
+    }
+
+    private fun createRequest(episodeId: Int = EPISODE_ID): SearchDanmakuRequest {
         return SearchDanmakuRequest(
             subjectInfo = SubjectInfo.createPlaceholder(SUBJECT_ID, "Subject", image = ""),
-            episodeInfo = EpisodeInfo.Empty.copy(episodeId = EPISODE_ID, name = "Episode 1"),
-            episodeId = EPISODE_ID,
+            episodeInfo = EpisodeInfo.Empty.copy(episodeId = episodeId, name = "Episode 1"),
+            episodeId = episodeId,
         )
     }
 
@@ -130,6 +186,18 @@ class DanmakuLoaderTest {
         )
     }
 
+    private fun overrideResult(): DanmakuFetchResult {
+        return DanmakuFetchResult(
+            providerId = DanmakuProviderId.Animeko,
+            matchInfo = DanmakuMatchInfo(
+                serviceId = DanmakuServiceId.Animeko,
+                count = 1,
+                method = DanmakuMatchMethod.ExactId(SUBJECT_ID, EPISODE_ID),
+            ),
+            list = listOf(danmakuInfo("override", DanmakuServiceId.Animeko)),
+        )
+    }
+
     private fun noMatchResults(): List<DanmakuFetchResult> {
         return listOf(
             DanmakuFetchResult.noMatch(DanmakuProviderId.Animeko, DanmakuServiceId.Animeko),
@@ -154,5 +222,6 @@ class DanmakuLoaderTest {
     private companion object {
         private const val SUBJECT_ID = 101
         private const val EPISODE_ID = 202
+        private const val OTHER_EPISODE_ID = 203
     }
 }

--- a/danmaku/api/src/commonMain/kotlin/DanmakuCollection.kt
+++ b/danmaku/api/src/commonMain/kotlin/DanmakuCollection.kt
@@ -163,8 +163,9 @@ class TimeBasedDanmakuSession private constructor(
                                 logger.debug("Danmaku list updated, size=${it.size}")
 
                                 state.updateList(filterList(currentList, currentFilterList))
-                                // reset indexing, 这里 reset 后下一次 tick 会从头索引一次.
-                                state.lastIndex = -1
+                                // 重新装填屏幕. 不能只重置 lastIndex: 那样下一次 tick 会从列表开头
+                                // 逐条 Add, 把当前时间之前的所有历史弹幕当作新弹幕一次性发出去.
+                                state.requestRepopulate()
                             }
                         }
                     }

--- a/danmaku/api/src/commonTest/kotlin/TimeBasedDanmakuSessionTest.kt
+++ b/danmaku/api/src/commonTest/kotlin/TimeBasedDanmakuSessionTest.kt
@@ -10,13 +10,18 @@
 package me.him188.ani.danmaku.api
 
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -49,6 +54,42 @@ internal class TimeBasedDanmakuSessionTest {
             danmakuRegexFilterList = flowOf(emptyList()),
         ).events.toList()
         assertEquals(0, list.size)
+    }
+
+    /**
+     * 弹幕列表迟于播放进度到达时 (每次 DanmakuSession 重建都会如此), 应当重新装填屏幕,
+     * 而不是把当前时间之前的所有弹幕逐条当作新弹幕发出.
+     */
+    @Test
+    fun `list arriving after progress repopulates`() = runTest {
+        val listFlow = MutableSharedFlow<List<DanmakuInfo>>(replay = 1)
+        listFlow.emit(emptyList())
+        val session = TimeBasedDanmakuSession.create(
+            listFlow,
+            coroutineContext = currentCoroutineContext()[ContinuationInterceptor] ?: EmptyCoroutineContext,
+        ).at(
+            MutableStateFlow(60.seconds),
+            { 1f },
+            danmakuRegexFilterList = MutableStateFlow(emptyList()),
+        )
+
+        val events = mutableListOf<DanmakuEvent>()
+        val job = launch { session.events.collect { events.add(it) } }
+
+        // 列表还没到, 先清空屏幕
+        advanceTimeBy(100)
+        assertEquals(emptyList(), assertIs<DanmakuEvent.Repopulate>(events.last()).list)
+        events.clear()
+
+        listFlow.emit((1..50).map { dummyDanmaku(it.toDouble()) })
+        advanceTimeBy(100)
+
+        // 只装填 repopulateDistance (20s) 以内的弹幕, 而不是 50 条 Add
+        assertEquals(
+            (41..50).map { it * 1000L },
+            assertIs<DanmakuEvent.Repopulate>(events.single()).list.map { it.playTimeMillis },
+        )
+        job.cancel()
     }
 
     @Test


### PR DESCRIPTION
Closes #2801

## 问题

### 手动匹配的弹幕源会自己变回去 (#2801)

`DanmakuLoaderImpl.fetchResultFlow` 在 `flatMapLatest` 里清空 `overrideResultsFlow`，注释写的是「每次切换剧集时, 这里会重新执行」，但这个 flow 是冷流，每次**重新订阅**都会重新执行一遍。它有三个订阅方（`DanmakuSession`、弹幕源列表 `fetchResults`、弹幕列表 `allDanmakuFlow`），都是 `WhileSubscribed`。

于是下列操作都会把手动匹配的结果清掉，弹幕源退回自动匹配的结果：

- 切换全屏（configuration change 使 UI 短暂停止收集，超过 `WhileSubscribed` 的 5 秒后上游重启）—— 对应 #2801 里「全屏情况下大概率会出现」
- 进出播放页内嵌的详情页、弹幕列表面板
- 调整任意弹幕源的开关或时间轴：`EpisodeDanmakuLoader` 的 config 变化会重建 `DanmakuSession`，立刻重新订阅，不需要等待任何超时

### 调整弹幕时间轴之后看不出效果

`TimeBasedDanmakuSession` 收到新的弹幕列表时只重置了 `lastIndex`，`lastTime` 仍是当前播放位置，下一次 tick 不满足重新装填的条件，于是从列表开头逐条发 `DanmakuEvent.Add`，把当前时间之前的整集弹幕一次性涌到屏幕上。

而列表迟于播放进度到达是常态：调整时间轴 → `DanmakuSession` 重建 → 重新订阅弹幕列表（原本还要重走请求流上的 1 秒 debounce）→ 首帧列表为空，只能先清屏。所以实际观感是弹幕先消失、再涌出一批时间错位的历史弹幕，新设的时间轴看不出效果。

## 改动

- 覆盖结果记录它属于哪一集，是否过期由 key 比较决定，不再依赖 flow 生命周期。换集后旧的覆盖照常作废。
- `fetchResultFlow` 改为共享（`shareIn(replay = 1)`）：三个订阅方不必各自重跑一遍请求流和缓存写入，`DanmakuSession` 重建时也能立刻拿到已加载的弹幕列表。
- 弹幕列表更新后调用 `requestRepopulate()`，与正则过滤更新的处理保持一致。

## 验证

新增 3 个回归测试，每个都确认过「回退对应实现改动后失败、加上改动后通过」：

- `DanmakuLoaderTest.manual override survives resubscription` —— 取消订阅再重新订阅后，手动匹配的结果仍在
- `DanmakuLoaderTest.manual override is dropped after switching episode` —— 换集后覆盖作废（守护上一条不会矫枉过正）
- `TimeBasedDanmakuSessionTest.list arriving after progress repopulates` —— 播放进度 60s、弹幕列表随后到达时，发出的是一条 `Repopulate`（只含 `repopulateDistance` 20s 以内的 10 条），而不是 50 条 `Add`

测试执行：

- `./gradlew :danmaku:danmaku-api:desktopTest :danmaku:danmaku-ui:desktopTest`：通过
- `./gradlew :app:shared:app-data:testAndroidHostTest`：859 个测试，2 个失败（`SubjectRecurrenceTest.off-by-one-day - still-within-tolerance`、`TimeFormatterTest.testUsingFormatter`）。这两个在未改动的 `main` 上同样失败，是本地时区导致的既有失败，与本 PR 无关。

Android TV 实机验证：

- 手动匹配换源后，紧接着调整任意弹幕源的开关或时间轴：换的源不再退回自动匹配的结果（改动前这一步必然丢失）。切换全屏、进出播放页内嵌详情页同样不再丢。
- 调整时间轴后弹幕按新时间轴重新装填，不再出现「先消失一秒、再涌出一批时间错位的历史弹幕」。

未覆盖：偏移量本身是否精确，肉眼无法分辨（该逻辑 `playTimeMillis + shiftMillis` 本 PR 未改动）。桌面端未运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
