### PR TITLE
fix(player): wait for media before restoring progress

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/RememberPlayProgressExtension.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -94,23 +95,29 @@ class RememberPlayProgressExtension(
                     }
 
                     PlaybackState.PLAYING -> {
-                        // Restore immediately, but only report after PLAYING has remained active for 5 seconds.
-                        withContext(NonCancellable) {
-                            if (!haveResumedOnce) {
-                                if (automationGate.suppressed.value) {
-                                    haveResumedOnce = true
-                                    return@withContext
-                                }
+                        // Some backends (notably desktop mpv) report PLAYING before the loaded file accepts seeks.
+                        // Restore once metadata is ready, but only report after PLAYING remains active for 5 seconds.
+                        if (!haveResumedOnce) {
+                            if (automationGate.suppressed.value) {
+                                haveResumedOnce = true
+                            } else {
                                 val positionMillis =
                                     playProgressRepository.getPositionMillisByEpisodeId(episodeSession.episodeId)
                                 if (positionMillis == null) {
                                     logger.info { "Did not find saved position" }
-                                } else {
-                                    logger.info { "Loaded saved position: $positionMillis, seeking to $positionMillis" }
-                                    withContext(Dispatchers.Main) { // android must call in main thread
-                                        player.seekTo(positionMillis)
-                                    }
                                     haveResumedOnce = true
+                                } else {
+                                    logger.info {
+                                        "Loaded saved position: $positionMillis, waiting for video properties"
+                                    }
+                                    player.mediaProperties.first { it != null && it.durationMillis > 0L }
+                                    withContext(Dispatchers.Main + NonCancellable) { // android must call in main thread
+                                        logger.info {
+                                            "Video properties ready, seeking to saved position: $positionMillis"
+                                        }
+                                        player.seekTo(positionMillis)
+                                        haveResumedOnce = true
+                                    }
                                 }
                             }
                         }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/RememberPlayProgressExtensionTest.kt
@@ -659,6 +659,26 @@ class RememberPlayProgressExtensionTest : AbstractPlayerExtensionTest() {
     }
 
     @Test
+    fun `waits for video properties before loading saved history`() = runTest {
+        val (testScope, suite, _) = createCase()
+        advanceUntilIdle()
+        repository.saveOrUpdate(episodeId = initialEpisodeId, 500)
+        suite.player.mediaProperties.value = null
+
+        suite.player.setMediaData(UriMediaData("file://test"))
+        suite.player.playbackState.value = PlaybackState.PLAYING
+        runCurrent()
+
+        assertEquals(0, suite.player.currentPositionMillis.value)
+
+        suite.player.mediaProperties.value = MediaProperties.Empty.copy(durationMillis = 100_000L)
+        advanceUntilIdle()
+
+        assertEquals(500, suite.player.currentPositionMillis.value)
+        testScope.cancel()
+    }
+
+    @Test
     fun `loads saved history on switch episode`() = runTest {
         val (testScope, suite, state) = createCase()
         advanceUntilIdle()


### PR DESCRIPTION
Fixes #3275

## Root cause

The attached issue log shows that normal app shutdown persisted and synced the latest position successfully. On the next launch, Animeko loaded that saved position, but desktop mpv rejected the restore seek before it logged `Starting playback...`. The periodic reporter then saved the near-zero playback position over the valid history.

Desktop mpv reports `PLAYING` as soon as `loadfile` is submitted, earlier than the point where the file accepts seek commands. Other platform players do not necessarily have that ordering.

## Changes

- Wait for non-null media properties with a positive duration before restoring saved progress.
- Keep the metadata wait cancellable when playback state changes, while keeping the actual main-thread seek non-cancellable.
- Add a regression test proving that restore does not seek until video properties become available.

## User impact

Reopening an episode on desktop no longer sends the resume seek too early and then overwrites the correct saved progress with a position near the beginning.

## Verification

- `./gradlew :app:shared:app-data:compileAndroidMain :app:shared:app-data:desktopTest --tests 'me.him188.ani.app.domain.player.extension.RememberPlayProgressExtensionTest'`
- `git diff --check`
- Launched the desktop app and opened the real player screen with the repository desktop verification workflow. The development runtime remained responsive; full source playback could not be exercised on this runner because it has no JCEF-enabled JBR, so selector-backed sources could not extract media. This change does not alter UI layout or rendering.
