### PR TITLE
fix(player): 下一集是特别篇时既不显示「下一集」也不自动连播

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePresentation.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePresentation.kt
@@ -17,6 +17,7 @@ import me.him188.ani.app.data.models.episode.displayName
 import me.him188.ani.app.data.models.episode.renderEpisodeEp
 import me.him188.ani.app.data.models.subject.SubjectRecurrence
 import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownCompleted
+import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownOnAir
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 
 /**
@@ -44,9 +45,14 @@ data class EpisodePresentation(
     val sort: String,
     val collectionType: UnifiedCollectionType,
     /**
-     * 是否已经确定开播了
+     * 是否已经确定开播了. 保守判定: 拿不到播出日期时为 `false`, 因此它的否定是"不确定播没播",
+     * 要表达"确定没播"请用 [isKnownNotYetAired].
      */
     val isKnownBroadcast: Boolean,
+    /**
+     * 是否确定还未播出. 同样是保守判定: 拿不到播出日期时为 `false`.
+     */
+    val isKnownNotYetAired: Boolean,
     val isPlaceholder: Boolean = false,
 ) {
     companion object {
@@ -58,6 +64,7 @@ data class EpisodePresentation(
             sort = "placeholder",
             collectionType = UnifiedCollectionType.WISH,
             isKnownBroadcast = false,
+            isKnownNotYetAired = false,
             isPlaceholder = true,
         )
     }
@@ -72,4 +79,5 @@ fun EpisodeCollectionInfo.toPresentation(
     sort = episodeInfo.sort.toString(),
     collectionType = collectionType,
     isKnownBroadcast = episodeInfo.isKnownCompleted(recurrence),
+    isKnownNotYetAired = episodeInfo.isKnownOnAir(recurrence),
 )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -74,7 +74,7 @@ import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.comment.PostCommentUseCase
 import me.him188.ani.app.domain.danmaku.DanmakuRepository
 import me.him188.ani.app.domain.danmaku.SetDanmakuEnabledUseCase
-import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownCompleted
+import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownOnAir
 import me.him188.ani.app.domain.episode.EpisodeDanmakuLoader
 import me.him188.ani.app.domain.episode.EpisodeFetchSelectPlayState
 import me.him188.ani.app.domain.episode.EpisodeSession
@@ -340,7 +340,8 @@ class EpisodeViewModel(
                     } else {
                         val nextEpisode = list.getOrNull(currentIndex + 1) ?: return@Factory null
 
-                        if (!nextEpisode.episodeInfo.isKnownCompleted(subject.recurrence)) {
+                        // 只拦"确定还没播出"的下一集, 不能用 !isKnownCompleted 代替
+                        if (nextEpisode.episodeInfo.isKnownOnAir(subject.recurrence)) {
                             null
                         } else {
                             nextEpisode.episodeId

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeSelectorSideSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeSelectorSideSheet.kt
@@ -105,7 +105,8 @@ class EpisodeSelectorState(
     val hasNextEpisode by derivedStateOf {
         val currentIndex = currentIndex
         currentIndex != -1 && currentIndex < items.lastIndex
-                && items[currentIndex + 1].isKnownBroadcast // 仅限下一集开播了
+                // 只挡"确定还没播出"的下一集, 不能用 !isKnownBroadcast 代替
+                && !items[currentIndex + 1].isKnownNotYetAired
     }
 
     fun select(item: Item) {
@@ -215,6 +216,7 @@ fun rememberTestEpisodeSelectorState() = remember {
                     sort = "01",
                     collectionType = UnifiedCollectionType.WISH,
                     isKnownBroadcast = true,
+                    isKnownNotYetAired = false,
                     isPlaceholder = true,
                 ),
                 EpisodePresentation(
@@ -224,6 +226,7 @@ fun rememberTestEpisodeSelectorState() = remember {
                     sort = "02",
                     collectionType = UnifiedCollectionType.WISH,
                     isKnownBroadcast = true,
+                    isKnownNotYetAired = false,
                     isPlaceholder = true,
                 ),
                 EpisodePresentation(
@@ -233,6 +236,7 @@ fun rememberTestEpisodeSelectorState() = remember {
                     sort = "03",
                     collectionType = UnifiedCollectionType.WISH,
                     isKnownBroadcast = false,
+                    isKnownNotYetAired = true, // 这条模拟的就是"还没播出"
                     isPlaceholder = true,
                 ),
             ),

--- a/app/shared/src/commonTest/kotlin/ui/subject/episode/EpisodePresentationTest.kt
+++ b/app/shared/src/commonTest/kotlin/ui/subject/episode/EpisodePresentationTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.episode
+
+import me.him188.ani.app.data.models.episode.EpisodeCollectionInfo
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.EpisodeType
+import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [EpisodePresentation.isKnownBroadcast] 与 [EpisodePresentation.isKnownNotYetAired] 都是保守判定,
+ * 因此不是互补关系: 拿不到播出日期时两者同时为 `false`.
+ */
+class EpisodePresentationTest {
+    private fun episode(
+        airDate: PackedDate,
+        type: EpisodeType = EpisodeType.MainStory,
+    ) = EpisodeCollectionInfo(
+        episodeInfo = EpisodeInfo(
+            episodeId = 1,
+            type = type,
+            name = "test",
+            airDate = airDate,
+            sort = EpisodeSort(1),
+        ),
+        collectionType = UnifiedCollectionType.WISH,
+    ).toPresentation(recurrence = null)
+
+    @Test
+    fun `episode without air date is neither known broadcast nor known not-yet-aired`() {
+        val presentation = episode(PackedDate.Invalid, EpisodeType.SP)
+        assertFalse(presentation.isKnownBroadcast, "没有播出日期 => 不能断定已播出")
+        assertFalse(
+            presentation.isKnownNotYetAired,
+            "没有播出日期 => 也不能断定还没播出",
+        )
+    }
+
+    @Test
+    fun `episode aired in the past is known broadcast`() {
+        val presentation = episode(PackedDate(2000, 1, 1))
+        assertTrue(presentation.isKnownBroadcast)
+        assertFalse(presentation.isKnownNotYetAired)
+    }
+
+    @Test
+    fun `episode airing in the future is known not-yet-aired`() {
+        val presentation = episode(PackedDate(9999, 12, 31))
+        assertFalse(presentation.isKnownBroadcast)
+        assertTrue(presentation.isKnownNotYetAired)
+    }
+}


### PR DESCRIPTION
## 问题

当下一集是**没有播出日期**的特别篇（SP / OVA / OAD）时，播放器既不显示「下一集」按钮，也不会自动连播。

判据用的是 `isKnownCompleted` 取反。看 `EpisodeCompletionContext` 的实现：

```kotlin
fun EpisodeInfo.isKnownCompleted(recurrence: SubjectRecurrence?): Boolean {
    recurrence.mapAirDate(airDate)?.let { return clock.now() >= it }
    return false          // 拿不到播出日期 -> false
}

fun EpisodeInfo.isKnownOnAir(recurrence: SubjectRecurrence?): Boolean {
    recurrence.mapAirDate(airDate)?.let { return clock.now() < it }
    return false          // 拿不到播出日期 -> 同样是 false
}
```

两者都是**保守**判定，因此**不是互补关系**：拿不到播出日期时同时为 `false`。于是 `!isKnownCompleted` 表达的是「不确定播没播」，而不是「确定没播」——没有播出日期的特别篇就被一律当成还没开播而挡掉。

两处受影响：

- `EpisodeViewModel` 里 `SwitchNextEpisodeExtension.Factory(getNextEpisode = ...)` —— 自动连播；
- `EpisodeSelectorState.hasNextEpisode` —— 播放器控制条的「下一集」按钮。

播放器的选集顺序本来就与详情页一致（同一个 `episodeCollectionsFlow`，含特别篇），并没有「下一集不能是特别篇」的设计，只是被这个判据挡住了。

## 影响范围与复现

判据与两处使用点全部在 `commonMain`，没有平台分支。按钮那一处最终落在 `EpisodeVideo` 的 `if (hasNextEpisode && expanded)`：

- 宽窗布局（桌面）`EpisodeScreenTabletVeryWide` 传的是 `expanded = true`，所以门槛就是 `hasNextEpisode`；
- 手机布局传的是 `vm.isFullscreen`，非全屏时这颗按钮本来就不画。

自动连播那一处与布局无关，所有平台一致。

**触发条件是下一集没有播出日期**，所以大多数条目看不出问题（抽查了几部近年番，它们的 SP 在 Bangumi 上都有 `airdate`）。一个可直接复现的条目是**新世纪福音战士（subject 265）**：它的 4 条特别篇 `airdate` 全为空。播到正片最后一集时，下一项就是这样的 SP —— 修复前按钮不出现、播完也不连播。

## 改动

- 给 `EpisodePresentation` 增加 `isKnownNotYetAired`（来自 `isKnownOnAir`），只表示「确定还未播出」；
- 上述两处改用它判断，即只拦确定还没播的下一集。

原有的 `isKnownBroadcast` 保留不动：它用在选集列表灰化等处，那里「不确定就弱化显示」是合适的。两个字段的 KDoc 都写明了保守判定与非互补关系。

## 验证

新增 `EpisodePresentationTest`，把这条语义钉住：无播出日期时 `isKnownBroadcast` 与 `isKnownNotYetAired` **同时为 `false`**（这正是不能用 `!isKnownBroadcast` 代替后者的原因），过去日期只有前者为真，未来日期只有后者为真。

`:app:shared:testAndroidHostTest --tests "*EpisodePresentationTest*"` 通过；本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

这里没法做「回退生产代码跑同一套测试」的对照实验——`isKnownNotYetAired` 是本 PR 新增的字段，回退后测试无法编译。用来替代的是测试里那条断言本身：它证明了旧写法 `!isKnownBroadcast` 对无日期剧集为 `true`，也就是把它判成了「还没播出」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
