### PR TITLE
feat: 条目详情页封面与角色/制作人员图片支持点击放大查看

### DIFF
--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageViewer.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/ImageViewer.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.annotation.ExperimentalCoilApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,6 +49,9 @@ interface ImageViewerHandler {
 val LocalImageViewerHandler: ProvidableCompositionLocal<ImageViewerHandler> = compositionLocalOf {
     error("no ImageViewerHandler provided")
 }
+
+/** [ImageViewer] 缩放层的 test tag, 供 UI 测试断言查看器已打开. */
+const val IMAGE_VIEWER_TEST_TAG = "ImageViewer"
 
 @Composable
 fun rememberImageViewerHandler(): ImageViewerHandler {
@@ -109,7 +113,7 @@ fun ImageViewer(
                 },
             ),
             state = zoomableState,
-            modifier = Modifier.background(Color.Black),
+            modifier = Modifier.testTag(IMAGE_VIEWER_TEST_TAG).background(Color.Black),
             detectGesture = ZoomableGestureScope(
                 onDoubleTap = { offset -> scope.launch { zoomableState.toggleScale(offset) } },
                 onTap = { _ -> onClose() },

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/SubjectDetailsPage.kt
@@ -340,6 +340,10 @@ private fun SubjectDetailsPage(
         )
     }
     val onClickCommentImage = { url: String -> imageViewer.viewImage(url) }
+    // 封面/角色/制作人员图片点击放大 (与评论图片共用页面级查看器)
+    val onClickPersonImage = { url: String -> imageViewer.viewImage(url) }
+    val coverImageUrl = state.info?.imageLarge?.takeIf { it.isNotBlank() }
+    val onClickCover: (() -> Unit)? = coverImageUrl?.let { url -> { imageViewer.viewImage(url) } }
     // Bangumi 源评价的 "在 Bangumi 打开" 菜单项
     val onOpenCommentOriginal = { _: UIComment ->
         browserNavigator.openUri("https://bgm.tv/subject/${presentation.subjectId}")
@@ -410,6 +414,8 @@ private fun SubjectDetailsPage(
                     navigationIcon = navigationIcon,
                     onClickOpenExternal = onClickOpenExternal,
                     onCoverImageSuccess = onCoverImageSuccess,
+                    onClickCover = onClickCover,
+                    onClickPersonImage = onClickPersonImage,
                 )
             }
             return@MaterialThemeFromPaletteAndImage
@@ -457,6 +463,7 @@ private fun SubjectDetailsPage(
             navigationIcon = navigationIcon,
             onCoverImageSuccess = onCoverImageSuccess,
             onClickOpenExternal = onClickOpenExternal,
+            onClickCover = onClickCover,
             floatingActionButton = {
                 when (SubjectDetailsTab.entries.getOrNull(pagerState.currentPage)) {
                     SubjectDetailsTab.COMMENTS -> {
@@ -500,6 +507,7 @@ private fun SubjectDetailsPage(
                             .nestedScrollWorkaround(state.detailsTabLazyListState),
                         listState = state.detailsTabLazyListState,
                         contentPadding = tabContentPadding,
+                        onClickPersonImage = onClickPersonImage,
                     )
                 },
                 commentsTab = { tabContentPadding ->
@@ -693,6 +701,7 @@ fun SubjectDetailsSingleColumnPage(
     navigationIcon: @Composable () -> Unit = {},
     onCoverImageSuccess: (AsyncImagePainter.State.Success) -> Unit = {},
     onClickOpenExternal: () -> Unit = {},
+    onClickCover: (() -> Unit)? = null,
     floatingActionButton: @Composable () -> Unit = {},
     tabRow: (@Composable (isOverlay: Boolean, visible: Boolean) -> Unit)? = null,
     nestedScrollableColumnState: NestedScrollableColumnState = rememberNestedScrollableColumnState(),
@@ -794,6 +803,7 @@ fun SubjectDetailsSingleColumnPage(
                                             .ifThen(!showTopBar) { padding(top = windowSizeClass.paneVerticalPadding) }
                                             .padding(horizontal = windowSizeClass.paneHorizontalPadding),
                                         onCoverImageSuccess = onCoverImageSuccess,
+                                        onClickCover = onClickCover,
                                     )
                                 }
                             }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/PersonCard.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/PersonCard.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.ui.subject.details.components
 
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,26 +31,37 @@ import me.him188.ani.app.data.models.subject.RelatedCharacterInfo
 import me.him188.ani.app.data.models.subject.RelatedPersonInfo
 import me.him188.ani.app.data.models.subject.nameCn
 import me.him188.ani.app.ui.foundation.avatar.AvatarImage
+import me.him188.ani.app.ui.foundation.ifThen
 
 /** 人物卡行: 方圆角头像 + 名字 + `职位/角色 (· CV)`. 用于角色/制作人员的"查看全部"列表. */
 @Composable
-fun PersonCard(info: RelatedPersonInfo, modifier: Modifier = Modifier) {
+fun PersonCard(
+    info: RelatedPersonInfo,
+    modifier: Modifier = Modifier,
+    onClickImage: (() -> Unit)? = null,
+) {
     PersonCard(
         avatarUrl = info.personInfo.imageMedium,
         name = info.personInfo.displayName,
         relation = info.position.nameCn ?: "",
         modifier = modifier,
+        onClickImage = onClickImage,
     )
 }
 
 @Composable
-fun PersonCard(info: RelatedCharacterInfo, modifier: Modifier = Modifier) {
+fun PersonCard(
+    info: RelatedCharacterInfo,
+    modifier: Modifier = Modifier,
+    onClickImage: (() -> Unit)? = null,
+) {
     PersonCard(
         avatarUrl = info.character.imageMedium,
         name = info.character.displayName,
         relation = info.role.nameCn,
         modifier = modifier,
         actorName = remember(info) { getFirstName(info.character.actors) },
+        onClickImage = onClickImage,
     )
 }
 
@@ -66,13 +78,19 @@ fun PersonCard(
     relation: String,
     modifier: Modifier = Modifier,
     actorName: String? = null,
+    onClickImage: (() -> Unit)? = null,
 ) {
     Row(modifier) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(Modifier.clip(MaterialTheme.shapes.small).size(48.dp)) {
+            Box(
+                Modifier
+                    .clip(MaterialTheme.shapes.small)
+                    .ifThen(onClickImage != null) { clickable(onClick = checkNotNull(onClickImage)) }
+                    .size(48.dp),
+            ) {
                 AvatarImage(avatarUrl, Modifier.matchParentSize(), alignment = Alignment.TopCenter)
             }
 

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/SubjectDetailsHeader.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/SubjectDetailsHeader.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
@@ -52,6 +53,7 @@ import me.him188.ani.app.data.models.subject.TestCoverImage
 import me.him188.ani.app.data.models.subject.TestSubjectInfo
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
@@ -69,6 +71,9 @@ import me.him188.ani.utils.platform.annotations.TestOnly
 
 const val COVER_WIDTH_TO_HEIGHT_RATIO = 849 / 1200f
 
+/** 条目封面图的 test tag, 供 UI 测试定位点击放大入口. */
+const val SUBJECT_COVER_IMAGE_TEST_TAG = "SubjectCoverImage"
+
 // 图片和标题
 @Composable
 internal fun SubjectDetailsHeader(
@@ -81,6 +86,7 @@ internal fun SubjectDetailsHeader(
     rating: @Composable () -> Unit,
     onCoverImageSuccess: (AsyncImagePainter.State.Success) -> Unit = {},
     modifier: Modifier = Modifier,
+    onClickCover: (() -> Unit)? = null,
 ) {
     if (currentWindowAdaptiveInfo1().isWidthAtLeastMedium) {
         SubjectDetailsHeaderWide(
@@ -106,6 +112,7 @@ internal fun SubjectDetailsHeader(
             rating = rating,
             onCoverImageSuccess = onCoverImageSuccess,
             modifier = modifier,
+            onClickCover = onClickCover,
         )
     } else {
         SubjectDetailsHeaderCompact(
@@ -120,6 +127,7 @@ internal fun SubjectDetailsHeader(
             rating = rating,
             onSuccess = onCoverImageSuccess,
             modifier = modifier,
+            onClickCover = onClickCover,
         )
     }
 }
@@ -139,12 +147,18 @@ fun SubjectDetailsHeaderCompact(
     rating: @Composable () -> Unit,
     onSuccess: (AsyncImagePainter.State.Success) -> Unit,
     modifier: Modifier = Modifier,
+    onClickCover: (() -> Unit)? = null,
 ) {
     Column(modifier) {
         Row(Modifier.height(IntrinsicSize.Min), verticalAlignment = Alignment.Top) {
             val imageWidth = 140.dp
 
-            Box(Modifier.clip(MaterialTheme.shapes.medium)) {
+            Box(
+                Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .ifThen(onClickCover != null) { clickable(onClick = checkNotNull(onClickCover)) }
+                    .testTag(SUBJECT_COVER_IMAGE_TEST_TAG),
+            ) {
                 AsyncImage(
                     ImageRequest.Builder(LocalPlatformContext.current)
                         .data(coverImageUrl)
@@ -227,6 +241,7 @@ fun SubjectDetailsHeaderWide(
     rating: @Composable () -> Unit,
     onCoverImageSuccess: (AsyncImagePainter.State.Success) -> Unit,
     modifier: Modifier = Modifier,
+    onClickCover: (() -> Unit)? = null,
 ) {
     Column(modifier) {
         Row(
@@ -235,7 +250,12 @@ fun SubjectDetailsHeaderWide(
         ) {
             val imageWidth = 220.dp
 
-            Box(Modifier.clip(MaterialTheme.shapes.medium)) {
+            Box(
+                Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .ifThen(onClickCover != null) { clickable(onClick = checkNotNull(onClickCover)) }
+                    .testTag(SUBJECT_COVER_IMAGE_TEST_TAG),
+            ) {
                 AsyncImage(
                     ImageRequest.Builder(LocalPlatformContext.current)
                         .data(coverImageUrl)

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/layout/CompactDetailsTab.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/layout/CompactDetailsTab.kt
@@ -78,6 +78,7 @@ internal fun CompactDetailsTabContent(
     listState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     horizontalPadding: Dp = 16.dp,
+    onClickPersonImage: ((url: String) -> Unit)? = null,
 ) {
     val presentation by state.presentation.collectAsStateWithLifecycle()
     val episodes = presentation.episodeListUiState.mainEpisodes
@@ -168,6 +169,7 @@ internal fun CompactDetailsTabContent(
                 contentPadding = horizontalPaddingValues,
                 avatarSize = 56.dp,
                 itemSpacing = 0.dp,
+                onClickImage = onClickPersonImage,
             )
         }
 
@@ -179,6 +181,7 @@ internal fun CompactDetailsTabContent(
                 totalStaffCount,
                 horizontalPaddingModifier,
                 gridColumns = 3,
+                onClickImage = onClickPersonImage,
             )
         }
 

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/layout/SubjectDetailsMultiColumnPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/layout/SubjectDetailsMultiColumnPage.kt
@@ -10,6 +10,7 @@
 package me.him188.ani.app.ui.subject.details.layout
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -55,6 +56,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -72,6 +74,7 @@ import me.him188.ani.app.tools.ColorUtils
 import me.him188.ani.app.ui.external.placeholder.placeholder
 import me.him188.ani.app.ui.foundation.AsyncImage
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
+import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.text.ProvideContentColor
 import me.him188.ani.app.ui.foundation.theme.AniThemeDefaults
 import me.him188.ani.app.ui.lang.Lang
@@ -89,6 +92,7 @@ import me.him188.ani.app.ui.subject.collection.progress.SubjectProgressButton
 import me.him188.ani.app.ui.subject.details.components.AnimatedGradientBackground
 import me.him188.ani.app.ui.subject.details.components.COVER_WIDTH_TO_HEIGHT_RATIO
 import me.him188.ani.app.ui.subject.details.components.RatingHistogram
+import me.him188.ani.app.ui.subject.details.components.SUBJECT_COVER_IMAGE_TEST_TAG
 import me.him188.ani.app.ui.subject.details.components.RelatedSubjectsGrid
 import me.him188.ani.app.ui.subject.details.components.rememberNavigateToRelatedSubject
 import me.him188.ani.app.ui.subject.details.sections.CharactersSection
@@ -133,6 +137,8 @@ internal fun SubjectDetailsMultiColumnPage(
     navigationIcon: @Composable () -> Unit = {},
     onClickOpenExternal: () -> Unit = {},
     onCoverImageSuccess: (AsyncImagePainter.State.Success) -> Unit = {},
+    onClickCover: (() -> Unit)? = null,
+    onClickPersonImage: ((url: String) -> Unit)? = null,
 ) {
     val info = state.info ?: return
     val presentation by state.presentation.collectAsStateWithLifecycle()
@@ -187,6 +193,7 @@ internal fun SubjectDetailsMultiColumnPage(
             itemSpacing = layoutParams.sidebarItemSpacing,
             onCoverImageSuccess = onCoverImageSuccess,
             modifier = Modifier.width(layoutParams.sidebarWidth),
+            onClickCover = onClickCover,
         )
 
         // 中栏内容流. 区块序 (定稿): 标题 → 评分 → 简介 → 选集 → 角色
@@ -226,13 +233,17 @@ internal fun SubjectDetailsMultiColumnPage(
                     }
                 },
             )
-            CharactersSection(exposedCharacters, allCharacters, totalCharactersCount)
+            CharactersSection(
+                exposedCharacters, allCharacters, totalCharactersCount,
+                onClickImage = onClickPersonImage,
+            )
             if (!layoutParams.showRail) {
                 StaffSection(
                     exposedStaff,
                     allStaff,
                     totalStaffCount,
                     gridColumns = layoutParams.staffGridColumns,
+                    onClickImage = onClickPersonImage,
                 )
             }
             if (related.itemCount > 0) {
@@ -268,7 +279,10 @@ internal fun SubjectDetailsMultiColumnPage(
                 }
                 if (exposedStaff.itemCount > 0) {
                     RailCard {
-                        StaffSection(exposedStaff, allStaff, totalStaffCount)
+                        StaffSection(
+                            exposedStaff, allStaff, totalStaffCount,
+                            onClickImage = onClickPersonImage,
+                        )
                     }
                 }
             }
@@ -465,6 +479,7 @@ private fun SubjectSidebar(
     itemSpacing: Dp,
     onCoverImageSuccess: (AsyncImagePainter.State.Success) -> Unit,
     modifier: Modifier = Modifier,
+    onClickCover: (() -> Unit)? = null,
 ) {
     Column(modifier, verticalArrangement = Arrangement.spacedBy(itemSpacing)) {
         // 封面: 固定海报比例 (849:1200) + 圆角 16, 对齐定稿 340×482, 不随图片本征尺寸变形.
@@ -474,7 +489,9 @@ private fun SubjectSidebar(
             Modifier
                 .fillMaxWidth()
                 .aspectRatio(COVER_WIDTH_TO_HEIGHT_RATIO)
-                .clip(RoundedCornerShape(16.dp)),
+                .clip(RoundedCornerShape(16.dp))
+                .ifThen(onClickCover != null) { clickable(onClick = checkNotNull(onClickCover)) }
+                .testTag(SUBJECT_COVER_IMAGE_TEST_TAG),
             contentScale = ContentScale.Crop,
             onSuccess = onCoverImageSuccess,
         )

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/sections/SubjectPeopleSections.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/sections/SubjectPeopleSections.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -163,6 +164,8 @@ fun SubjectRatingSummary(
  * 尺寸对齐 Figma `CharacterCard`: 桌面 Large (头像 76, 间距 12), 手机 Small (头像 56, 间距 0).
  *
  * @param contentPadding 头像条与标题的水平内边距; 手机端传水平 16dp 可让头像条边到边滚动.
+ * @param onClickImage 非 null 时点击头像放大查看大图 (点击名字仍进入角色详情);
+ * "查看全部" sheet 中点击头像会先关闭 sheet (页面级查看器在 sheet 之下).
  */
 @Composable
 fun CharactersSection(
@@ -174,6 +177,7 @@ fun CharactersSection(
     itemWidth: Dp = 76.dp,
     avatarSize: Dp = 76.dp,
     itemSpacing: Dp = 12.dp,
+    onClickImage: ((url: String) -> Unit)? = null,
 ) {
     if (exposedCharacters.itemCount == 0) return
     var showAll by rememberSaveable { mutableStateOf(false) }
@@ -191,9 +195,13 @@ fun CharactersSection(
         ) {
             items(exposedCharacters.itemCount) { i ->
                 val item = exposedCharacters[i] ?: return@items
+                val imageUrl = item.character.imageLarge.takeIf { it.isNotBlank() }
                 CharacterAvatarCell(
                     item, itemWidth, avatarSize,
                     onClick = { onClickCharacter(PeoplePreviewTarget.Character(item.character.id)) },
+                    onClickImage = if (onClickImage != null && imageUrl != null) {
+                        { onClickImage(imageUrl) }
+                    } else null,
                 )
             }
         }
@@ -206,6 +214,7 @@ fun CharactersSection(
             items = allCharacters,
             onDismissRequest = { showAll = false },
         ) {
+            val imageUrl = it.character.imageLarge.takeIf { url -> url.isNotBlank() }
             PersonCard(
                 it,
                 Modifier
@@ -214,10 +223,19 @@ fun CharactersSection(
                         showAll = false
                         onClickCharacter(PeoplePreviewTarget.Character(it.character.id))
                     },
+                onClickImage = if (onClickImage != null && imageUrl != null) {
+                    {
+                        showAll = false
+                        onClickImage(imageUrl)
+                    }
+                } else null,
             )
         }
     }
 }
+
+/** 角色横向头像条中头像的 test tag, 供 UI 测试定位点击放大入口. */
+const val CHARACTER_AVATAR_TEST_TAG = "CharacterAvatar"
 
 @Composable
 private fun CharacterAvatarCell(
@@ -225,6 +243,7 @@ private fun CharacterAvatarCell(
     itemWidth: Dp,
     avatarSize: Dp,
     onClick: () -> Unit,
+    onClickImage: (() -> Unit)? = null,
 ) {
     val cv = remember(info) { info.character.actors.firstOrNull()?.displayName }
     Column(
@@ -236,7 +255,13 @@ private fun CharacterAvatarCell(
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         // 固定圆形, crop, 顶部对齐 (立绘顶部为脸部)
-        Box(Modifier.size(avatarSize).clip(CircleShape)) {
+        Box(
+            Modifier
+                .size(avatarSize)
+                .clip(CircleShape)
+                .ifThen(onClickImage != null) { clickable(onClick = checkNotNull(onClickImage)) }
+                .testTag(CHARACTER_AVATAR_TEST_TAG),
+        ) {
             AvatarImage(
                 info.character.imageMedium,
                 Modifier.matchParentSize(),
@@ -269,6 +294,9 @@ private fun CharacterAvatarCell(
  * 内容形态 (对齐定稿):
  * - [gridColumns] 非 null: `职位 上 / 名字 下` 的网格 (双栏中栏单行 6 列, 手机 3 列两行);
  * - [gridColumns] 为 null: `职位 -> 名字` 竖排键值行 (三栏右栏卡, 显示 [maxItems] 个职位).
+ *
+ * @param onClickImage 非 null 时 "查看全部" sheet 中点击头像放大查看大图
+ * (会先关闭 sheet, 页面级查看器在 sheet 之下); 区块本体为纯文字, 无图片.
  */
 @Composable
 fun StaffSection(
@@ -278,6 +306,7 @@ fun StaffSection(
     modifier: Modifier = Modifier,
     gridColumns: Int? = null,
     maxItems: Int = if (gridColumns != null) 6 else 10,
+    onClickImage: ((url: String) -> Unit)? = null,
 ) {
     if (exposedStaff.itemCount == 0) return
     var showAll by rememberSaveable { mutableStateOf(false) }
@@ -307,6 +336,7 @@ fun StaffSection(
             items = allStaff,
             onDismissRequest = { showAll = false },
         ) {
+            val imageUrl = it.personInfo.imageLarge.takeIf { url -> url.isNotBlank() }
             PersonCard(
                 it,
                 Modifier
@@ -315,6 +345,12 @@ fun StaffSection(
                         showAll = false
                         onClickPerson(PeoplePreviewTarget.Person(it.personInfo.id))
                     },
+                onClickImage = if (onClickImage != null && imageUrl != null) {
+                    {
+                        showAll = false
+                        onClickImage(imageUrl)
+                    }
+                } else null,
             )
         }
     }

--- a/app/shared/ui-subject/src/desktopTest/kotlin/ui/subject/details/SubjectDetailsImageViewerTest.kt
+++ b/app/shared/ui-subject/src/desktopTest/kotlin/ui/subject/details/SubjectDetailsImageViewerTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.details
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.Density
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.resetMain
+import me.him188.ani.app.data.models.subject.TestCoverImage
+import me.him188.ani.app.data.models.subject.TestSelfRatingInfo
+import me.him188.ani.app.data.models.subject.TestSubjectCollections
+import me.him188.ani.app.data.models.subject.TestSubjectInfo
+import me.him188.ani.app.ui.comment.createTestCommentState
+import me.him188.ani.app.ui.foundation.IMAGE_VIEWER_TEST_TAG
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.stateOf
+import me.him188.ani.app.ui.rating.createTestEditableRatingState
+import me.him188.ani.app.ui.search.createTestPager
+import me.him188.ani.app.ui.subject.collection.components.createTestEditableSubjectCollectionTypeState
+import me.him188.ani.app.ui.subject.collection.progress.createTestSubjectProgressState
+import me.him188.ani.app.ui.subject.createTestAiringLabelState
+import me.him188.ani.app.ui.subject.details.components.SUBJECT_COVER_IMAGE_TEST_TAG
+import me.him188.ani.app.ui.subject.details.sections.CHARACTER_AVATAR_TEST_TAG
+import me.him188.ani.app.ui.subject.details.state.SubjectDetailsPresentation
+import me.him188.ani.app.ui.subject.details.state.SubjectDetailsState
+import me.him188.ani.app.ui.subject.episode.list.TestEpisodeListUiState
+import me.him188.ani.app.ui.user.TestSelfInfoUiState
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import me.him188.ani.utils.platform.annotations.TestOnly
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * 交互测试: 条目详情页点击封面/角色头像打开页面级图片查看器, 再点击查看器关闭.
+ *
+ * 断点由 Skiko 场景像素尺寸控制 (density=1 => px==dp):
+ * 360 => Compact(手机单栏) / 1400 => Medium(双栏).
+ */
+@OptIn(TestOnly::class, ExperimentalTestApi::class)
+class SubjectDetailsImageViewerTest {
+    private val outDir: File =
+        File(System.getProperty("ani.screenshot.out") ?: "build/screenshots").also { it.mkdirs() }
+
+    /** 与 [SubjectDetailsScreenshotTest] 一致, 导出 PNG 供人工核对交互结果. */
+    private fun SkikoComposeUiTest.capture(name: String) {
+        val png = Image.makeFromBitmap(captureToImage().asSkiaBitmap())
+            .encodeToData(EncodedImageFormat.PNG)
+            ?.bytes
+            ?: error("Failed to encode screenshot $name")
+        File(outDir, "$name.png").writeBytes(png)
+    }
+
+    /** 与截图测试的数据类似, 但封面与角色图为非空 URL (空 URL 不启用点击放大). */
+    private fun testStateWithImages(scope: CoroutineScope): SubjectDetailsState {
+        val subjectInfo = TestSubjectCollections.first().subjectInfo
+        val characters = TestSubjectCharacterList.map { related ->
+            related.copy(
+                character = related.character.copy(
+                    imageMedium = TestCoverImage,
+                    imageLarge = TestCoverImage,
+                ),
+            )
+        }
+        val info = TestSubjectInfo.copy(imageLarge = TestCoverImage)
+        return SubjectDetailsState(
+            subjectId = info.subjectId,
+            info = info,
+            selfCollectionTypeState = stateOf(UnifiedCollectionType.DOING),
+            airingLabelState = createTestAiringLabelState(),
+            charactersPager = createTestPager(characters),
+            exposedCharactersPager = createTestPager(characters),
+            totalCharactersCountState = stateOf(characters.size),
+            staffPager = createTestPager(TestSubjectStaffInfo),
+            exposedStaffPager = createTestPager(TestSubjectStaffInfo),
+            totalStaffCountState = stateOf(TestSubjectStaffInfo.size),
+            relatedSubjectsPager = createTestPager(TestRelatedSubjects),
+            editableSubjectCollectionTypeState = createTestEditableSubjectCollectionTypeState(
+                MutableStateFlow(UnifiedCollectionType.DOING),
+                scope,
+            ),
+            editableRatingState = createTestEditableRatingState(
+                subjectInfo,
+                selfRatingInfo = TestSelfRatingInfo,
+                backgroundScope = scope,
+            ),
+            subjectProgressState = createTestSubjectProgressState(),
+            subjectCommentState = createTestCommentState(scope),
+            presentation = MutableStateFlow(
+                SubjectDetailsPresentation(
+                    subjectId = info.subjectId,
+                    displayName = info.displayName,
+                    episodeListUiState = TestEpisodeListUiState,
+                    isPlaceholder = false,
+                ),
+            ),
+        )
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    private fun runPageTest(widthDp: Int, heightDp: Int, block: SkikoComposeUiTest.() -> Unit) {
+        // 查看器的单击关闭经 Dispatchers.Main 真实 delay 触发; 确保 Main 未被其他测试替换为虚拟时钟.
+        Dispatchers.resetMain()
+        runSkikoComposeUiTest(Size(widthDp.toFloat(), heightDp.toFloat()), density = Density(1f)) {
+            setContent {
+                ProvideCompositionLocalsForPreview {
+                    CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                        val scope = rememberCoroutineScope()
+                        val state = remember {
+                            testStateWithImages(scope).let { SubjectDetailsUIState.Ok(it.subjectId, it) }
+                        }
+                        SubjectDetailsScreen(
+                            state,
+                            TestSelfInfoUiState,
+                            onPlay = {},
+                            onLoadErrorRetry = {},
+                            onClickTag = {},
+                            onEpisodeCollectionUpdate = {},
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+            block()
+        }
+    }
+
+    @Test
+    fun `compact - click cover opens image viewer`() = runPageTest(360, 800) {
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertDoesNotExist()
+        onNodeWithTag(SUBJECT_COVER_IMAGE_TEST_TAG).performClick()
+        waitForIdle()
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertIsDisplayed()
+        capture("image-viewer-compact-cover-open")
+    }
+
+    @Test
+    fun `multi column - click cover opens image viewer, tap closes it`() = runPageTest(1400, 1400) {
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertDoesNotExist()
+        capture("image-viewer-multicolumn-before")
+        onNodeWithTag(SUBJECT_COVER_IMAGE_TEST_TAG).performClick()
+        waitForIdle()
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertIsDisplayed()
+        capture("image-viewer-multicolumn-cover-open")
+
+        // 单击查看器关闭. 注意: 查看器的 tap 检测要求手势期间没有 Move 事件
+        // (performClick 会注入 down-move-up), 因此只注入 down+up;
+        // 其单击回调经真实墙钟 delay(272ms) 触发 (区分双击), 不受测试虚拟时钟控制,
+        // 因此用实时轮询等待节点消失.
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).performTouchInput {
+            down(center)
+            up()
+        }
+        waitUntil(timeoutMillis = 5000) {
+            onAllNodesWithTag(IMAGE_VIEWER_TEST_TAG).fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    @Test
+    fun `multi column - click character avatar opens image viewer`() = runPageTest(1400, 1400) {
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertDoesNotExist()
+        onAllNodesWithTag(CHARACTER_AVATAR_TEST_TAG).onFirst().performScrollTo().performClick()
+        waitForIdle()
+        onNodeWithTag(IMAGE_VIEWER_TEST_TAG).assertIsDisplayed()
+        capture("image-viewer-multicolumn-avatar-open")
+    }
+}


### PR DESCRIPTION
## 改动内容

给条目详情页的图片增加点击放大查看功能, 复用现有的页面级 `ImageViewer` (缩放/拖动/双击缩放) overlay:

- **封面**: 手机窄版 header、宽版 header、桌面多栏侧栏封面, 点击放大查看 `imageLarge`
- **角色横向头像条**: 点击头像放大查看; 点击名字仍进入角色详情 (原导航保留)
- **角色 / 制作人员 "查看全部" sheet**: 点击 `PersonCard` 头像放大查看; 点击行其余部分仍导航
- 空图片 URL 时不启用点击 (占位/加载中状态不可点)
- 现有 `BackHandler` 生效: 查看器打开时按返回键只关闭查看器
- 为 UI 测试新增稳定 test tag (`ImageViewer` / `SubjectCoverImage` / `CharacterAvatar`)

## 实现说明

- 所有新参数为可选默认 `null`, 其余调用方 (PeopleDetailsPage 等) 行为不变
- "查看全部" sheet 中点头像会**先关闭 sheet** 再打开查看器: 页面级查看器渲染在 ModalBottomSheet popup 层之下, 不关 sheet 查看器会被遮住 (行点击导航也是同样的既有模式)。彻底解法是把查看器提升到独立 window 层 (顺带可修复多栏评论 sheet 中评论图片被遮住的既有问题), 留作 follow-up
- 新增桌面交互测试 `SubjectDetailsImageViewerTest`: compact 点封面 / 多栏点封面 + 单击关闭 / 多栏点角色头像, 并导出截图到 `build/screenshots`

## 测试

- [x] `:app:shared:ui-subject:desktopTest` 全部通过 (新增 3 个交互测试 + 既有截图测试)
- [x] Android 模拟器 (Pixel 8 Pro API 35, arm64) 真机交互验证: 封面放大 / 单击关闭 / 头像放大 / 返回键关闭 / 名字导航不受影响 / 查看全部 sheet 头像放大
- [x] 宽屏 (2560x1600 ≈ 1280x800dp, 与桌面同款多栏布局) 真机验证: 侧栏封面放大
- [x] 桌面 (macOS, createDistributable 打包 .app) 启动健康, Skiko 桌面渲染管线交互测试通过

截图见下方评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)