### PR TITLE
fix(exploration): 「继续观看」栏改收藏后不再更新, 需重启应用

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/database/dao/SubjectCollectionDao.kt
@@ -177,8 +177,8 @@ interface SubjectCollectionDao {
 
     @Query(
         """
-    SELECT * FROM subject_collection 
-    WHERE collectionType IS NOT NULL 
+    SELECT * FROM subject_collection
+    WHERE collectionType IS NOT NULL
     ORDER BY lastUpdated DESC
     LIMIT :limit
     OFFSET :offset
@@ -188,6 +188,44 @@ interface SubjectCollectionDao {
         limit: Int,
         offset: Int = 0,
     ): Flow<List<SubjectCollectionEntity>>
+
+    /**
+     * 同 [filterMostRecentUpdated], 但一次查询就把每个条目的剧集一起取出.
+     */
+    @Query(
+        """
+    SELECT * FROM subject_collection
+    WHERE collectionType IS NOT NULL
+    AND (collectionType IN (:collectionTypes))
+    ORDER BY lastUpdated DESC
+    LIMIT :limit
+    OFFSET :offset
+    """,
+    )
+    @Transaction
+    fun filterMostRecentUpdatedWithEpisodes(
+        collectionTypes: List<UnifiedCollectionType>,
+        limit: Int,
+        offset: Int = 0,
+    ): Flow<List<SubjectCollectionAndEpisodes>>
+
+    /**
+     * @see filterMostRecentUpdatedWithEpisodes
+     */
+    @Query(
+        """
+    SELECT * FROM subject_collection
+    WHERE collectionType IS NOT NULL
+    ORDER BY lastUpdated DESC
+    LIMIT :limit
+    OFFSET :offset
+    """,
+    )
+    @Transaction
+    fun mostRecentUpdatedWithEpisodes(
+        limit: Int,
+        offset: Int = 0,
+    ): Flow<List<SubjectCollectionAndEpisodes>>
 
     /**
      * Retrieves a paginated list of `SubjectCollectionEntity` items, optionally filtered by type.
@@ -313,3 +351,17 @@ fun SubjectCollectionDao.filterMostRecentUpdated(
     collectionType: UnifiedCollectionType? = null,
     limit: Int,
 ): Flow<List<SubjectCollectionEntity>> = filterMostRecentUpdated(listOfNotNull(collectionType), limit)
+
+/**
+ * @param collectionTypes `null` 表示不限类型
+ * @see SubjectCollectionDao.filterMostRecentUpdatedWithEpisodes
+ */
+fun SubjectCollectionDao.filterMostRecentUpdatedWithEpisodes(
+    collectionTypes: List<UnifiedCollectionType>?,
+    limit: Int,
+    offset: Int = 0,
+): Flow<List<SubjectCollectionAndEpisodes>> = if (collectionTypes == null) {
+    mostRecentUpdatedWithEpisodes(limit, offset)
+} else {
+    filterMostRecentUpdatedWithEpisodes(collectionTypes, limit, offset)
+}

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/FollowedSubjectsRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/FollowedSubjectsRepository.kt
@@ -14,18 +14,16 @@ import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
-import me.him188.ani.app.data.models.preference.NsfwMode
 import me.him188.ani.app.data.models.subject.*
 import me.him188.ani.app.data.repository.Repository
 import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.data.repository.RepositoryUnknownException
 import me.him188.ani.app.data.repository.episode.AnimeScheduleRepository
-import me.him188.ani.app.data.repository.episode.EpisodeCollectionRepository
 import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.session.SessionStateProvider
 import me.him188.ani.app.domain.session.restartOnNewLogin
-import me.him188.ani.datasources.api.PackedDate
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import me.him188.ani.utils.coroutines.retryWithBackoffDelay
 import me.him188.ani.utils.logging.error
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -38,15 +36,11 @@ import kotlin.time.Duration.Companion.hours
 class FollowedSubjectsRepository(
     private val subjectCollectionRepository: SubjectCollectionRepository,
     private val animeScheduleRepository: AnimeScheduleRepository,
-    private val episodeCollectionRepository: EpisodeCollectionRepository,
 //    private val subjectProgressRepository: EpisodeProgressRepository,
 //    private val subjectCollectionDao: SubjectCollectionDao,
     private val sessionManager: SessionStateProvider,
-    settingsRepository: SettingsRepository,
     defaultDispatcher: CoroutineContext = Dispatchers.Default,
 ) : Repository(defaultDispatcher) {
-    private val nsfwModeSettingsFlow = settingsRepository.uiSettings.flow.map { it.searchSettings.nsfwMode }
-
     private fun followedSubjectsFlow(
         updatePeriod: Duration = 1.hours,
     ): Flow<List<FollowedSubjectInfo>> {
@@ -59,13 +53,12 @@ class FollowedSubjectsRepository(
             }
         }
 
-        val now = PackedDate.now()
-
         // 对于最近看过的一些条目
         return ticker.flatMapLatest {
             try {
+                // 必须与下面查本地的 limit 一致, 否则中间那段永远拿不到新播出的剧集
                 subjectCollectionRepository.updateRecentlyUpdatedSubjectCollections(
-                    30, // should be enough
+                    FOLLOWED_SUBJECTS_LIMIT,
                     UnifiedCollectionType.DOING,
                 ) // refresh
             } catch (e: CancellationException) {
@@ -83,59 +76,37 @@ class FollowedSubjectsRepository(
             // 先查询完成 (插入数据库) 再返回 flow 去查数据库. 前端会展示 placeholder 所以延迟没问题.
 
             subjectCollectionRepository.mostRecentlyUpdatedSubjectCollectionsFlow(
-                limit = 64,
+                limit = FOLLOWED_SUBJECTS_LIMIT,
                 types = listOf(
                     UnifiedCollectionType.DOING,
                 ),
-            ).flatMapLatest { subjectCollectionInfoList ->
-                // 对于每个条目, 获取其最新的集数信息
-                if (subjectCollectionInfoList.isEmpty()) { // `combine(emptyList)` does not emit
-                    return@flatMapLatest flowOf(emptyList())
-                }
-                getFollowedSubjectInfoFlows(subjectCollectionInfoList, now)
-            }.map { followedSubjectInfoList ->
-                followedSubjectInfoList
+            ).map { subjectCollectionInfoList ->
+                toFollowedSubjectInfos(subjectCollectionInfoList)
                     .toMutableList()
                     .apply {
                         sortWith(sorter)
                     }
-            }.catch {
-                throw RepositoryException.wrapOrThrowCancellation(it)
             }
+                // 失败不能让异常抛穿: 上层 cachedIn 的收集协程一旦死掉, 这一栏就停在旧快照直到重启
+                .retryWithBackoffDelay { e, _ ->
+                    if (e is CancellationException) throw e
+                    logger.error(e) { "Failed to collect followed subjects, retrying. 这只会导致探索页的继续观看栏目短暂显示旧结果." }
+                    true
+                }
         }.flowOn(defaultDispatcher)
     }
 
-    private fun getFollowedSubjectInfoFlows(
+    private fun toFollowedSubjectInfos(
         subjectCollectionInfoList: List<SubjectCollectionInfo>,
-        now: PackedDate,
-    ): Flow<List<FollowedSubjectInfo>> = combine(
-        subjectCollectionInfoList.map { info ->
-            episodeCollectionRepository.subjectEpisodeCollectionInfosFlow(info.subjectId)
-        },
-    ) { array ->
-        array.toList()
-    }.combine(nsfwModeSettingsFlow) { epInfoLists, nsfwMode ->
-        subjectCollectionInfoList.asSequence().zip(epInfoLists.asSequence()) { subjectCollectionInfo, episodes ->
-            // 计算每个条目的播放进度
-            FollowedSubjectInfo(
-                subjectCollectionInfo,
-                SubjectAiringInfo.computeFromEpisodeList(
-                    episodes.map { it.episodeInfo },
-                    subjectCollectionInfo.subjectInfo.airDate,
-                    subjectCollectionInfo.recurrence,
-                ),
-                SubjectProgressInfo.compute(
-                    subjectCollectionInfo.subjectInfo,
-                    episodes,
-                    now,
-                    subjectCollectionInfo.recurrence,
-                ),
-                nsfwMode =
-                    if (subjectCollectionInfo.subjectInfo.nsfw) nsfwMode
-                    else NsfwMode.DISPLAY,
-            )
-        }.toList()
-    }.flowOn(defaultDispatcher)
+    ): List<FollowedSubjectInfo> = subjectCollectionInfoList.map { subjectCollectionInfo ->
+        FollowedSubjectInfo(
+            subjectCollectionInfo,
+            // SubjectCollectionInfo 里已按同样的参数算好, 直接复用
+            subjectCollectionInfo.airingInfo,
+            subjectCollectionInfo.progressInfo,
+            nsfwMode = subjectCollectionInfo.nsfwMode,
+        )
+    }
 
     fun followedSubjectsPager(
         updatePeriod: Duration = 1.hours,
@@ -149,6 +120,11 @@ class FollowedSubjectsRepository(
         }.flowOn(defaultDispatcher)
 
     private companion object {
+        /**
+         * 服务器刷新与本地查询共用, 两者必须一致.
+         */
+        private const val FOLLOWED_SUBJECTS_LIMIT = 64
+
         private val NotLoading = LoadStates(
             refresh = LoadState.NotLoading(true),
             prepend = LoadState.NotLoading(true),

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retry
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -52,16 +51,16 @@ import me.him188.ani.app.data.network.EpisodeService
 import me.him188.ani.app.data.network.SubjectService
 import me.him188.ani.app.data.persistent.database.dao.EpisodeCollectionDao
 import me.him188.ani.app.data.persistent.database.dao.EpisodeCollectionEntity
+import me.him188.ani.app.data.persistent.database.dao.SubjectCollectionAndEpisodes
 import me.him188.ani.app.data.persistent.database.dao.SubjectCollectionDao
 import me.him188.ani.app.data.persistent.database.dao.SubjectCollectionEntity
 import me.him188.ani.app.data.persistent.database.dao.SubjectRelations
 import me.him188.ani.app.data.persistent.database.dao.SubjectRelationsDao
 import me.him188.ani.app.data.persistent.database.dao.deleteAll
-import me.him188.ani.app.data.persistent.database.dao.filterMostRecentUpdated
+import me.him188.ani.app.data.persistent.database.dao.filterMostRecentUpdatedWithEpisodes
 import me.him188.ani.app.data.repository.Repository
 import me.him188.ani.app.data.repository.RepositoryException
 import me.him188.ani.app.data.repository.episode.AnimeScheduleRepository
-import me.him188.ani.app.data.repository.episode.EpisodeCollectionRepository
 import me.him188.ani.app.data.repository.episode.toEpisodeCollectionInfo
 import me.him188.ani.app.data.repository.shouldRetry
 import me.him188.ani.app.domain.search.SubjectType
@@ -85,7 +84,6 @@ import me.him188.ani.datasources.api.PackedDate
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 import me.him188.ani.datasources.bangumi.processing.toSubjectCollectionType
 import me.him188.ani.utils.coroutines.combine
-import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
 import me.him188.ani.utils.logging.debug
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.platform.currentTimeMillis
@@ -186,7 +184,6 @@ class SubjectCollectionRepositoryImpl(
     private val subjectService: SubjectService,
     private val subjectCollectionDao: SubjectCollectionDao,
     private val subjectRelationsDao: SubjectRelationsDao,
-    private val episodeCollectionRepository: EpisodeCollectionRepository,
     private val animeScheduleRepository: AnimeScheduleRepository,
     private val episodeService: EpisodeService,
     private val episodeCollectionDao: EpisodeCollectionDao,
@@ -284,32 +281,25 @@ class SubjectCollectionRepositoryImpl(
             }
     }.flowOn(defaultDispatcher)
 
+    /**
+     * 条目与其剧集在同一次查询里取出 (`@Relation`), 整条链只有一条 Room flow, 不带网络请求.
+     * 数据新鲜度由调用方先行的 [updateRecentlyUpdatedSubjectCollections] 保证.
+     */
     override fun mostRecentlyUpdatedSubjectCollectionsFlow(
         limit: Int,
         types: List<UnifiedCollectionType>?, // null for all
-    ): Flow<List<SubjectCollectionInfo>> = subjectCollectionDao.filterMostRecentUpdated(types, limit)
-        .restartOnNewLogin(sessionManager)
-        .combine(nsfwModeSettingsFlow) { list, nsfwModeSettings ->
-            list to nsfwModeSettings
-        }
-        .flatMapLatest { (list, nsfwModeSettings) ->
-            if (list.isEmpty()) {
-                return@flatMapLatest flowOfEmptyList()
-            }
-            combine(
-                list.map { entity ->
-                    episodeCollectionRepository.subjectEpisodeCollectionInfosFlow(entity.subjectId).map { episodes ->
-                        entity.toSubjectCollectionInfo(
-                            episodes = episodes,
-                            currentDate = getCurrentDate(),
-                            nsfwModeSettings = nsfwModeSettings,
-                        )
-                    }
-                },
-            ) {
-                it.toList()
-            }
-        }
+    ): Flow<List<SubjectCollectionInfo>> = combine(
+        subjectCollectionDao.filterMostRecentUpdatedWithEpisodes(types, limit)
+            .restartOnNewLogin(sessionManager),
+        nsfwModeSettingsFlow,
+        getEpisodeTypeFiltersUseCase(),
+    ) { list, nsfwModeSettings, epTypes ->
+        val currentDate = getCurrentDate()
+        list.map { it.toSubjectCollectionInfo(epTypes, currentDate, nsfwModeSettings) }
+    }
+        // entity 的 lastFetched 每次刷新都变却不进 SubjectCollectionInfo, 挡掉"刷新了但数据没变"
+        // 引起的整栏重建
+        .distinctUntilChanged()
         .flowOn(defaultDispatcher)
 
     override fun subjectCollectionsPager(
@@ -330,20 +320,7 @@ class SubjectCollectionRepositoryImpl(
                     )
                 },
             ).flow.map { data ->
-                data.map { (entity, episodesOfAnyType) ->
-                    val date = getCurrentDate()
-                    entity.toSubjectCollectionInfo(
-                        episodes = episodesOfAnyType
-                            .asSequence()
-                            .let { sequence ->
-                                sequence.filter { it.episodeType in epTypes }
-                            }
-                            .map { it.toEpisodeCollectionInfo() }
-                            .toList(),
-                        currentDate = date,
-                        nsfwModeSettings = nsfwModeSettings,
-                    )
-                }
+                data.map { it.toSubjectCollectionInfo(epTypes, getCurrentDate(), nsfwModeSettings) }
             }
         }.flowOn(defaultDispatcher)
 
@@ -627,6 +604,28 @@ private fun SubjectCollectionEntity.toSubjectCollectionInfo(
         relations = relations ?: SubjectRelations.Empty,
     )
 }
+
+/**
+ * `@Relation` 一次取出的"条目 + 其全部剧集"到 [SubjectCollectionInfo] 的映射,
+ * 追番页 pager 与探索页"继续观看"共用.
+ */
+private fun SubjectCollectionAndEpisodes.toSubjectCollectionInfo(
+    epTypes: List<EpisodeType>,
+    currentDate: PackedDate,
+    nsfwModeSettings: NsfwMode,
+): SubjectCollectionInfo = collection.toSubjectCollectionInfo(
+    episodes = episodesOfAnyType
+        .asSequence()
+        .filter { it.episodeType in epTypes }
+        // @Relation 的子查询没有 ORDER BY, 而 [SubjectCollectionInfo.episodes] 约定按 sort 升序.
+        // 与 DAO 里其余查询的 `ORDER BY sortNumber ASC, sort ASC` 一致. 次级键用 sort.toString()
+        // 而不是 EpisodeSort: 后者的 Special 分支不满足反对称性, 会撞上 TimSort 的 contract 检查
+        .sortedWith(compareBy({ it.sortNumber }, { it.sort.toString() }))
+        .map { it.toEpisodeCollectionInfo() }
+        .toList(),
+    currentDate = currentDate,
+    nsfwModeSettings = nsfwModeSettings,
+)
 
 
 data class LoadInfo(

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -291,7 +291,6 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
 //            subjectCharacterRelationDao = database.subjectCharacterRelation(),
 //            subjectPersonRelationDao = database.subjectPersonRelation(),
             subjectRelationsDao = database.subjectRelations(),
-            episodeCollectionRepository = get(),
             animeScheduleRepository = get(),
             episodeService = get(),
             episodeCollectionDao = database.episodeCollection(),
@@ -304,8 +303,6 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
         FollowedSubjectsRepository(
             subjectCollectionRepository = get(),
             animeScheduleRepository = get(),
-            episodeCollectionRepository = get(),
-            settingsRepository = get(),
             sessionManager = get(),
         )
     }


### PR DESCRIPTION
## 问题

**主问题**：首页「继续观看」栏在修改收藏状态后不再更新，只能重启应用才恢复。

`FollowedSubjectsRepository` 原本是「先查条目列表，再为每个条目订阅一条 flow 拿剧集」，而那条 flow 带条件网络请求（缓存过期就拉单条）。于是改一次收藏就会让几十条 flow 重建并发请求，其中任意一条失败都会顺着 `combine` 抛穿上层，把 `cachedIn` 的收集协程一起打死 —— 此后这一栏永久停在旧快照，主动刷新也救不回来（`FlowRestarter` 只是发信号，承载它的协程已经不在了）。

**同批修掉的**：

- 批量刷新的条数与本地查询不一致（刷 30 条却显示 64 条），中间那段永远拿不到新播出的剧集。去掉逐条刷新后，批量刷新成了这一栏唯一的刷新来源，这个不一致会直接表现为数据陈旧。
- 追番页的分集没有排序：`SubjectCollectionRepository` 里同一份映射写了两份，只有一份做了排序。

全平台一致。

## 改动

- 条目与剧集改为在同一次 `@Relation` 查询里取出，整条链只剩一条 Room flow：没有网络请求也就没有异常源，数据库一变立即整体重算。内层再出错也只按退避重试，不再杀链。
- 批量刷新条数与本地查询对齐。
- `FollowedSubjectInfo` 复用 `SubjectCollectionInfo` 里已按同样参数算好的 `airingInfo` 与 `progressInfo`，不再逐条重算。
- 加 `distinctUntilChanged`：entity 的 `lastFetched` 每次刷新都变却不进 `SubjectCollectionInfo`，挡掉「刷新了但数据没变」引起的整栏重建与重组。
- 去掉重复的分集映射，排序只留一份。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

复现方式：在首页「继续观看」栏把某个条目标记为看过。修复前该栏会停在旧快照直到重启应用；应用本修复后立即刷新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
