### PR TITLE
feat(comment): support selecting and copying comment content

### DIFF
--- a/app/shared/ui-comment/src/commonMain/kotlin/ui/comment/CommentItem.kt
+++ b/app/shared/ui-comment/src/commonMain/kotlin/ui/comment/CommentItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material.icons.filled.ThumbUp
@@ -226,12 +227,15 @@ fun CommentItem(
                 val scaledContent = remember(comment.content) {
                     comment.content.withDefaultFontSize(CommentItemDefaults.ContentFontSize)
                 }
-                RichText(
-                    elements = scaledContent.elements,
-                    modifier = Modifier.fillMaxWidth(),
-                    onClickUrl = onClickUrl,
-                    onClickImage = onClickImage,
-                )
+                // 允许划选复制正文. 长按选择文本会优先于长按唤出菜单, 菜单仍可通过正文以外的区域长按或右键唤出.
+                SelectionContainer {
+                    RichText(
+                        elements = scaledContent.elements,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClickUrl = onClickUrl,
+                        onClickImage = onClickImage,
+                    )
+                }
             },
             reactions = if (comment.reactions.isNotEmpty()) {
                 {


### PR DESCRIPTION
## Changes

评论正文之前用 `BasicText` 直接渲染, 没有 `SelectionContainer`, 所以无法划选复制. 本 PR 将 `CommentItem` 的正文 slot 包进 `SelectionContainer`, 使条目评论和剧集评论的正文都支持:

- 桌面端: 鼠标拖动划选, 然后复制
- 触摸端 (Android/iOS): 长按正文进入文本选择

## Notes

- 长按正文现在优先触发文本选择; 长按/右键唤出的上下文菜单仍可通过正文以外的区域 (头像/时间/空白) 唤出, 菜单内置的「复制内容」不受影响.
- 正文内链接点击、遮罩 (mask) 点击、整条评论点击回复等手势均不受影响, `CommentItemInteractionTest` 全部通过.

## Tests

- `:app:shared:ui-comment:desktopTest --tests CommentItemInteractionTest` ✅ (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)