### PR TITLE
docs: 修正贡献指南链接并更新 KMP 平台说明

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -35,4 +35,4 @@
 ## 更多信息
 
 - [查找待解决的问题](issues.md) (如何查阅 issues)
-- [PR 审核](pr-review.md)
+- [PR 审核](code-style.md#pr-review-惯例)

--- a/docs/contributing/kmp.md
+++ b/docs/contributing/kmp.md
@@ -1,8 +1,7 @@
 ## Kotlin 多平台
 
-Animeko 客户端 基于 Kotlin 多平台技术，目前正式支持 Android、桌面 JVM（macOS、Windows）共三个实际平台。
-代码库中有正在开发中的
-iOS 代码，但还没有配置构建 iOS APP。
+Animeko 客户端基于 Kotlin 多平台技术，目前配置了 Android、桌面 JVM（Windows、macOS、Linux）和 iOS
+编译目标。iOS 目标默认不启用，只能在 macOS 上构建；启用方式参见[构建和打包](building.md#打包-ios-app)。
 
 ### 什么是 Kotlin 多平台
 


### PR DESCRIPTION
## 修改动机

贡献指南中的“PR 审核”仍指向已经删除的 `pr-review.md`。该文件的内容已在此前的文档整理中合并至 `code-style.md`，但入口链接没有同步更新。

Kotlin 多平台文档中的平台说明也已过时：文档仍称 iOS APP 尚未配置构建，并且没有列出 Linux 桌面平台；当前仓库已经配置 Android、桌面 JVM（Windows、macOS、Linux）和 iOS 编译目标，也提供了 iOS 构建步骤。

## 修改内容

- 将“PR 审核”链接改为指向 `code-style.md` 中现有的“PR Review 惯例”章节。
- 更新 KMP 文档中的平台说明，补充 Linux 桌面平台和已配置的 iOS 编译目标。
- 说明 iOS 目标默认不启用、只能在 macOS 上构建，并链接到现有构建指南。

## 验证

- `git diff --check`
- 确认 `code-style.md#pr-review-惯例` 与 `building.md#打包-ios-app` 对应的标题均存在。
- 未运行 Gradle 测试（仅修改文档）。
