### PR TITLE
fix(desktop): sync package version with release tag

### DIFF
--- a/ci-helper/build.gradle.kts
+++ b/ci-helper/build.gradle.kts
@@ -272,12 +272,14 @@ tasks.register("updateReleaseVersionNameFromGit") {
     doLast {
         val releaseVersion = ReleaseArtifactNames.fullVersionFromTag(ciTag.get())
         val releaseVersionCode = ReleaseArtifactNames.versionCodeFromTag(ciTag.get())
+        val packageVersion = releaseVersion.substringBefore("-")
         val propertiesText = gradleProperties.readText()
-        println("New version: $releaseVersion($releaseVersionCode)")
+        println("New version: $releaseVersion($releaseVersionCode), packageVersion=$packageVersion")
         gradleProperties.writeText(
             propertiesText
                 .replaceFirst(Regex("version.name=(.+)"), "version.name=$releaseVersion")
-                .replaceFirst(Regex("ios.version.code=(.+)"), "ios.version.code=$releaseVersionCode"),
+                .replaceFirst(Regex("ios.version.code=(.+)"), "ios.version.code=$releaseVersionCode")
+                .replaceFirst(Regex("package.version=(.+)"), "package.version=$packageVersion"),
             // 不要更新 version.code, 这是为了让更新到测试版出 bug 的人可以回退到旧版
         )
     }


### PR DESCRIPTION
Closes #3299

## 问题

Release CI 会根据 Git tag 更新 `version.name` 和 `ios.version.code`，但不会更新`package.version`。桌面端打包直接使用 `package.version`，因此 v6.0.0 Windows发布包的 `FileVersion` 和 `ProductVersion` 仍显示为 5.0.0。

## 修改

- 在 `updateReleaseVersionNameFromGit` 中同步更新 `package.version`
- 移除 `alpha`/`beta` 等预发布后缀，使桌面 package version 保持 `major.minor.patch` 格式

例如，`v6.1.0-alpha02` 会生成：

- `version.name=6.1.0-alpha02`
- `package.version=6.1.0`
- `ios.version.code=60102`

## 验证

- 使用 `CI_TAG=v6.0.0` 运行 `:ci-helper:updateReleaseVersionNameFromGit --no-configuration-cache`
- 运行 `:app:desktop:createReleaseDistributable`
- 构建成功
- 检查生成的 `Ani.exe` 文件属性，`FileVersion` 和 `ProductVersion` 均为 `6.0.0`

未新增单元测试；该改动通过实际 Windows 发布包验证。