### PR TITLE
fix(cache): 合集种子的缓存统计被乘上条目数

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/AbstractMediaCacheEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/AbstractMediaCacheEngine.kt
@@ -127,8 +127,15 @@ abstract class AbstractDataStoreMediaCacheStorage(
             return@flatMapLatest flowOf(MediaStats.Zero)
         }
 
+        // 同一个下载会话只能算一份. [MediaCache.sessionStats] 报的是**整个会话**的量 (它自己的
+        // 文档就写着"会包含其他剧集"), 而一个合集种子会被它的每一集各挂一个缓存条目 —— 逐条目
+        // 相加等于把同一份流量乘上条目数. 2026-08-15 实测: 一季 9 集共用一个种子, 实际下了
+        // 1.32 GB, 页面显示 11.9 GB (9 倍), 上传量与速度同样被放大.
+        //
+        // 按 download URI 去重而不是 mediaId: 同一个种子被两个数据源分别收录时 mediaId 不同,
+        // 但它们最终落到同一个 torrent 会话上.
         combine(
-            caches.map { cache ->
+            caches.distinctBy { it.origin.download.uri }.map { cache ->
                 cache.sessionStats.map { stats ->
                     MediaStats(
                         uploaded = stats.uploadedBytes,

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/AbstractMediaCacheEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/AbstractMediaCacheEngine.kt
@@ -127,13 +127,6 @@ abstract class AbstractDataStoreMediaCacheStorage(
             return@flatMapLatest flowOf(MediaStats.Zero)
         }
 
-        // 同一个下载会话只能算一份. [MediaCache.sessionStats] 报的是**整个会话**的量 (它自己的
-        // 文档就写着"会包含其他剧集"), 而一个合集种子会被它的每一集各挂一个缓存条目 —— 逐条目
-        // 相加等于把同一份流量乘上条目数. 2026-08-15 实测: 一季 9 集共用一个种子, 实际下了
-        // 1.32 GB, 页面显示 11.9 GB (9 倍), 上传量与速度同样被放大.
-        //
-        // 按 download URI 去重而不是 mediaId: 同一个种子被两个数据源分别收录时 mediaId 不同,
-        // 但它们最终落到同一个 torrent 会话上.
         combine(
             caches.distinctBy { it.origin.download.uri }.map { cache ->
                 cache.sessionStats.map { stats ->


### PR DESCRIPTION
## 问题

缓存管理页的总下载量 / 上传量 / 速度会被乘上倍数。

`AbstractDataStoreMediaCacheStorage.stats` 把每个缓存条目的 `sessionStats` 逐个相加：

```kotlin
combine(
    caches.map { cache -> cache.sessionStats.map { ... } },
) { it.sum() }
```

而 `sessionStats` 报的是**整个下载会话**的量 —— `MediaCache.sessionStats` 的文档就写明它会包含同一会话里其他剧集的流量。一个合集种子会被它的每一集各挂一个缓存条目，于是同一份流量被加了 N 遍。

实测（12 集合集，缓存其中 9 集）：torrent 侧实际下载 1.32 GB，缓存页显示 11.9 GB —— 正好 9 倍。上传量与上下行速度同样被放大，速度数字大得离谱。

复现条件是**同一个合集种子缓存了 ≥2 集**：`AbstractDataStoreMediaCacheStorage.cache()` 的去重键是 `mediaId + subjectId + episodeId`（`isSameMediaAndEpisode`），所以每一集各自成为一个 `MediaCache`，而它们的 `sessionStats` 都来自同一个 `fileHandle.session`。单集缓存时 N=1，所以一直没暴露。全平台一致。

## 改动

求和前按 `origin.download.uri` 去重，同一个下载会话只计一次。

用 URI 而不是 `mediaId`：同一个种子被两个数据源分别收录时 `mediaId` 不同，但它们最终落到同一个 torrent 会话上。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。上面的倍数关系来自真机实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
