### PR TITLE
feat(search): 优化桌面端宽屏标签筛选

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -1186,6 +1186,7 @@
     <string name="exploration_search_filter_source">来源</string>
     <string name="exploration_search_filter_technology">技术</string>
     <string name="exploration_search_filter_custom">自定义</string>
+    <string name="exploration_search_filter_all">全部</string>
     <string name="settings_app_background_running">后台运行</string>
     <string name="settings_app_background_running_description">缓存功能需要应用保持在后台运行才能下载视频</string>
     <string name="settings_app_ignore_battery_optimizations">禁用电池优化</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -1159,6 +1159,7 @@
     <string name="exploration_search_filter_source">來源</string>
     <string name="exploration_search_filter_technology">技術</string>
     <string name="exploration_search_filter_custom">自定義</string>
+    <string name="exploration_search_filter_all">全部</string>
     <string name="settings_app_background_running">背景運行</string>
     <string name="settings_app_background_running_description">快取功能需要應用保持在背景運行才能下載影片</string>
     <string name="settings_app_ignore_battery_optimizations">停用電池最佳化</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -1149,6 +1149,7 @@
     <string name="exploration_search_filter_source">來源</string>
     <string name="exploration_search_filter_technology">技術</string>
     <string name="exploration_search_filter_custom">自訂</string>
+    <string name="exploration_search_filter_all">全部</string>
     <string name="settings_app_background_running">背景運行</string>
     <string name="settings_app_background_running_description">快取功能需要應用保持在背景運行才能下載影片</string>
     <string name="settings_app_ignore_battery_optimizations">停用電池最佳化</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -1146,6 +1146,7 @@
     <string name="exploration_search_filter_source">Source</string>
     <string name="exploration_search_filter_technology">Technology</string>
     <string name="exploration_search_filter_custom">Custom</string>
+    <string name="exploration_search_filter_all">All</string>
     <string name="settings_app_background_running">Background running</string>
     <string name="settings_app_background_running_description">Caching downloads require the app to keep running in the background</string>
     <string name="settings_app_ignore_battery_optimizations">Ignore battery optimizations</string>

--- a/app/shared/ui-exploration/build.gradle.kts
+++ b/app/shared/ui-exploration/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
     }
     sourceSets.named("jvmTest").dependencies {
         implementation(kotlin("reflect"))
+        implementation(projects.utils.uiTesting)
     }
     sourceSets.androidMain.dependencies {
     }

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchFilter.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchFilter.kt
@@ -197,6 +197,14 @@ private fun renderChipLabel(
     }
 }
 
+@Composable
+internal fun searchFilterGroupLabel(state: SearchFilterChipState): String {
+    return renderChipLabel(
+        state = state.copy(selected = emptyList()),
+        labels = rememberSearchFilterLabels(),
+    )
+}
+
 @Immutable
 private data class SearchFilterLabels(
     val audience: String,

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchFilterSidePanel.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchFilterSidePanel.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.search
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.data.models.subject.CanonicalTagKind
+import me.him188.ani.app.ui.foundation.lists.LazyListVerticalScrollbar
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.exploration_search_filter_all
+import me.him188.ani.app.ui.lang.subject_episode_collapse
+import me.him188.ani.app.ui.lang.subject_episode_expand
+import org.jetbrains.compose.resources.stringResource
+
+internal val SearchFilterSidePanelWidth = 330.dp
+
+@Composable
+internal fun SearchFilterSidePanel(
+    state: SearchFilterState,
+    collapsedGroupKeys: Collection<String>,
+    onToggleGroup: (groupKey: String) -> Unit,
+    onCheckedChange: (SearchFilterChipState, value: String) -> Unit,
+    onClearGroup: (SearchFilterChipState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+
+    Surface(
+        modifier = modifier.testTag(SearchFilterSidePanelTestTags.Panel),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                state = listState,
+                contentPadding = PaddingValues(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(
+                    count = state.chips.size,
+                    key = { index -> state.chips[index].groupKey },
+                ) { index ->
+                    val chipState = state.chips[index]
+                    val groupKey = chipState.groupKey
+                    SearchFilterGroup(
+                        state = chipState,
+                        expanded = groupKey !in collapsedGroupKeys,
+                        onToggleExpanded = { onToggleGroup(groupKey) },
+                        onCheckedChange = { onCheckedChange(chipState, it) },
+                        onClear = { onClearGroup(chipState) },
+                    )
+                }
+            }
+
+            LazyListVerticalScrollbar(
+                state = listState,
+                modifier = Modifier.align(Alignment.CenterEnd),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchFilterGroup(
+    state: SearchFilterChipState,
+    expanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    onCheckedChange: (value: String) -> Unit,
+    onClear: () -> Unit,
+) {
+    val groupLabel = searchFilterGroupLabel(state)
+    val expandText = stringResource(Lang.subject_episode_expand)
+    val collapseText = stringResource(Lang.subject_episode_collapse)
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Surface(
+            onClick = onToggleExpanded,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(SearchFilterSidePanelTestTags.group(state.groupKey)),
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = groupLabel,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Icon(
+                    imageVector = if (expanded) {
+                        Icons.Rounded.ExpandLess
+                    } else {
+                        Icons.Rounded.ExpandMore
+                    },
+                    contentDescription = if (expanded) collapseText else expandText,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                val allText = stringResource(Lang.exploration_search_filter_all)
+                SearchFilterSidePanelChip(
+                    selected = !state.hasSelection,
+                    onClick = {
+                        if (state.hasSelection) {
+                            onClear()
+                        }
+                    },
+                    label = allText,
+                    modifier = Modifier.testTag(SearchFilterSidePanelTestTags.all(state.groupKey)),
+                )
+
+                for (value in state.values) {
+                    val selected = value in state.selected
+                    SearchFilterSidePanelChip(
+                        selected = selected,
+                        onClick = { onCheckedChange(value) },
+                        label = value,
+                        modifier = Modifier.testTag(
+                            SearchFilterSidePanelTestTags.value(state.groupKey, value),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchFilterSidePanelChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val colors = MaterialTheme.colorScheme
+    val containerColor = when {
+        selected && hovered -> colors.primaryContainer.copy(alpha = 0.78f)
+        selected -> colors.primaryContainer
+        hovered -> colors.primaryContainer.copy(alpha = 0.45f)
+        else -> Color.Transparent
+    }
+    val contentColor = when {
+        selected || hovered -> colors.onPrimaryContainer
+        else -> colors.onSurfaceVariant
+    }
+    val borderColor = when {
+        selected -> colors.primary
+        hovered -> colors.primary.copy(alpha = 0.55f)
+        else -> colors.outlineVariant
+    }
+
+    Surface(
+        modifier = modifier
+            .hoverable(interactionSource)
+            .selectable(
+                selected = selected,
+                interactionSource = interactionSource,
+                indication = null,
+                role = Role.Button,
+                onClick = onClick,
+            ),
+        shape = MaterialTheme.shapes.small,
+        color = containerColor,
+        contentColor = contentColor,
+        border = BorderStroke(1.dp, borderColor),
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+internal val SearchFilterChipState.groupKey: String
+    get() = when (kind) {
+        CanonicalTagKind.Audience -> "audience"
+        CanonicalTagKind.Category -> "category"
+        CanonicalTagKind.Character -> "character"
+        CanonicalTagKind.Emotion -> "emotion"
+        CanonicalTagKind.Genre -> "genre"
+        CanonicalTagKind.Rating -> "rating"
+        CanonicalTagKind.Region -> "region"
+        CanonicalTagKind.Series -> "series"
+        CanonicalTagKind.Setting -> "setting"
+        CanonicalTagKind.Source -> "source"
+        CanonicalTagKind.Technology -> "technology"
+        null -> "custom"
+    }
+
+internal object SearchFilterSidePanelTestTags {
+    const val Panel = "search-filter-side-panel"
+
+    fun group(groupKey: String): String = "search-filter-group-$groupKey"
+
+    fun all(groupKey: String): String = "search-filter-all-$groupKey"
+
+    fun value(groupKey: String, value: String): String = "search-filter-value-$groupKey-$value"
+}

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPage.kt
@@ -14,16 +14,22 @@ package me.him188.ani.app.ui.exploration.search
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -59,11 +65,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -126,6 +134,11 @@ fun SearchPage(
     var isSearchBarExpanded by rememberSaveable { mutableStateOf(false) }
     var layoutKind by rememberSaveable { mutableStateOf(SearchResultLayoutKind.COVER) }
     var editingQuery by rememberSaveable(state.query.keywords) { mutableStateOf(state.query.keywords) }
+    var collapsedFilterGroups by rememberSaveable { mutableStateOf(emptyList<String>()) }
+    val useWideDesktopFilterPanel = shouldUseWideDesktopFilterPanel(
+        isDesktop = LocalPlatform.current.isDesktop(),
+        maxHorizontalPartitions = navigator.scaffoldDirective.maxHorizontalPartitions,
+    )
 
     LaunchedEffect(state.hasSelectedItem) {
         if (state.hasSelectedItem) {
@@ -157,8 +170,8 @@ fun SearchPage(
                 windowInsets = contentWindowInsets.only(WindowInsetsSides.Horizontal),
             )
         },
-        searchResultColumn = {
-            BoxWithConstraints {
+        searchResultColumn = { _, resultModifier ->
+            BoxWithConstraints(resultModifier) {
                 SearchResultColumn(
                     items = items,
                     layoutKind = layoutKind,
@@ -219,35 +232,39 @@ fun SearchPage(
                         onIntent(SearchPageIntent.Play(it))
                     },
                     headers = {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            SearchFilterChipsRow(
-                                state = state.searchFilterState,
-                                onClickItemText = { chip, value ->
-                                    val updatedQuery = state.toggleTagSelection(
-                                        tag = chip,
-                                        value = value,
-                                        unselectOthersOfSameKind = true,
-                                    ).query
-                                    onIntent(
-                                        SearchPageIntent.UpdateQuery(
-                                            updatedQuery,
-                                        ),
-                                    )
-                                },
-                                onCheckedChange = { chip, value ->
-                                    val updatedQuery = state.toggleTagSelection(
-                                        tag = chip,
-                                        value = value,
-                                        unselectOthersOfSameKind = false,
-                                    ).query
-                                    onIntent(
-                                        SearchPageIntent.UpdateQuery(
-                                            updatedQuery,
-                                        ),
-                                    )
-                                },
-                                modifier = Modifier.fillMaxWidth(),
-                            )
+                        if (!useWideDesktopFilterPanel) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                SearchFilterChipsRow(
+                                    state = state.searchFilterState,
+                                    onClickItemText = { chip, value ->
+                                        val updatedQuery = state.toggleTagSelection(
+                                            tag = chip,
+                                            value = value,
+                                            unselectOthersOfSameKind = true,
+                                        ).query
+                                        onIntent(
+                                            SearchPageIntent.UpdateQuery(
+                                                updatedQuery,
+                                            ),
+                                        )
+                                    },
+                                    onCheckedChange = { chip, value ->
+                                        val updatedQuery = state.toggleTagSelection(
+                                            tag = chip,
+                                            value = value,
+                                            unselectOthersOfSameKind = false,
+                                        ).query
+                                        onIntent(
+                                            SearchPageIntent.UpdateQuery(
+                                                updatedQuery,
+                                            ),
+                                        )
+                                    },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag(SearchPageTestTags.LegacyFilterRow),
+                                )
+                            }
                         }
                     },
                     highlightSelected = !isSinglePane,
@@ -266,6 +283,35 @@ fun SearchPage(
                     ),
                 )
             }
+        },
+        searchFilterPanel = if (useWideDesktopFilterPanel && !state.hasSelectedItem) {
+            {
+                SearchFilterSidePanel(
+                    state = state.searchFilterState,
+                    collapsedGroupKeys = collapsedFilterGroups,
+                    onToggleGroup = { groupKey ->
+                        collapsedFilterGroups = if (groupKey in collapsedFilterGroups) {
+                            collapsedFilterGroups - groupKey
+                        } else {
+                            collapsedFilterGroups + groupKey
+                        }
+                    },
+                    onCheckedChange = { chip, value ->
+                        val updatedQuery = state.toggleTagSelection(
+                            tag = chip,
+                            value = value,
+                            unselectOthersOfSameKind = false,
+                        ).query
+                        onIntent(SearchPageIntent.UpdateQuery(updatedQuery))
+                    },
+                    onClearGroup = { chip ->
+                        onIntent(SearchPageIntent.UpdateQuery(state.clearTagSelection(chip).query))
+                    },
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        } else {
+            null
         },
         detailContent = {
             items.itemSnapshotList.getOrNull(state.selectedItemIndex)?.let {
@@ -303,6 +349,15 @@ fun SearchPage(
         contentWindowInsets = contentWindowInsets,
     )
 }
+
+internal object SearchPageTestTags {
+    const val LegacyFilterRow = "search-filter-legacy-row"
+}
+
+internal fun shouldUseWideDesktopFilterPanel(
+    isDesktop: Boolean,
+    maxHorizontalPartitions: Int,
+): Boolean = isDesktop && maxHorizontalPartitions > 1
 
 @Composable
 private fun SearchPageSearchBar(
@@ -457,7 +512,8 @@ internal fun SearchPageListDetailScaffold(
     navigator: ThreePaneScaffoldNavigator<*>,
     hasSelectedItem: Boolean,
     searchBar: @Composable (PaneScope.() -> Unit),
-    searchResultColumn: @Composable (PaneScope.(NestedScrollConnection?) -> Unit),
+    searchResultColumn: @Composable (PaneScope.(NestedScrollConnection?, Modifier) -> Unit),
+    searchFilterPanel: @Composable (PaneScope.() -> Unit)? = null,
     detailContent: @Composable (PaneScope.() -> Unit),
     navigateToTopButton: @Composable PaneScope.() -> Unit,
     modifier: Modifier = Modifier,
@@ -502,7 +558,11 @@ internal fun SearchPageListDetailScaffold(
         },
         listPaneContent = {
             Scaffold(
-                floatingActionButton = { navigateToTopButton() },
+                floatingActionButton = {
+                    if (searchFilterPanel == null) {
+                        navigateToTopButton()
+                    }
+                },
                 containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
             ) { _ ->
                 Column(
@@ -518,7 +578,44 @@ internal fun SearchPageListDetailScaffold(
                         },
                 ) {
                     searchBar()
-                    searchResultColumn(topAppBarScrollBehavior?.nestedScrollConnection)
+                    if (searchFilterPanel == null) {
+                        searchResultColumn(
+                            topAppBarScrollBehavior?.nestedScrollConnection,
+                            Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f),
+                            horizontalArrangement = Arrangement.spacedBy(24.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                            ) {
+                                searchResultColumn(
+                                    topAppBarScrollBehavior?.nestedScrollConnection,
+                                    Modifier.fillMaxSize(),
+                                )
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(16.dp),
+                                ) {
+                                    navigateToTopButton()
+                                }
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .width(SearchFilterSidePanelWidth)
+                                    .fillMaxHeight(),
+                            ) {
+                                searchFilterPanel()
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageState.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageState.kt
@@ -114,6 +114,17 @@ fun SearchPageState.toggleTagSelection(
     )
 }
 
+fun SearchPageState.clearTagSelection(
+    tag: SearchFilterChipState,
+    tagKinds: List<CanonicalTagKind> = SearchFilterState.DEFAULT_TAG_KINDS,
+): SearchPageState {
+    val updatedTags = query.tags.orEmpty().filterNot { it in tag.values }
+    return withQuery(
+        query.copy(tags = updatedTags),
+        tagKinds = tagKinds,
+    )
+}
+
 fun buildSearchFilterState(
     selectedTags: List<String>,
     tagKinds: List<CanonicalTagKind> = SearchFilterState.DEFAULT_TAG_KINDS,

--- a/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/search/SearchPageStateTest.kt
+++ b/app/shared/ui-exploration/src/commonTest/kotlin/ui/exploration/search/SearchPageStateTest.kt
@@ -64,4 +64,52 @@ class SearchPageStateTest {
 
         assertEquals(listOf("百合", value), updated.query.tags)
     }
+
+    @Test
+    fun `clearTagSelection clears one group and preserves other groups`() {
+        val emptyState = createTestSearchPageState(
+            query = SubjectSearchQuery(""),
+            hasActiveSearch = true,
+        )
+        val firstGroup = emptyState.searchFilterState.chips[0]
+        val secondGroup = emptyState.searchFilterState.chips[1]
+        val firstValue = firstGroup.values.first()
+        val secondValue = secondGroup.values.first()
+        val state = createTestSearchPageState(
+            query = SubjectSearchQuery("", tags = listOf(firstValue, secondValue)),
+            hasActiveSearch = true,
+        )
+
+        val updated = state.clearTagSelection(
+            state.searchFilterState.chips.first { it.kind == firstGroup.kind },
+        )
+
+        assertEquals(listOf(secondValue), updated.query.tags)
+        assertTrue(
+            updated.searchFilterState.chips
+                .first { it.kind == firstGroup.kind }
+                .selected
+                .isEmpty(),
+        )
+        assertEquals(
+            listOf(secondValue),
+            updated.searchFilterState.chips.first { it.kind == secondGroup.kind }.selected,
+        )
+    }
+
+    @Test
+    fun `clearTagSelection removes an existing custom group`() {
+        val customTag = "自定义标签"
+        val state = createTestSearchPageState(
+            query = SubjectSearchQuery("", tags = listOf(customTag)),
+            hasActiveSearch = true,
+        )
+
+        val updated = state.clearTagSelection(
+            state.searchFilterState.chips.first { it.kind == null },
+        )
+
+        assertTrue(updated.query.tags.orEmpty().isEmpty())
+        assertTrue(updated.searchFilterState.chips.none { it.kind == null })
+    }
 }

--- a/app/shared/ui-exploration/src/desktopTest/kotlin/ui/exploration/search/SearchPageWideLayoutTest.kt
+++ b/app/shared/ui-exploration/src/desktopTest/kotlin/ui/exploration/search/SearchPageWideLayoutTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.exploration.search
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.MutableStateFlow
+import me.him188.ani.app.domain.search.SubjectSearchQuery
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.framework.doesNotExist
+import me.him188.ani.app.ui.framework.exists
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.app.ui.search.TestSearchState
+import me.him188.ani.utils.platform.annotations.TestOnly
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(TestOnly::class, ExperimentalTestApi::class)
+class SearchPageWideLayoutTest {
+    @Test
+    fun `wide desktop shows side filters and no legacy row`() {
+        runSearchPageTest(widthDp = 840) {
+            assertTrue(onNodeWithTag(SearchFilterSidePanelTestTags.Panel).exists())
+            assertTrue(onNodeWithTag(SearchPageTestTags.LegacyFilterRow).doesNotExist())
+        }
+    }
+
+    @Test
+    fun `wide mode follows desktop scaffold horizontal partitions`() {
+        assertFalse(shouldUseWideDesktopFilterPanel(true, 1))
+        assertTrue(shouldUseWideDesktopFilterPanel(true, 2))
+        assertFalse(shouldUseWideDesktopFilterPanel(false, 2))
+    }
+
+    @Test
+    fun `desktop below wide breakpoint keeps legacy filter row`() {
+        runSearchPageTest(widthDp = 839) {
+            assertTrue(onNodeWithTag(SearchFilterSidePanelTestTags.Panel).doesNotExist())
+            assertTrue(onNodeWithTag(SearchPageTestTags.LegacyFilterRow).exists())
+        }
+    }
+
+    @Test
+    fun `wide desktop detail mode hides both filter presentations`() {
+        runSearchPageTest(
+            widthDp = 1400,
+            state = createTestSearchPageState().copy(selectedItemIndex = 0),
+        ) {
+            assertTrue(onNodeWithTag(SearchFilterSidePanelTestTags.Panel).doesNotExist())
+            assertTrue(onNodeWithTag(SearchPageTestTags.LegacyFilterRow).doesNotExist())
+        }
+    }
+
+    @Test
+    fun `side filters expand collapse select and clear a group`() = runAniComposeUiTest {
+        val genre = createTestSearchPageState().searchFilterState.chips.first()
+        val selectedValue = genre.values.first()
+        val unselectedValue = genre.values[1]
+        var selectedTags by mutableStateOf(listOf(selectedValue))
+        var collapsedGroups by mutableStateOf(emptyList<String>())
+
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                Surface(Modifier.size(width = SearchFilterSidePanelWidth, height = 720.dp)) {
+                    val filterState = buildSearchFilterState(selectedTags)
+                    SearchFilterSidePanel(
+                        state = filterState,
+                        collapsedGroupKeys = collapsedGroups,
+                        onToggleGroup = { groupKey ->
+                            collapsedGroups = if (groupKey in collapsedGroups) {
+                                collapsedGroups - groupKey
+                            } else {
+                                collapsedGroups + groupKey
+                            }
+                        },
+                        onCheckedChange = { _, value ->
+                            selectedTags = if (value in selectedTags) {
+                                selectedTags - value
+                            } else {
+                                selectedTags + value
+                            }
+                        },
+                        onClearGroup = { chip ->
+                            selectedTags = selectedTags.filterNot { it in chip.values }
+                        },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+        }
+
+        val groupKey = genre.groupKey
+        val selectedNode = onNodeWithTag(
+            SearchFilterSidePanelTestTags.value(groupKey, selectedValue),
+        )
+        val unselectedNode = onNodeWithTag(
+            SearchFilterSidePanelTestTags.value(groupKey, unselectedValue),
+        )
+        selectedNode.assertIsSelected()
+        unselectedNode.assertIsNotSelected()
+
+        onNodeWithTag(SearchFilterSidePanelTestTags.group(groupKey)).performClick()
+        assertFalse(selectedNode.exists())
+        onNodeWithTag(SearchFilterSidePanelTestTags.group(groupKey)).performClick()
+        unselectedNode.performClick().assertIsSelected()
+
+        onNodeWithTag(SearchFilterSidePanelTestTags.all(groupKey)).performClick().assertIsSelected()
+        selectedNode.assertIsNotSelected()
+        unselectedNode.assertIsNotSelected()
+        runOnIdle { assertEquals(emptyList(), selectedTags) }
+    }
+
+    private fun runSearchPageTest(
+        widthDp: Int,
+        state: SearchPageState = createUiTestState(),
+        block: SkikoComposeUiTest.() -> Unit,
+    ) {
+        runSkikoComposeUiTest(
+            size = Size(widthDp.toFloat(), 900f),
+            density = Density(1f),
+        ) {
+            setContent {
+                ProvideCompositionLocalsForPreview {
+                    SearchPage(
+                        state = state,
+                        onIntent = {},
+                        suggestionsPager = { MutableStateFlow(PagingData.empty()) },
+                        detailContent = { Surface(Modifier.fillMaxSize()) {} },
+                    )
+                }
+            }
+            waitForIdle()
+            block()
+        }
+    }
+
+    private fun createUiTestState(
+        query: SubjectSearchQuery = SubjectSearchQuery("test"),
+    ): SearchPageState = createTestSearchPageState(
+        searchState = TestSearchState(
+            MutableStateFlow(
+                MutableStateFlow(PagingData.from(TestSubjectPreviewItemInfos.take(12))),
+            ),
+        ),
+        query = query,
+    )
+}


### PR DESCRIPTION
针对于桌面宽屏模式下添加了常驻侧边标签栏，窄屏模式下未做修改

宽屏：
<img width="1163" height="854" alt="image" src="https://github.com/user-attachments/assets/63653284-9c31-4364-9711-99017ee42c2d" />

窄屏：
<img width="398" height="854" alt="image" src="https://github.com/user-attachments/assets/8da2a2ff-4b74-4030-9c70-32da23c835f1" />

Closes #3302 
