### PR TITLE
fix(desktop): 避免 macOS 打开详情页时闪退

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -114,6 +114,10 @@ compose.desktop {
         )
         if (getOs() == Os.MacOS) {
             jvmArgs(
+                // Compose 1.11.1 can crash while synchronizing its macOS accessibility tree.
+                // Remove this workaround after MediaMP is compatible with Compose 1.12+, which
+                // includes the upstream fix: https://github.com/JetBrains/compose-multiplatform-core/commit/81c2b3c283afae15b642f39dc8f8a1859041a755
+                "-Dcompose.accessibility.enable=false",
                 "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
                 "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
             )


### PR DESCRIPTION

macOS 上打开番剧详情页时，应用有时会直接闪退。日志最后落在 ComposeSceneAccessibility.defaultAccessibilityFocusTarget，原因是 Compose 1.11.1 同步辅助功能节点时把空节点传给了 ArrayDeque。

JetBrains 已经修了这个问题：
https://github.com/JetBrains/compose-multiplatform-core/commit/81c2b3c283afae15b642f39dc8f8a1859041a755


原本想直接升级 Compose，但 Compose 1.12 移除了 MediaMP 0.3.2 还在使用的 LocalWindow API，目前直接升级会导致桌面播放器无法启动。

所以这次先在 macOS 临时关闭 Compose Accessibility。这个改法只增加一个 JVM 参数，不修改 Compose JAR，也不需要维护一大段字节码补丁。等 MediaMP 兼容新版本 Compose 后，删掉这个参数即可恢复辅助功能。

这里有一个明确的取舍：当前 macOS 版本会暂时失去 VoiceOver 等 Compose 辅助功能，但普通键鼠操作、播放器和其他平台不受影响。

## 验证

- 从干净构建目录执行 createDistributable，打包成功
- 确认最终 Ani.app 已带上关闭参数
- 确认包内 Compose JAR 没有被修改
- 此前使用上游空值保护生成的测试包已在真实 macOS 环境验证，详情页不再闪退

这次只修改 Animeko，一个文件共 4 行，没有改 MediaMP。