### PR TITLE
fix(subject): 一次空分集响应会让选集区永久空白且不再发请求

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -87,7 +87,9 @@ import me.him188.ani.datasources.bangumi.processing.toSubjectCollectionType
 import me.him188.ani.utils.coroutines.combine
 import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
 import me.him188.ani.utils.logging.debug
+import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.currentTimeMillis
 import me.him188.ani.utils.serialization.BigNum
 import kotlin.coroutines.CoroutineContext
@@ -233,6 +235,9 @@ class SubjectCollectionRepositoryImpl(
     override fun subjectCollectionFlow(
         subjectId: Int
     ): Flow<SubjectCollectionInfo> = getEpisodeTypeFiltersUseCase().flatMapLatest { epTypes ->
+        // 每次订阅最多为"条目在库但分集为空"补取一次. 用标志而不是"空就重取": 真的没有分集的条目
+        // (未播出新番) 会每次 DAO 发射都触发, 变成请求风暴
+        var refetchedForMissingEpisodes = false
         subjectCollectionDao.findById(subjectId)
             .restartOnNewLogin(sessionManager)
             .transform { existing ->
@@ -241,8 +246,16 @@ class SubjectCollectionRepositoryImpl(
                     emit(existing)
                 }
 
-                // 如果没有缓存, 则 fetch 然后插入 subject 缓存
-                if (existing == null || existing.isExpired()) {
+                val missingEpisodes = existing != null &&
+                    !refetchedForMissingEpisodes &&
+                    episodeCollectionDao.listIdBySubjectId(subjectId).first().isEmpty()
+                if (missingEpisodes) {
+                    refetchedForMissingEpisodes = true
+                    logger.info { "Subject $subjectId is cached but has no episodes locally, refetching" }
+                }
+
+                // 如果没有缓存 (或缓存过期, 或分集缺失), 则 fetch 然后插入 subject 缓存
+                if (existing == null || existing.isExpired() || missingEpisodes) {
                     val subject = subjectService.getSubjectCollection(subjectId)
                     val lastFetched = currentTimeMillis()
                     val subjectEntity = subject?.toEntity(
@@ -255,13 +268,27 @@ class SubjectCollectionRepositoryImpl(
                         subjectCollectionDao.upsert(subjectEntity)
 
                         // 更新剧集列表
-                        val oldIds = episodeCollectionDao.listIdBySubjectId(subjectId).first().toMutableList()
-                        episodeCollectionDao.upsert(episodeEntities)
-                        for (newEntity in episodeEntities) {
-                            oldIds.remove(newEntity.episodeId)
-                        }
-                        if (oldIds.isNotEmpty()) { // 删除本地存的多余的剧集 (通常没有)
-                            episodeCollectionDao.deleteAllByEpisodeIds(subjectId, oldIds)
+                        if (episodeEntities.isEmpty()) {
+                            // 空列表更可能是接口抖动, 不能按下面的 oldIds 逻辑把本地分集全删掉:
+                            // 同一次 upsert 已经把条目行刷新, 删完就一小时内都不会再取
+                            val localCount = episodeCollectionDao.listIdBySubjectId(subjectId).first().size
+                            logger.warn {
+                                "Fetched subject $subjectId returned no episodes; " +
+                                    "keeping $localCount local episodes instead of deleting them"
+                            }
+                        } else {
+                            val oldIds = episodeCollectionDao.listIdBySubjectId(subjectId).first().toMutableList()
+                            episodeCollectionDao.upsert(episodeEntities)
+                            for (newEntity in episodeEntities) {
+                                oldIds.remove(newEntity.episodeId)
+                            }
+                            if (oldIds.isNotEmpty()) { // 删除本地存的多余的剧集 (通常没有)
+                                episodeCollectionDao.deleteAllByEpisodeIds(subjectId, oldIds)
+                            }
+                            logger.info {
+                                "Fetched subject $subjectId: ${episodeEntities.size} episodes" +
+                                    if (oldIds.isNotEmpty()) ", removed ${oldIds.size} stale" else ""
+                            }
                         }
                     }
                     // TODO: 2025/5/24 handle subject not found 


### PR DESCRIPTION
## 问题

一次「取条目成功但分集列表为空」的响应，会让该条目的选集区**空白一小时**，期间连一条网络请求都不发。

两处叠加：

1. 分集只是取条目的副产品。取回来的空列表会走 `oldIds` 逻辑，把本地已有的分集全部当成「多余的」删掉；而同一次 upsert 又把条目行的 `lastFetched` 刷成新鲜的。
2. 取分集的唯一时机是「条目缓存为空或过期」（TTL 1 小时）。条目行既然新鲜，之后每次进详情页都不再发请求，`combine` 出来的 `episodes` 恒为空。

界面上就是空的选集区 + 零网络请求，与「这部番真的没有分集」长得一模一样。全平台一致。

## 改动

- 取回**空**分集列表时不动本地已有数据，只记一条 warn：空列表更可能是接口抖动，而不是这部番的分集没了；
- 条目在库但本地分集为空时，把它当作过期，补取一次。用「每次订阅最多补一次」的标志而不是「空就重取」—— 否则真的没有分集的条目（未播出新番）会在每次 DAO 发射时触发，变成请求风暴。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

真机复现与验证（subject 9622）：

| 构建 | 日志 |
| --- | --- |
| 修复前 | 反复进入都是 `enter with 0 episodes`，且日志里没有任何分集请求 |
| 修复后 | `Subject 9622 is cached but has no episodes locally, refetching` → `Fetched subject 9622: 50 episodes` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
