### PR TITLE
fix(desktop): isolate bundled Linux libraries from the global search path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -847,24 +847,27 @@ jobs:
         overwrite: 'true'
       if: '${{ steps.step-47.outcome == ''failure'' }}'
     - id: 'step-49'
+      name: 'Install patchelf'
+      run: 'sudo apt-get install -y patchelf'
+    - id: 'step-50'
       name: 'Package Desktop (Attempt #1)'
       continue-on-error: true
       timeout-minutes: 180
       run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-    - id: 'step-50'
+    - id: 'step-51'
       name: 'Package Desktop (Attempt #2)'
       continue-on-error: false
       timeout-minutes: 180
       run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-      if: '${{ steps.step-49.outcome == ''failure'' }}'
-    - id: 'step-51'
+      if: '${{ steps.step-50.outcome == ''failure'' }}'
+    - id: 'step-52'
       name: 'Upload compose logs'
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'compose-logs-github-ubuntu-2404'
         path: 'app/desktop/build/compose/logs'
       if: '${{ always() }}'
-    - id: 'step-52'
+    - id: 'step-53'
       name: 'Build AppImage'
       run: |-
         # Download appimagetool
@@ -890,7 +893,13 @@ jobs:
         # Fix permissions
         chmod a+x AppDir/AppRun
         chmod a+x AppDir/usr/bin/Ani
-        chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
+
+        # The CEF helpers get their executable bit from restoreLinuxRuntimeExecutables,
+        # so assert rather than chmod. A chmod here would keep the AppImage green while
+        # the deb, the rpm and every direct user of createReleaseDistributable ship a
+        # runtime whose helpers cannot be spawned (#3259).
+        test -x AppDir/usr/lib/runtime/lib/jcef_helper
+        test -x AppDir/usr/lib/runtime/lib/cef_server
 
         # Build an AppImage whose zsync metadata points at this repository's release asset.
         # Build with the final release filename so the generated zsync metadata keeps that name,
@@ -909,7 +918,7 @@ jobs:
         sed -i "s|^URL:.*|URL: $releaseAsset|" "$releaseAsset.zsync"
         mv "$releaseAsset" Animeko-x86_64.AppImage
         mv "$releaseAsset.zsync" Animeko-x86_64.AppImage.zsync
-    - id: 'step-53'
+    - id: 'step-54'
       name: 'Upload Linux packages (Attempt #1)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
@@ -920,7 +929,7 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-    - id: 'step-54'
+    - id: 'step-55'
       name: 'Upload Linux packages (Attempt #2)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
@@ -931,8 +940,8 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-      if: '${{ steps.step-53.outcome == ''failure'' }}'
-    - id: 'step-55'
+      if: '${{ steps.step-54.outcome == ''failure'' }}'
+    - id: 'step-56'
       name: 'Upload Linux packages (Attempt #3)'
       continue-on-error: false
       uses: 'actions/upload-artifact@v4'
@@ -943,7 +952,7 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-      if: '${{ steps.step-54.outcome == ''failure'' }}'
+      if: '${{ steps.step-55.outcome == ''failure'' }}'
   build_github-macos-15-intel:
     name: 'Build (macOS 15 x86_64 (GitHub))'
     runs-on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2148,24 +2148,27 @@ jobs:
       run: './gradlew :ci-helper:uploadIosIpaQR "--no-configuration-cache" "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
       if: '${{ steps.step-59.outcome == ''failure'' }}'
     - id: 'step-61'
+      name: 'Install patchelf'
+      run: 'sudo apt-get install -y patchelf'
+    - id: 'step-62'
       name: 'Package Desktop (Attempt #1)'
       continue-on-error: true
       timeout-minutes: 180
       run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-    - id: 'step-62'
+    - id: 'step-63'
       name: 'Package Desktop (Attempt #2)'
       continue-on-error: false
       timeout-minutes: 180
       run: './gradlew createReleaseDistributable "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-      if: '${{ steps.step-61.outcome == ''failure'' }}'
-    - id: 'step-63'
+      if: '${{ steps.step-62.outcome == ''failure'' }}'
+    - id: 'step-64'
       name: 'Upload compose logs'
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'compose-logs-github-ubuntu-2404'
         path: 'app/desktop/build/compose/logs'
       if: '${{ always() }}'
-    - id: 'step-64'
+    - id: 'step-65'
       name: 'Build AppImage'
       run: |-
         # Download appimagetool
@@ -2191,7 +2194,13 @@ jobs:
         # Fix permissions
         chmod a+x AppDir/AppRun
         chmod a+x AppDir/usr/bin/Ani
-        chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
+
+        # The CEF helpers get their executable bit from restoreLinuxRuntimeExecutables,
+        # so assert rather than chmod. A chmod here would keep the AppImage green while
+        # the deb, the rpm and every direct user of createReleaseDistributable ship a
+        # runtime whose helpers cannot be spawned (#3259).
+        test -x AppDir/usr/lib/runtime/lib/jcef_helper
+        test -x AppDir/usr/lib/runtime/lib/cef_server
 
         # Build an AppImage whose zsync metadata points at this repository's release asset.
         # Build with the final release filename so the generated zsync metadata keeps that name,
@@ -2210,7 +2219,7 @@ jobs:
         sed -i "s|^URL:.*|URL: $releaseAsset|" "$releaseAsset.zsync"
         mv "$releaseAsset" Animeko-x86_64.AppImage
         mv "$releaseAsset.zsync" Animeko-x86_64.AppImage.zsync
-    - id: 'step-65'
+    - id: 'step-66'
       name: 'Upload Linux packages (Attempt #1)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
@@ -2221,7 +2230,7 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-    - id: 'step-66'
+    - id: 'step-67'
       name: 'Upload Linux packages (Attempt #2)'
       continue-on-error: true
       uses: 'actions/upload-artifact@v4'
@@ -2232,8 +2241,8 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-      if: '${{ steps.step-65.outcome == ''failure'' }}'
-    - id: 'step-67'
+      if: '${{ steps.step-66.outcome == ''failure'' }}'
+    - id: 'step-68'
       name: 'Upload Linux packages (Attempt #3)'
       continue-on-error: false
       uses: 'actions/upload-artifact@v4'
@@ -2244,8 +2253,8 @@ jobs:
           Animeko-x86_64.AppImage.zsync
         if-no-files-found: 'error'
         overwrite: 'true'
-      if: '${{ steps.step-66.outcome == ''failure'' }}'
-    - id: 'step-68'
+      if: '${{ steps.step-67.outcome == ''failure'' }}'
+    - id: 'step-69'
       name: 'Upload Desktop Installers (Attempt #1)'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -2268,7 +2277,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 180
       run: './gradlew :ci-helper:uploadDesktopInstallers "--no-configuration-cache" "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-    - id: 'step-69'
+    - id: 'step-70'
       name: 'Upload Desktop Installers (Attempt #2)'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -2291,8 +2300,8 @@ jobs:
       continue-on-error: false
       timeout-minutes: 180
       run: './gradlew :ci-helper:uploadDesktopInstallers "--no-configuration-cache" "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g" "-Dkotlin.daemon.jvm.options=-Xmx6g"'
-      if: '${{ steps.step-68.outcome == ''failure'' }}'
-    - id: 'step-70'
+      if: '${{ steps.step-69.outcome == ''failure'' }}'
+    - id: 'step-71'
       name: 'Upload compose logs'
       uses: 'actions/upload-artifact@v4'
       with:

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -1829,6 +1829,11 @@ class WithMatrix(
         }
 
         if (matrix.isUbuntu) {
+            run(
+                // isolateLinuxBundledLibraries needs it to give the bundled libraries a DT_RPATH.
+                name = "Install patchelf",
+                command = "sudo apt-get install -y patchelf",
+            )
             runGradle(
                 name = "Package Desktop",
                 tasks = arrayOf("createReleaseDistributable"),
@@ -1901,7 +1906,13 @@ class WithMatrix(
                         # Fix permissions
                         chmod a+x AppDir/AppRun
                         chmod a+x AppDir/usr/bin/Ani
-                        chmod a+x AppDir/usr/lib/runtime/lib/jcef_helper
+
+                        # The CEF helpers get their executable bit from restoreLinuxRuntimeExecutables,
+                        # so assert rather than chmod. A chmod here would keep the AppImage green while
+                        # the deb, the rpm and every direct user of createReleaseDistributable ship a
+                        # runtime whose helpers cannot be spawned (#3259).
+                        test -x AppDir/usr/lib/runtime/lib/jcef_helper
+                        test -x AppDir/usr/lib/runtime/lib/cef_server
                         
                         # Build an AppImage whose zsync metadata points at this repository's release asset.
                         # Build with the final release filename so the generated zsync metadata keeps that name,

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -339,6 +339,8 @@ afterEvaluate {
         doLast {
             unpackComposeDesktopNativeLibraries()
             reconstructLinuxSolink()
+            isolateLinuxBundledLibraries()
+            restoreLinuxRuntimeExecutables()
         }
     }
 }

--- a/buildSrc/src/main/kotlin/unpackDektopNatives.kt
+++ b/buildSrc/src/main/kotlin/unpackDektopNatives.kt
@@ -154,6 +154,259 @@ fun AbstractJPackageTask.reconstructLinuxSolink() {
         }
 }
 
+/**
+ * Directory inside `lib/app` that holds the bundled libraries which are not JNI entry points.
+ */
+private const val ISOLATED_LIBRARY_DIR = "native"
+
+/**
+ * Libraries that stay in `lib/app` even though they export no JNI symbol.
+ *
+ * `ai.onnxruntime.OnnxRuntime.load` calls `System.loadLibrary("onnxruntime")` before loading the JNI
+ * library, so this one has to remain resolvable through `java.library.path`. Isolating it makes that
+ * call fall through to the system onnxruntime, which is then already loaded under the same SONAME by
+ * the time the JNI library is linked — the `DT_RPATH` below cannot override an image that is already
+ * in the process.
+ */
+private val KEPT_NON_JNI_LIBRARIES = setOf("libonnxruntime.so")
+
+/**
+ * The only libraries allowed to stay in `lib/app`.
+ *
+ * Deciding this against the build machine's `ldconfig` would only ever catch the names that machine
+ * happens to package: Ubuntu, where the release is built, ships no onnxruntime, while Arch does — so
+ * the very library that had to stay is the one such a check would wave through. The rule is therefore
+ * inverted. A library stays because it is listed here, not because some distribution does not ship a
+ * library of the same name.
+ */
+private val ALLOWED_ON_LIBRARY_PATH = setOf(
+    "libskiko-linux-x64.so",
+    "libmediampv.so",
+    "libanitorrent.so",
+    "libffmpegkitjni.so",
+    "libonnxruntime4j_jni.so",
+    // See KEPT_NON_JNI_LIBRARIES for why these two cannot be isolated.
+    "libonnxruntime.so",
+    "libonnxruntime.so.1",
+)
+
+private val SHARED_LIBRARY_NAME = Regex("""^lib.*\.so(\.\d+)*$""")
+
+/**
+ * Moves every bundled library that is not a JNI entry point out of `lib/app` into `lib/app/native`,
+ * and gives each of them a `DT_RPATH` of `$ORIGIN` so they only ever resolve against each other.
+ *
+ * jpackage makes `lib/app` the `java.library.path`, and [unpackComposeDesktopNativeLibraries] flattens
+ * the mediamp runtime jars into that same directory. That puts ~45 generically named system libraries
+ * (`libglib-2.0.so.0`, `libssl.so.3`, `libz.so.1`, `libX*`, `libav*`, ...) on a search path that is
+ * visible to everything else in the process. Whoever asks for one of those SONAMEs first wins, so the
+ * bundled copy can shadow the system one for an unrelated consumer: #3259 is CEF loading the system
+ * `libgobject-2.0.so.0` against the bundled `libglib-2.0.so.0`, which then cannot resolve `g_string_copy`.
+ *
+ * `AppRun` cannot fix this. CEF builds the environment for `jcef_helper` itself and appends the
+ * `java.library.path` entries to the child's `LD_LIBRARY_PATH`, so the directory reaches the helper
+ * process no matter what the launcher script exports.
+ *
+ * `--force-rpath` is deliberate. `DT_RUNPATH` — which is what the upstream libraries ship — loses to
+ * `LD_LIBRARY_PATH`, so a user with their own `LD_LIBRARY_PATH` can still feed mpv a mismatched FFmpeg.
+ * `DT_RPATH` wins over it and is inherited along the dependency chain.
+ */
+fun AbstractJPackageTask.isolateLinuxBundledLibraries() {
+    if (getOsTriple() != "linux-x64") {
+        return
+    }
+    val appDir = destinationDir.get().asFile
+        .walk()
+        .firstOrNull { it.isDirectory && it.name == "app" && it.parentFile.name == "lib" }
+        ?: throw FileNotFoundException(
+            "app runtime directory doesn't exist after compose jpackage task.",
+        )
+
+    requirePatchelf()
+
+    // A library and the SONAME symlinks reconstructLinuxSolink created for it move together.
+    val groups = appDir.listFiles()
+        ?.toList()
+        .orEmpty()
+        .filter { SHARED_LIBRARY_NAME.matches(it.name) }
+        .groupBy { it.toPath().toRealPath().toFile() }
+
+    val (kept, isolated) = groups.entries.partition { (realFile, names) ->
+        names.any { it.name in KEPT_NON_JNI_LIBRARIES } || exportsJniSymbols(realFile)
+    }
+
+    val isolatedDir = appDir.resolve(ISOLATED_LIBRARY_DIR)
+    isolatedDir.mkdirs()
+    val isolatedNames = mutableSetOf<String>()
+
+    isolated.forEach { (realFile, names) ->
+        check(realFile.parentFile == appDir) {
+            "$realFile is linked from ${appDir.name} but does not live there; refusing to move it."
+        }
+        // Only the aliases are removed here — realFile is one of `names` and has yet to be moved.
+        val links = names.filter { Files.isSymbolicLink(it.toPath()) }
+            .map { it.name to Files.readSymbolicLink(it.toPath()) }
+        links.forEach { (name, _) -> appDir.resolve(name).delete() }
+
+        Files.move(realFile.toPath(), isolatedDir.resolve(realFile.name).toPath())
+        links.forEach { (name, target) ->
+            Files.createSymbolicLink(isolatedDir.resolve(name).toPath(), target)
+        }
+
+        forceRpath(isolatedDir.resolve(realFile.name), "\$ORIGIN")
+        isolatedNames += names.map { it.name }
+    }
+
+    // Only the entry points that actually depend on a bundled library are rewritten. libskiko ships a
+    // .sha256 sidecar that it verifies on load, so patching it unconditionally would break startup.
+    val bundledNames = isolatedNames + kept.flatMap { (_, names) -> names.map { it.name } }
+    kept.forEach { (realFile, _) ->
+        if (readNeededLibraries(realFile).none { it in bundledNames }) {
+            return@forEach
+        }
+        forceRpath(realFile, "\$ORIGIN/$ISOLATED_LIBRARY_DIR:\$ORIGIN")
+    }
+
+    checkOnlyAllowedLibrariesRemain(appDir)
+
+    logger.lifecycle(
+        "Isolated ${isolated.size} bundled libraries into $isolatedDir, " +
+                "kept ${kept.joinToString { it.key.name }} on java.library.path.",
+    )
+}
+
+/**
+ * Fails the build when anything outside [ALLOWED_ON_LIBRARY_PATH] is left in `lib/app`.
+ *
+ * jpackage exposes that directory as `java.library.path` and `AppRun` puts it on `LD_LIBRARY_PATH`,
+ * so whatever sits there is reachable by SONAME from every other consumer in the process — including
+ * the system libraries CEF loads. That is the shape of #3259.
+ */
+private fun checkOnlyAllowedLibrariesRemain(appDir: File) {
+    val unexpected = appDir.listFiles()
+        ?.toList()
+        .orEmpty()
+        .map { it.name }
+        .filter { SHARED_LIBRARY_NAME.matches(it) }
+        .filter { it !in ALLOWED_ON_LIBRARY_PATH }
+
+    check(unexpected.isEmpty()) {
+        "Bundled libraries left on java.library.path are not allow-listed: " +
+                "${unexpected.joinToString()}. They can shadow the system library of the same SONAME " +
+                "for an unrelated consumer such as CEF (#3259). Isolate them, or add them to " +
+                "ALLOWED_ON_LIBRARY_PATH once the collision is understood and harmless."
+    }
+}
+
+/**
+ * Runtime programs that are meant to stay non-executable.
+ *
+ * JBR ships `chrome-sandbox` as `0644` because the setuid sandbox has to be installed as root by
+ * whoever distributes the app. CEF falls back to the user namespace sandbox when the helper is not
+ * usable, so marking it executable without the setuid bit only moves the failure.
+ */
+private val NON_EXECUTABLE_RUNTIME_PROGRAMS = setOf("chrome-sandbox")
+
+/**
+ * Restores the executable bit on the runtime's helper programs.
+ *
+ * jpackage copies the JBR into `lib/runtime` without preserving permissions, so `jcef_helper` and
+ * `cef_server` arrive as `0644` even though JBR ships them `0755`. CEF then cannot spawn its child
+ * processes: `failed to execvp`, every GPU and network service launch fails, and the browser process
+ * aborts with `GPU process isn't usable`.
+ *
+ * The AppImage job worked around this with a `chmod a+x` of its own, which leaves every other
+ * consumer of `createReleaseDistributable` — the deb and rpm packages among them — broken. Doing it
+ * here covers all of them.
+ *
+ * Programs are told apart from shared libraries by their `PT_INTERP` segment, so a helper added by a
+ * future JBR is picked up without editing a list here.
+ */
+fun AbstractJPackageTask.restoreLinuxRuntimeExecutables() {
+    if (getOsTriple() != "linux-x64") {
+        return
+    }
+    val runtimeLibDir = destinationDir.get().asFile
+        .walk()
+        .firstOrNull { it.isDirectory && it.name == "lib" && it.parentFile.name == "runtime" }
+        ?: throw FileNotFoundException(
+            "runtime library directory doesn't exist after compose jpackage task.",
+        )
+
+    val restored = runtimeLibDir.listFiles()
+        ?.toList()
+        .orEmpty()
+        .filter { it.isFile && !it.canExecute() && it.name !in NON_EXECUTABLE_RUNTIME_PROGRAMS }
+        .filter { isElfProgram(it) }
+        .onEach {
+            check(it.setExecutable(true, false)) { "Failed to mark $it executable." }
+        }
+
+    if (restored.isEmpty()) {
+        logger.info("No runtime helper program needed its executable bit restored.")
+    } else {
+        logger.lifecycle("Restored the executable bit on ${restored.joinToString { it.name }}.")
+    }
+}
+
+/**
+ * Whether [file] is an ELF program rather than a shared library. Only programs carry `PT_INTERP`.
+ */
+private fun isElfProgram(file: File): Boolean {
+    val programHeaders = runCommandOrNull("readelf", "-lW", file.absolutePath) ?: return false
+    return programHeaders.lineSequence().any { it.trimStart().startsWith("INTERP") }
+}
+
+private fun exportsJniSymbols(library: File): Boolean {
+    val symbols = runCommandOrNull("readelf", "-W", "--dyn-syms", library.absolutePath) ?: return false
+    return symbols.lineSequence().any { it.contains(" Java_") || it.contains(" JNI_OnLoad") }
+}
+
+private fun readNeededLibraries(library: File): List<String> {
+    val dynamic = runCommandOrNull("readelf", "-d", library.absolutePath) ?: return emptyList()
+    return Regex("""Shared library: \[(.+?)]""")
+        .findAll(dynamic)
+        .map { it.groupValues[1] }
+        .toList()
+}
+
+private fun forceRpath(library: File, rpath: String) {
+    checkNotNull(runCommandOrNull("patchelf", "--force-rpath", "--set-rpath", rpath, library.absolutePath)) {
+        "patchelf failed to set RPATH '$rpath' on $library."
+    }
+    // patchelf exits 0 whether or not `--force-rpath` took effect, and a leftover DT_RUNPATH loses to
+    // LD_LIBRARY_PATH — which is the override this whole function exists to prevent. Read it back.
+    val dynamic = checkNotNull(runCommandOrNull("readelf", "-dW", library.absolutePath)) {
+        "readelf failed to read the dynamic section of $library."
+    }
+    check(!dynamic.contains("(RUNPATH)")) {
+        "$library still carries a DT_RUNPATH after --force-rpath; it would lose to LD_LIBRARY_PATH."
+    }
+    val actual = Regex("""\(RPATH\)\s+Library rpath: \[(.*?)]""").find(dynamic)?.groupValues?.get(1)
+    check(actual == rpath) {
+        "$library has DT_RPATH '$actual' but '$rpath' was requested."
+    }
+}
+
+private fun requirePatchelf() {
+    checkNotNull(runCommandOrNull("patchelf", "--version")) {
+        "patchelf is required to package the Linux distribution but is not available on PATH."
+    }
+}
+
+/**
+ * Returns the combined output of [command], or `null` if it could not be started or exited non-zero.
+ */
+private fun runCommandOrNull(vararg command: String): String? {
+    val process = try {
+        ProcessBuilder(*command).redirectErrorStream(true).start()
+    } catch (e: java.io.IOException) {
+        return null
+    }
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    return output.takeIf { process.waitFor() == 0 }
+}
+
 private fun unpackJar(jar: File, dest: File, filter: (ZipEntry) -> Boolean = { true }) {
     val zip = ZipFile(jar)
     zip.use {


### PR DESCRIPTION
## 概述

把 jpackage 平铺进 `lib/app` 的捆绑库移入 `lib/app/native`，只保留 JNI 入口点在 `java.library.path` 上；移入的库以 `DT_RPATH=$ORIGIN` 只在彼此之间解析。

## 根因

`lib/app` 既是 jpackage 设定的 `java.library.path`，也在 `AppRun` 导出的 `LD_LIBRARY_PATH` 上。mediamp 的 runtime jar 展开到同一目录，45 个通用 SONAME（`libglib-2.0.so.0`、`libssl.so.3`、`libX*`、`libav*`）因此落在全进程可见的搜索路径上。

CEF 把 `java.library.path` 追加到 `jcef_helper` 的 `LD_LIBRARY_PATH`，子进程于是用系统 `libgobject-2.0.so.0` 链接捆绑的 `libglib-2.0.so.0`：

```
jcef_helper: symbol lookup error: /usr/lib/libgobject-2.0.so.0: undefined symbol: g_string_copy
```

helper 全部退出后，GPU 与 network service 进程反复启动失败，浏览器进程以 `GPU process isn't usable` abort。子进程环境由 CEF 自行拼装，`AppRun` 无法修正。

捆绑的 libglib 与构建机 Ubuntu 24.04 的 glib 2.80 同代，只有宿主 glib 更新（Arch、Void 的 2.88）才触发，因此 CI 未能发现。

## 改动

- `isolateLinuxBundledLibraries` 按是否导出 JNI 符号切分 `lib/app`，非入口点移入 `native/`。用 `--force-rpath` 而非默认的 `DT_RUNPATH`，后者输给 `LD_LIBRARY_PATH`。
- `libonnxruntime.so` 保持原位。`OnnxRuntime.load` 先调 `System.loadLibrary("onnxruntime")`，隔离后这一步会落到系统副本。
- `restoreLinuxRuntimeExecutables` 恢复 `jcef_helper`、`cef_server` 的执行位。jpackage 复制 JBR 不保留权限，0755 变 0644，CEF 报 `failed to execvp` 后走向同一个 abort。此前只有 AppImage job 的 `chmod a+x` 覆盖，deb、rpm 和直接使用 `createReleaseDistributable` 都没有。
- CI 的 `chmod a+x` 改为 `test -x` 断言，避免掩盖构建侧的退化。
- `lib/app` 的残留库改为白名单判定，不再比对构建机的 `ldconfig`。旧判据取决于构建机装了什么：Ubuntu 不打 onnxruntime，而它正是唯一需要留下的库。
- `forceRpath` 设完 RPATH 后回读校验。patchelf 无论 `--force-rpath` 是否生效都退出 0。

## 验证

Void（glib 2.88）上对同一 commit 前后各构建一次并运行产物：

| | 修复前 | 修复后 |
|---|---|---|
| `lib/app` 平铺 .so | 59 | 8 |
| `symbol lookup error` | 5 | 0 |
| `GPU process launch failed` | 9 | 0 |
| `GPU process isn't usable` | 1 | 0 |
| 进程 | SIGTRAP | 正常退出 |

ubuntu:24.04 容器内构建并打包，产物在 archlinux 容器（glib 2.88）中经 `xvfb-run` 启动，输出 `JCEF is initialized`；同一容器内运行 v6.0.0 发布包作为对照，输出 `JCEFInitializationException: state: TERMINATED`。

播放链路：JCEF 解析出 m3u8，mpv 使用 `nvdec` 硬解，`VO: [libmpv] 1920x1080 cuda[nv12]`。

onnxruntime：以打包后的布局加载 `captcha-v1.0.onnx` 并推理，契约与 `docs/contributing/code/image-captcha.md` 记录一致。

`LD_LIBRARY_PATH=lib/app ldd -r jcef_helper` 修复前报 3 个未解析符号，修复后为 0；同一命令在 Ubuntu 24.04 上两版均为 0。

Fixes #3259
