### PR TITLE
fix(torrent): 多文件种子里别的文件的 piece 通知导致镜像越界

### DIFF
--- a/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/PieceListProxy.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/torrent/service/proxy/PieceListProxy.kt
@@ -20,6 +20,7 @@ import me.him188.ani.app.torrent.api.pieces.Piece
 import me.him188.ani.app.torrent.api.pieces.PieceList
 import me.him188.ani.app.torrent.api.pieces.PieceListSubscriptions
 import me.him188.ani.app.torrent.api.pieces.PieceSubscribable
+import me.him188.ani.app.torrent.api.pieces.containsAbsolutePieceIndex
 import me.him188.ani.app.torrent.api.pieces.forEach
 import me.him188.ani.utils.coroutines.childScope
 import me.him188.ani.utils.logging.logger
@@ -49,7 +50,26 @@ class PieceListProxy(
         pieceStateSubscriber = (delegate as PieceSubscribable)
             .subscribePieceState(Piece.Invalid) { piece, state ->
                 with(delegate) {
-                    pieceStatesRwBuf.put(piece.indexInList, state.ordinal.toByte())
+                    // **必须先判范围**: subscribePieceState(Piece.Invalid) 的语义是"订阅所有 piece",
+                    // 而订阅登记表是整个 torrent 共用的 —— 多文件种子(整季合集)里, 别的文件的 piece
+                    // 也会通知到这里. 那些 piece 的 indexInList (= pieceIndex - initialPieceIndex)
+                    // 会超出本 file 的 piece 数, put 直接抛
+                    //     IndexOutOfBoundsException: index=567 out of bounds (limit=324)
+                    //
+                    // 后果远不止"这一次镜像没写": 异常从 notifyPieceStateChanges 一路抛到
+                    // AnitorrentTorrentDownloader 的事件循环 (那里只记一行 "Error while handling event"),
+                    // **排在它后面的订阅者当次全部收不到通知** —— 包括 registerPieceStateObserver
+                    // 注册的那些, 也就是正在等 piece 完成的那一方.
+                    //
+                    // 于是: BT 确实在下载、piece 也在完成, 但 TorrentInput.fillBuffer 里的
+                    // awaitFinished 永远等不到; 而 mediamp 0.3.0 的 setMediaData 会挂起到媒体
+                    // 真正打开, 于是它不返回, 界面一直停在 DecodingData ("正在解析磁力链或查询元数据").
+                    //
+                    // 2026-08-11 真机: 23GB 整季 BDrip 合集, 这个异常每秒刷几十条. v1 时代
+                    // setMediaData 不挂起, 同一个 bug 只表现为"卡缓冲", 所以一直没被发现.
+                    if (containsAbsolutePieceIndex(piece.pieceIndex)) {
+                        pieceStatesRwBuf.put(piece.indexInList, state.ordinal.toByte())
+                    }
                 }
             }
     }


### PR DESCRIPTION
## 问题

Android 上播放**多文件种子**（整季合集）时，BT 在正常下载、piece 也在完成，但播放界面一直停在「正在解析磁力链或查询元数据」。

`PieceListProxy` 的共享内存镜像是按**本 file** 的 piece 数开的（例：`limit=324`）。而它订阅时用的 `subscribePieceState(Piece.Invalid)` 语义是「订阅所有 piece」，且订阅登记表是整个 torrent 共用的 —— 同一个种子里**别的文件**的 piece 也会通知到这个回调。那些 piece 的 `indexInList`（`pieceIndex - initialPieceIndex`）超出本 file 的范围，`put` 直接抛：

```
IndexOutOfBoundsException: index=567 out of bounds (limit=324)
  at PieceListProxy._init_$lambda$2(PieceListProxy.kt:52)
  at PieceListSubscriptions.notifyPieceStateChanges
  at AnitorrentDownloadSession.onPieceDownloading
```

后果不止「这一次镜像没写」：异常从 `notifyPieceStateChanges` 一路抛到 `AnitorrentTorrentDownloader` 的事件循环（那里只记一行 `Error while handling event`），于是**排在它后面的订阅者当次全部收不到通知** —— 包括 `registerPieceStateObserver` 注册的、正在等 piece 完成的那一方。`TorrentInput.fillBuffer` 里的 `awaitFinished` 因此可能一直等不到已经下好的 piece。

## 影响范围

Android（手机与 TV 同样适用，只要走跨进程 torrent 服务 + 多文件种子）。桌面端不经过这个 proxy。

单文件种子时 `indexInList` 不会越界，所以只有合集才暴露。

## 改动

写镜像前先 `containsAbsolutePieceIndex(piece.pieceIndex)` 判范围；不属于本 file 的通知直接跳过。

## 验证

- 本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。
- 真机（Android，23GB 整季 BDrip 合集）：修复前该异常在日志里每秒刷几十条（一段日志内 68 次）；应用本修复的构建上不再出现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
