### PR TITLE
fix(desktop): 修复 Windows 10 全屏窗口半透明

### DIFF
--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowProc.kt
@@ -73,6 +73,24 @@ import java.awt.Window
 
 private val logger = logger("HandleWindowsWindowProc")
 
+internal const val WINDOWS_11_MIN_BUILD_NUMBER = 22000
+
+internal data class WindowsWindowCompositionMode(
+    val frameMargin: Int,
+    val skiaLayerTransparency: Boolean,
+)
+
+internal fun windowsWindowCompositionMode(
+    windowsBuildNumber: Int?,
+    fullscreen: Boolean,
+): WindowsWindowCompositionMode = WindowsWindowCompositionMode(
+    // Microsoft documents all-zero margins as resetting an extended DWM frame.
+    frameMargin = if (fullscreen) 0 else -1,
+    // Windows 10 needs this for the custom title bar, but a fullscreen window must be opaque.
+    skiaLayerTransparency = !fullscreen &&
+        (windowsBuildNumber ?: WINDOWS_11_MIN_BUILD_NUMBER) < WINDOWS_11_MIN_BUILD_NUMBER,
+)
+
 @Composable
 fun HandleWindowsWindowProc() {
     if (LocalPlatform.current.isWindows()) {
@@ -203,7 +221,7 @@ internal open class BasicWindowProc(
 internal class ExtendedTitleBarWindowProc(
     window: Window,
     private val user32: ExtendedUser32,
-    dwmapi: Dwmapi
+    private val dwmapi: Dwmapi,
 ) : BasicWindowProc(user32, window, installTouchBridge = false) {
 
     private var childHitTestOwner: WindowsWindowHitTestOwner? = null
@@ -216,8 +234,10 @@ internal class ExtendedTitleBarWindowProc(
 
     private var hitTestResult = WindowsWindowHitResult.CLIENT
 
+    private val skiaLayer = window.findSkiaLayer()
     private val skiaLayerWindowProc: SkiaLayerHitTestWindowProc? =
-        window.findSkiaLayer()?.let { SkiaLayerHitTestWindowProc(it, user32, ::hitTest, window) }
+        skiaLayer?.let { SkiaLayerHitTestWindowProc(it, user32, ::hitTest, window) }
+    private val windowsBuildNumber = WindowsWindowUtils.instance.windowsBuildNumber()
 
     private var isMaximized: Boolean = user32.isWindowInMaximized(windowHandle)
     private var dpi: UINT = UINT(0)
@@ -230,9 +250,24 @@ internal class ExtendedTitleBarWindowProc(
     private var padding: Int = 0
 
     init {
-        dwmapi.DwmExtendFrameIntoClientArea(windowHandle, Dwmapi.WindowMargins(-1, -1, -1, -1))
+        applyWindowCompositionMode(fullscreen = false)
         windowHandle.updateWindowStyle { it and WS_SYSMENU.inv() }
         eraseWindowBackground()
+    }
+
+    /**
+     * A Windows 10 custom title bar uses a glass client frame and a transparent Skia layer.
+     * Borderless fullscreen has no title bar to extend and must stay opaque; otherwise
+     * partially transparent Compose/video pixels are blended with the desktop.
+     */
+    internal fun applyWindowCompositionMode(fullscreen: Boolean) {
+        val mode = windowsWindowCompositionMode(windowsBuildNumber, fullscreen)
+        val margin = mode.frameMargin
+        skiaLayer?.transparency = mode.skiaLayerTransparency
+        dwmapi.DwmExtendFrameIntoClientArea(
+            windowHandle,
+            Dwmapi.WindowMargins(margin, margin, margin, margin),
+        )
     }
 
     /***
@@ -455,8 +490,8 @@ internal class ExtendedTitleBarWindowProc(
 
     // Workaround for background erase.
     private fun eraseWindowBackground() {
-        val buildNumber = WindowsWindowUtils.instance.windowsBuildNumber() ?: return
-        if (buildNumber < 22000) {
+        val buildNumber = windowsBuildNumber ?: return
+        if (buildNumber < WINDOWS_11_MIN_BUILD_NUMBER) {
             val flag =
                 SWP_NOZORDER or SWP_NOACTIVATE or SWP_FRAMECHANGED or SWP_NOMOVE or SWP_NOSIZE or SWP_ASYNCWINDOWPOS
             user32.SetWindowPos(windowHandle, null, 0, 0, 0, 0, flag or SWP_HIDEWINDOW)
@@ -593,8 +628,6 @@ internal class SkiaLayerHitTestWindowProc(
             skiaLayerWindow = windowHandle,
             contentWindow = contentHandle,
         )
-        val buildNumber = WindowsWindowUtils.instance.windowsBuildNumber() ?: 22000
-        skiaLayer.transparency = buildNumber < 22000
     }
 
     override fun callback(

--- a/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
+++ b/app/shared/ui-foundation/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
@@ -202,6 +202,9 @@ class WindowsWindowUtils : AwtWindowUtils() {
                 maximized = maximised,
             )
 
+            (window.windowsWindowProc.value as? ExtendedTitleBarWindowProc)
+                ?.applyWindowCompositionMode(fullscreen = true)
+
             User32.INSTANCE.SetWindowLong(
                 hwnd, WinUser.GWL_STYLE,
                 currentStyle and (WinUser.WS_CAPTION or WinUser.WS_THICKFRAME).inv(),
@@ -255,6 +258,8 @@ class WindowsWindowUtils : AwtWindowUtils() {
                 )
             }
             window.savedWindowsWindowState = null
+            (window.windowsWindowProc.value as? ExtendedTitleBarWindowProc)
+                ?.applyWindowCompositionMode(fullscreen = false)
             window.onWindowsUndecoratedFullscreenStateChange(false)
         }
     }

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsWindowCompositionModeTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/platform/window/WindowsWindowCompositionModeTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform.window
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowsWindowCompositionModeTest {
+    @Test
+    fun `Windows 10 custom title bar keeps transparent Skia layer`() {
+        val mode = windowsWindowCompositionMode(
+            windowsBuildNumber = WINDOWS_11_MIN_BUILD_NUMBER - 1,
+            fullscreen = false,
+        )
+
+        assertEquals(-1, mode.frameMargin)
+        assertTrue(mode.skiaLayerTransparency)
+    }
+
+    @Test
+    fun `borderless fullscreen resets glass frame and is opaque on Windows 10`() {
+        val mode = windowsWindowCompositionMode(
+            windowsBuildNumber = WINDOWS_11_MIN_BUILD_NUMBER - 1,
+            fullscreen = true,
+        )
+
+        assertEquals(0, mode.frameMargin)
+        assertFalse(mode.skiaLayerTransparency)
+    }
+
+    @Test
+    fun `Windows 11 Skia layer remains opaque outside fullscreen`() {
+        val mode = windowsWindowCompositionMode(
+            windowsBuildNumber = WINDOWS_11_MIN_BUILD_NUMBER,
+            fullscreen = false,
+        )
+
+        assertEquals(-1, mode.frameMargin)
+        assertFalse(mode.skiaLayerTransparency)
+    }
+
+    @Test
+    fun `unknown Windows build uses opaque fallback`() {
+        assertFalse(
+            windowsWindowCompositionMode(
+                windowsBuildNumber = null,
+                fullscreen = false,
+            ).skiaLayerTransparency,
+        )
+    }
+}


### PR DESCRIPTION
## 现象与根因

#3306 的全屏截图中，视频、弹幕和控制栏后方都能看到 Windows 桌面，说明透明的是顶层 Compose 窗口，而不是单独的视频纹理。日志同时确认环境为 Windows 10、Compose DIRECT3D 和 mpv D3D12 surface。

Windows 10 自定义标题栏会把 DWM frame 扩展到整个客户区，并启用 SkiaLayer 逐像素透明。进入 Win32 无边框全屏时，原实现只移除了窗口边框并调整尺寸，没有撤销这两个透明合成状态，导致全屏内容与桌面混合。

## 修复

- 进入无边框全屏时，将 DWM frame margins 归零并禁用 SkiaLayer transparency。
- 退出全屏时恢复整窗 frame extension，以及 Windows 10 标题栏所需的透明 Skia layer。
- Windows 11 和无法识别系统 build 的路径继续保持 Skia layer 不透明。
- 增加桌面单测覆盖 Windows 10、Windows 11、全屏及未知 build 的合成策略。

## 验证

- `./gradlew :app:shared:ui-foundation:desktopTest`
- `./gradlew :app:shared:compileKotlinDesktop`
- `./gradlew :app:desktop:test`

以上均通过。

- [x] 在 Windows 10 + DIRECT3D 上播放视频，进入全屏后确认桌面不再透出。
- [x] 退出全屏后确认自定义标题栏、窗口边框和文本渲染正常。
- [x] 重复切换全屏，确认无闪烁或透明状态残留。

Closes #3306