### PR TITLE
fix(torrent): 「总是过滤异常指纹」绕开外层开关, 默认即拦且无法关闭

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/torrent/TorrentManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/torrent/TorrentManager.kt
@@ -76,12 +76,6 @@ class DefaultTorrentManager(
             ) { config, rules ->
                 PeerFilterSettings(
                     rules + config.createRuleWithEnabled(),
-                    // 必须跟着 enableIdFilter 一起判断: "总是过滤异常指纹" 这个开关在设置界面里是嵌在
-                    // "过滤客户端指纹" 的展开区内的 (PeerFilterEditPane), 外层一关它就看不见了.
-                    // 而 blockInvalidId 默认是 true, enableIdFilter 默认是 false, 于是开箱即得一个
-                    // 看不见又关不掉的指纹过滤器 —— 它会拦掉所有 peer id 不是 `-xxxxxx-` 格式的客户端,
-                    // 国内 swarm 里这种占比很高, 表现就是 "peer 连上一堆但全被拦, 速度 0, BT 不下载".
-                    // (2026-08-11 真机: 单个种子一小时内拦掉 256 个 peer, 只剩 1 个还 choke 我们)
                     config.enableIdFilter && config.blockInvalidId,
                 )
             },

--- a/app/shared/app-data/src/commonMain/kotlin/domain/torrent/TorrentManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/torrent/TorrentManager.kt
@@ -76,7 +76,13 @@ class DefaultTorrentManager(
             ) { config, rules ->
                 PeerFilterSettings(
                     rules + config.createRuleWithEnabled(),
-                    config.blockInvalidId,
+                    // 必须跟着 enableIdFilter 一起判断: "总是过滤异常指纹" 这个开关在设置界面里是嵌在
+                    // "过滤客户端指纹" 的展开区内的 (PeerFilterEditPane), 外层一关它就看不见了.
+                    // 而 blockInvalidId 默认是 true, enableIdFilter 默认是 false, 于是开箱即得一个
+                    // 看不见又关不掉的指纹过滤器 —— 它会拦掉所有 peer id 不是 `-xxxxxx-` 格式的客户端,
+                    // 国内 swarm 里这种占比很高, 表现就是 "peer 连上一堆但全被拦, 速度 0, BT 不下载".
+                    // (2026-08-11 真机: 单个种子一小时内拦掉 256 个 peer, 只剩 1 个还 choke 我们)
+                    config.enableIdFilter && config.blockInvalidId,
                 )
             },
             baseSaveDir().resolve(TorrentEngineType.Anitorrent.id),


### PR DESCRIPTION
## 问题

`blockInvalidId`（「总是过滤异常指纹」）开箱即为一个**看不见也关不掉**的过滤器。

三处叠加：

- `TorrentPeerConfig` 里 `enableIdFilter` 默认 `false`，而 `blockInvalidId` 默认 `true`；
- `PeerFilterEditPane` 把「总是过滤异常指纹」这个 `SwitchItem` 放在 `AniAnimatedVisibility(visible = state.idFilterEnabled)` **内部** —— 外层「过滤客户端指纹」关着时它根本不渲染，用户看不到也点不到；
- `DefaultTorrentManager` 直接把 `config.blockInvalidId` 传进 `PeerFilterSettings`，绕开了 `createRuleWithEnabled()` 的启用判断。

于是每个新用户默认就在跑一个 `PeerInvalidIdFilter`：它拦掉所有 peer id 不是 `-xxxxxx-` 格式的客户端，而这类客户端在部分 swarm 中占比很高，表现为「peer 连上一堆但速度是 0」。

这一条纯看代码即可确认，与设备无关。

## 改动

`DefaultTorrentManager` 里改成 `config.enableIdFilter && config.blockInvalidId`：

- 外层关着时不过滤（与设置界面显示的状态一致）；
- 打开外层后子开关照常可控；
- 不改 UI，不改默认值语义。

## 验证

- 本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。
- 真机同一个种子的修前修后对比：

| | peerCount | 下载速度 |
| --- | --- | --- |
| 修复前 | 1（且对方 choke 我们） | 0 |
| 修复后 | 7 | 3.9 MB/s |

新连上的正是那批 peer id 不符合 `-xxxxxx-` 格式的客户端。排查时可以在日志里搜 `is blocked by rule PeerInvalidIdFilter`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
