### PR TITLE
fix: 重命名 app:shared 资源包名以修复 iOS 打包被 App Store 拒绝

### DIFF
--- a/app/shared/build.gradle.kts
+++ b/app/shared/build.gradle.kts
@@ -202,7 +202,10 @@ val mergeCommonMainComposeResources = tasks.register<Sync>("mergeCommonMainCompo
 }
 
 compose.resources {
-    packageOfResClass = "me.him188.ani.app"
+    // 不能用 "me.him188.ani.app": 资源会打进以包名命名的目录, 目录名以 ".app" 结尾时
+    // App Store 校验会把它当成嵌套 app bundle, 因缺少可执行文件和 Info.plist 拒绝上传
+    // (ITMS-90207 / ITMS-90036).
+    packageOfResClass = "me.him188.ani.app.shared"
     generateResClass = always
     // provider 从 merge task 派生, 自动携带任务依赖.
     customDirectory(

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContent.kt
@@ -41,7 +41,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.window.core.layout.WindowSizeClass
-import me.him188.ani.app.Res
+import me.him188.ani.app.shared.Res
 import me.him188.ani.app.data.models.subject.SubjectInfo
 import me.him188.ani.app.domain.mediasource.rss.RssMediaSource
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSource


### PR DESCRIPTION
## 问题

#3310 引入开源许可页后, TestFlight 上传被拒:

> **ITMS-90207**: Invalid Bundle. The bundle at '/Payload/Animeko.app/compose-resources/composeResources/me.him188.ani.app' does not contain a bundle executable.
> **ITMS-90036**: This bundle is invalid. The Info.plist file for /Payload/Animeko.app/compose-resources/composeResources/me.him188.ani.app is missing or could not be read.

## 根因

`:app:shared` 的 `packageOfResClass = "me.him188.ani.app"`。Compose Multiplatform 会把模块资源打进以包名命名的目录，iOS bundle 里即 `compose-resources/composeResources/me.him188.ani.app/`。**目录名以 `.app` 结尾**，App Store 校验将其视为嵌套 app bundle，要求其中存在可执行文件和 Info.plist，于是同时报出上面两个错误。

此前 `:app:shared` 没有任何资源文件（`generateResClass = always` 只生成空 Res 类），该目录从未真实出现；#3310 把 `aboutlibraries.json` / `additional_libraries.json` 放进该模块的 composeResources 后首次触发。

## 修复

- `packageOfResClass` 改为 `"me.him188.ani.app.shared"`（目录后缀变为 `.shared`，不再命中 Apple 的 bundle 扩展名校验），并在构建脚本留下注释防止改回
- `AniAppContent.kt` 的 import 同步改为 `me.him188.ani.app.shared.Res`

全仓已确认没有其他对 `me.him188.ani.app.Res` 或旧资源路径的引用。

## 验证

- `:app:shared:compileKotlinDesktop` / `desktopProcessResources` BUILD SUCCESSFUL
- 打包产物确认为 `composeResources/me.him188.ani.app.shared/files/{aboutlibraries,additional_libraries}.json`，无旧目录残留
- Android 实机（Meizu 18X）安装启动正常
- 资源目录名对所有 target 一致，iOS 重新打包提交 TestFlight 即可验证通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)