### PR TITLE
fix(player): WEB 源解析超时后 WebView 永不销毁

### DIFF
--- a/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
@@ -211,13 +211,6 @@ class AndroidWebViewVideoExtractor(
                     deferred.await()
                 }
             } finally {
-                // 销毁 WebView 挂在 deferred 完成上 (见 createWebView 里的 invokeOnCompletion), 而
-                // withTimeoutOrNull 超时只取消里面那次 await, deferred 本身仍是活的 —— 嗅探不到地址
-                // 的源 (失效/被墙) 每试一次就留下一个永不销毁、仍在加载页面并持有 Context 的 WebView.
-                // 自动换源会一个接一个地试, 一集下来就是好几个常驻实例.
-                //
-                // 放 finally 而不是原来的 catch: withTimeoutOrNull 把超时异常吞掉了, 根本不进 catch,
-                // 而超时正是最需要销毁的那条路. 已完成时 cancel() 是 no-op, 成功路径不受影响.
                 deferred.cancel()
             }
         }

--- a/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
+++ b/app/shared/app-data/src/androidMain/kotlin/domain/media/resolver/AndroidWebMediaResolver.kt
@@ -210,11 +210,15 @@ class AndroidWebViewVideoExtractor(
                 withTimeoutOrNull(timeoutMillis) {
                     deferred.await()
                 }
-            } catch (e: Throwable) {
-                if (deferred.isActive) {
-                    deferred.cancel()
-                }
-                throw e
+            } finally {
+                // 销毁 WebView 挂在 deferred 完成上 (见 createWebView 里的 invokeOnCompletion), 而
+                // withTimeoutOrNull 超时只取消里面那次 await, deferred 本身仍是活的 —— 嗅探不到地址
+                // 的源 (失效/被墙) 每试一次就留下一个永不销毁、仍在加载页面并持有 Context 的 WebView.
+                // 自动换源会一个接一个地试, 一集下来就是好几个常驻实例.
+                //
+                // 放 finally 而不是原来的 catch: withTimeoutOrNull 把超时异常吞掉了, 根本不进 catch,
+                // 而超时正是最需要销毁的那条路. 已完成时 cancel() 是 no-op, 成功路径不受影响.
+                deferred.cancel()
             }
         }
 //        }


### PR DESCRIPTION
## 问题

`AndroidWebMediaResolver` 里 WebView 的销毁挂在 `deferred.invokeOnCompletion` 上，而外层等待用的是 `withTimeoutOrNull`。

超时只取消了那一次 `await`，`deferred` 本身仍然是活的，`invokeOnCompletion` 永远不会触发 —— 于是每一个嗅探不到地址的源（失效 / 不可达）每试一次就留下一个**永不销毁、仍在加载页面并持有 Context** 的 WebView。自动换源会一个接一个地试，一集下来就是好几个常驻实例，表现为内存持续上涨、Activity 无法回收。

原来的 `catch` 拦不住这条路：`withTimeoutOrNull` 把 `TimeoutCancellationException` 吞掉了，根本不进 `catch`，而超时恰恰是最需要销毁的那条路径。

## 影响范围

Android（手机与 TV 一致）。

## 改动

把销毁移到 `finally`，顺带覆盖协程被取消的情形。已完成时 `cancel()` 是 no-op，成功路径行为不变。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
