### PR TITLE
fix: 修复防多开功能在托盘模式状态未能正常传递

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,6 +46,7 @@ import com.sun.jna.platform.win32.WinReg
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
@@ -83,6 +85,7 @@ import me.him188.ani.app.platform.startCommonKoinModule
 import me.him188.ani.app.platform.trace.recordAppStart
 import me.him188.ani.app.platform.window.HandleWindowsWindowProc
 import me.him188.ani.app.platform.window.LocalTitleBarThemeController
+import me.him188.ani.app.platform.window.WindowsWindowUtils
 import me.him188.ani.app.platform.window.rememberLayoutHitTestOwner
 import me.him188.ani.app.platform.window.setTitleBar
 import me.him188.ani.app.tools.update.DesktopUpdateInstaller
@@ -525,6 +528,18 @@ object AniDesktop {
                         MainWindowContent(navigator)
                     } else {
                         HandleWindowsWindowProc()
+                        if (platform.isWindows()) {
+                            val platformWindow = LocalPlatformWindow.current
+                            LaunchedEffect(platformWindow, trayState) {
+                                WindowsWindowUtils.instance.windowIsActive(platformWindow)
+                                    .filter { it == true }
+                                    .collect {
+                                        if (trayState.isWindowHiddenToTray) {
+                                            trayState.restoreWindow()
+                                        }
+                                    }
+                            }
+                        }
                         WindowFrame(
                             windowState = windowState,
                             onCloseRequest = {


### PR DESCRIPTION
Closes #3312

## 问题

Windows 设置“关闭时最小化到托盘”后，再次启动应用会通过 Win32 API 显示原窗口，但 Compose 仍保持“窗口已隐藏”的状态，导致窗口显示异常或看似卡死。

## 修复

监听 Windows 窗口激活事件。当窗口被重新激活且仍处于托盘隐藏状态时，调用 `restoreWindow()`，同步原生窗口与 Compose 的可见性状态。

## 验证

- `:app:desktop:compileKotlin` 通过
- `:app:desktop:test` 通过（当前为 `NO-SOURCE`）
- 手动验证：手动进行了打包，并用同样的方式进行测试该问题，确定成功修复
- 测试环境：win11