### PR TITLE
fix(player): reapply playback speed once media is loaded

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/PlaybackSpeedExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/PlaybackSpeedExtension.kt
@@ -10,11 +10,14 @@
 package me.him188.ani.app.domain.player.extension
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.domain.episode.EpisodeSession
 import org.koin.core.Koin
 import org.openani.mediamp.features.PlaybackSpeed
+import org.openani.mediamp.isMediaLoaded
 
 /**
  * 将当前生效的倍速同步到播放器, 并持续跟随其变更.
@@ -32,13 +35,16 @@ class PlaybackSpeedExtension(
         backgroundTaskScope: ExtensionBackgroundTaskScope
     ) {
         backgroundTaskScope.launch("PlaybackSpeed") {
-            playbackSpeedFlow
-                .distinctUntilChanged()
-                .collect { speed ->
-                    withContext(context.player.mainDispatcher) {
-                        context.player.features[PlaybackSpeed]?.set(speed)
-                    }
+            combine(
+                playbackSpeedFlow,
+                context.player.state.map { it.isMediaLoaded }.distinctUntilChanged(),
+            ) { speed, _ ->
+                speed
+            }.collect { speed ->
+                withContext(context.player.mainDispatcher) {
+                    context.player.features[PlaybackSpeed]?.set(speed)
                 }
+            }
         }
     }
 

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/PlaybackSpeedExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/PlaybackSpeedExtensionTest.kt
@@ -70,4 +70,27 @@ class PlaybackSpeedExtensionTest : AbstractPlayerExtensionTest() {
             testScope.cancel()
         }
     }
+
+    /**
+     * 播放器在媒体加载完成后可能把速度重置回 1x, 扩展需要在媒体就绪时重新应用.
+     */
+    @Test
+    fun `reapplies the speed when media becomes loaded`() = runTest {
+        val speed = MutableStateFlow(1.75f)
+        val (testScope, suite, _) = createCase(speed)
+        try {
+            advanceUntilIdle()
+            assertEquals(1.75f, suite.playerSpeed)
+
+            // 模拟新媒体加载过程中底层重置倍速为 1x
+            suite.player.loadMedia(100_000L)
+            suite.player.features[PlaybackSpeed]?.set(1f)
+            suite.setMediaDuration(100_000L)
+            advanceUntilIdle()
+
+            assertEquals(1.75f, suite.playerSpeed)
+        } finally {
+            testScope.cancel()
+        }
+    }
 }


### PR DESCRIPTION
## 概述

修复了退出播放后重新进入番剧时，界面上仍显示之前选择的倍速，但底层播放器实际以 1.0x 播放，必须手动长按快进或重新切换倍速才能生效的问题。

关联参考：
- 关联 #2547
- 承接倍速 Roadmap #3177、倍速控制系统重做 #3187 及生命周期范围切换 #3227
fixes #3322

---

## 问题原因

1. **时序重置**：进入播放页或建立 `EpisodeSession` 时，`PlaybackSpeedExtension.onStart` 会先收到 `playbackSpeedFlow` 发射的当前配置倍速（如 1.5x），并调用 `player.features[PlaybackSpeed]?.set(speed)`。
2. **底层引擎覆盖**：此时媒体仍在异步解析阶段；待解析完成后执行 `player.setMediaData(...)` 打开媒体流时，底层播放器引擎在加载新文件时会自动将内部播放速度重置为 `1.0`。
3. **未监听媒体就绪**：原 `PlaybackSpeedExtension` 仅使用 `playbackSpeedFlow.distinctUntilChanged()` 监听倍速值的变化。媒体加载就绪后，由于倍速数值本身未变，未再次触发同步，导致实际以 1.0x 播放，而 UI / Feature 缓存显示预设倍速。
4. **唤醒原因**：长按快进松手（`onStop` 会还原原始倍速）或点击切换倍速时，会在媒体已处于就绪状态下再次发送 `set(speed)` 指令，因此会使倍速重新生效。

---

## 修复方案

在 `PlaybackSpeedExtension` 中将 `playbackSpeedFlow` 与播放器的 `context.player.state.map { it.isMediaLoaded }.distinctUntilChanged()` 结合监听：
- 每次进入播放页导致媒体加载就绪（`isMediaLoaded` 变为 `true`）时，自动将当前生效的倍速重新写回底层播放器。
- 用户在播放过程中调整倍速时保持即时生效。

---

## 改动内容

- **`PlaybackSpeedExtension.kt`**：结合 `isMediaLoaded` 状态流，在媒体加载完成时重新应用倍速。
- **`PlaybackSpeedExtensionTest.kt`**：补充单元测试 `reapplies the speed when media becomes loaded`，模拟媒体加载阶段底层倍速被重置的恢复场景。

---

## 验证情况

- [x] 新增单测 `PlaybackSpeedExtensionTest.reapplies the speed when media becomes loaded` 验证通过。
- [x] `PlaybackSpeedExtensionTest` 既有单测回归通过。
