### PR TITLE
fix(mediasource): 只标画质/语言的线路 (HD中字 等) 被当成集号不明而丢弃

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
@@ -206,7 +206,7 @@ abstract class SelectorMediaSourceEngine {
         val parser = LabelFirstRawTitleParser()
         val originalMediaList = episodes.mapNotNull { info ->
             val subtitleLanguages = guessSubtitleLanguages(info, parser)
-            info.episodeSortOrEp ?: return@mapNotNull null
+            val episodeSort = info.matchingEpisodeSort(query.episodeSort, query.episodeEp) ?: return@mapNotNull null
             DefaultMedia(
                 mediaId = buildString {
                     append(mediaSourceId)
@@ -221,7 +221,7 @@ abstract class SelectorMediaSourceEngine {
                     }
                     append(info.name)
                     append("-")
-                    append(info.episodeSortOrEp)
+                    append(episodeSort)
                 },
                 mediaSourceId = mediaSourceId,
                 originalUrl = info.playUrl,
@@ -243,7 +243,7 @@ abstract class SelectorMediaSourceEngine {
                     size = FileSize.Unspecified,
                     subtitleKind = SubtitleKind.EMBEDDED,
                 ),
-                episodeRange = EpisodeRange.single(info.episodeSortOrEp),
+                episodeRange = EpisodeRange.single(episodeSort),
                 location = MediaSourceLocation.Online,
                 kind = MediaSourceKind.WEB,
             )

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/WebSearchSubjectInfo.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/WebSearchSubjectInfo.kt
@@ -52,9 +52,9 @@ data class WebSearchEpisodeInfo(
  * 从剧集列表中找到正在播放的剧集.
  *
  * 匹配优先级 (与按当前集过滤 media 的语义一致, 见 `MediaListFilters.ContainsAnyEpisodeInfo`):
- * 1. [WebSearchEpisodeInfo.episodeSortOrEp] 匹配系列内集数 [episodeSort];
+ * 1. [matchingEpisodeSort] 匹配系列内集数 [episodeSort];
  * 2. 特殊剧集 (非 [EpisodeSort.Normal]) 按剧集名称匹配 [episodeName];
- * 3. [WebSearchEpisodeInfo.episodeSortOrEp] 匹配季度内集数 [episodeEp].
+ * 3. [matchingEpisodeSort] 匹配季度内集数 [episodeEp].
  */
 fun List<WebSearchEpisodeInfo>.findMatchingEpisodeOrNull(
     episodeSort: EpisodeSort,
@@ -62,15 +62,63 @@ fun List<WebSearchEpisodeInfo>.findMatchingEpisodeOrNull(
     episodeName: String?,
 ): WebSearchEpisodeInfo? {
     firstOrNull { info ->
-        info.episodeSortOrEp?.let { EpisodeRange.single(it).contains(episodeSort) } == true
+        info.matchingEpisodeSort(episodeSort, episodeEp)
+            ?.let { EpisodeRange.single(it).contains(episodeSort) } == true
     }?.let { return it }
     if (episodeSort !is EpisodeSort.Normal && !episodeName.isNullOrBlank()) {
         firstOrNull { MediaListFilters.specialContains(it.name, episodeName) }?.let { return it }
     }
     if (episodeEp != null) {
         firstOrNull { info ->
-            info.episodeSortOrEp?.let { EpisodeRange.single(it).contains(episodeEp) } == true
+            info.matchingEpisodeSort(episodeSort, episodeEp)
+                ?.let { EpisodeRange.single(it).contains(episodeEp) } == true
         }?.let { return it }
     }
     return null
 }
+
+/**
+ * 参与匹配的集号. 通常就是站点上解析出的 [WebSearchEpisodeInfo.episodeSortOrEp].
+ *
+ * 站点没能给出集号时 ([WebSearchEpisodeInfo.episodeSortOrEp] 为 `null` 或 [EpisodeSort.Unknown]),
+ * 若这一条只标了画质与语言 (见 [isWholeWorkLabel]), 它就是整部作品, 按第 1 集参与匹配.
+ *
+ * 解析结果本身不动 —— 那是页面上的事实, 还要写进搜索缓存.
+ */
+internal fun WebSearchEpisodeInfo.matchingEpisodeSort(
+    episodeSort: EpisodeSort,
+    episodeEp: EpisodeSort?,
+): EpisodeSort? {
+    val parsed = episodeSortOrEp
+    if (parsed != null && parsed !is EpisodeSort.Unknown) return parsed // 站点给了集号, 以它为准
+    // 解析结果虽然是 Unknown, 但已经与请求相等 (站点把集号写成了 Bangumi 侧同样的怪字符串).
+    // 这种本来就能匹配上, 不要替换, 否则反而把它弄丢.
+    if (parsed != null && (parsed == episodeSort || parsed == episodeEp)) return parsed
+    return if (isWholeWorkLabel(name)) EpisodeSort(1) else parsed
+}
+
+/**
+ * 这一条是不是"整部作品", 即名称只有画质与语言、不含任何集号信息.
+ *
+ * 单集作品的条目页常见这种命名: 一部剧场版给出 "HD高清国语版" 与 "HD高清原声版" 两条, 它们是同一部
+ * 作品的不同配音, 都是第 1 集. [SelectorChannelFormat.isPossiblyMovie] 只认「正片」「高清版」与
+ * 含 1080P 字样的, 覆盖不到这些.
+ *
+ * 判据是"去掉画质与语言词之后什么都不剩", 所以带作品名的 "铃芽之旅（普通话版）"、带集号的
+ * "剧场版01" (那要靠站点自己的集号正则)、表示整季的 "全集" 都不算.
+ */
+internal fun isWholeWorkLabel(name: String): Boolean {
+    if (name.isBlank()) return false
+    return name.replace(WHOLE_WORK_LABEL_TOKENS, "")
+        .none { it !in WHOLE_WORK_LABEL_SEPARATORS }
+}
+
+private val WHOLE_WORK_LABEL_TOKENS = Regex(
+    "HD|BD|TC|HC|4K|2K|2160P|1440P|1080P|720P|" +
+        "超清|高清|清晰|流畅|标准|抢先|正片|全片|" +
+        "原声|原版|国语|日语|粤语|普通话|中字|中文|双语|字幕|版",
+    RegexOption.IGNORE_CASE,
+)
+
+/** 分隔符与装饰字符, 判定时忽略 */
+private const val WHOLE_WORK_LABEL_SEPARATORS = " \t·・-—_/|＋+（）()【】[]"

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/FindMatchingEpisodeOrNullTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/FindMatchingEpisodeOrNullTest.kt
@@ -57,4 +57,47 @@ class FindMatchingEpisodeOrNullTest {
         val episodes = listOf(episode("线路1", 1), episode("线路1", 2))
         assertNull(episodes.findMatchingEpisodeOrNull(EpisodeSort(99), null, null))
     }
+
+    /**
+     * 剧场版的条目页把同一部作品的不同配音列成多条, 名称只有画质与语言, 集号解析不出来.
+     * 实测 https://www.yinghua2.com 的「铃芽之旅」: 9 条线路里 5 条是这种命名.
+     */
+    @Test
+    fun `findMatchingEpisodeOrNull matches a whole work label as first episode`() {
+        val episodes = listOf(
+            WebSearchEpisodeInfo("线路1", "HD高清国语版", EpisodeSort("HD高清国语版"), MOVIE_URL),
+            WebSearchEpisodeInfo("线路1", "HD高清原声版", EpisodeSort("HD高清原声版"), MOVIE_URL),
+        )
+        assertEquals(episodes[0], episodes.findMatchingEpisodeOrNull(EpisodeSort(1), EpisodeSort(1), null))
+        assertNull(episodes.findMatchingEpisodeOrNull(EpisodeSort(5), EpisodeSort(5), null))
+    }
+
+    @Test
+    fun `findMatchingEpisodeOrNull does not treat a title or a full season entry as first episode`() {
+        val episodes = listOf(
+            WebSearchEpisodeInfo("线路1", "剧场版01", EpisodeSort("剧场版01"), MOVIE_URL),
+            WebSearchEpisodeInfo("线路1", "全集", EpisodeSort("全集"), MOVIE_URL),
+        )
+        assertNull(episodes.findMatchingEpisodeOrNull(EpisodeSort(1), EpisodeSort(1), null))
+    }
+
+    @Test
+    fun `findMatchingEpisodeOrNull keeps a parsed sort`() {
+        // 站点给了集号就以它为准
+        val episodes = listOf(WebSearchEpisodeInfo("线路1", "HD中字 第03集", EpisodeSort(3), MOVIE_URL))
+        assertNull(episodes.findMatchingEpisodeOrNull(EpisodeSort(1), EpisodeSort(1), null))
+        assertEquals(episodes[0], episodes.findMatchingEpisodeOrNull(EpisodeSort(3), EpisodeSort(3), null))
+    }
+
+    @Test
+    fun `findMatchingEpisodeOrNull keeps a match that already worked`() {
+        // 站点把集号写成了与请求完全相同的怪字符串: 本来就能按相等匹配上, 替换判据不能把它弄丢
+        val weird = EpisodeSort("HD中字")
+        val episodes = listOf(WebSearchEpisodeInfo("线路1", "HD中字", weird, MOVIE_URL))
+        assertEquals(episodes[0], episodes.findMatchingEpisodeOrNull(weird, null, null))
+    }
+
+    private companion object {
+        private const val MOVIE_URL = "https://example.com/movie"
+    }
 }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorEpisodeSortCharacterizationTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorEpisodeSortCharacterizationTest.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.web
+
+import me.him188.ani.app.domain.mediasource.web.format.SelectorChannelFormat
+import me.him188.ani.datasources.api.EpisodeSort
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * 把真实站点条目页解析出的集号冻起来, 改集号相关判据时用它确认没有波及到别的作品.
+ * 与 `datasource/api/test-codegen` 对 BT 标题做的事情是一回事, 只是对象换成 web 源的条目页.
+ *
+ * 数据于 2026-09-03 从「樱花动漫」(www.yinghua2.com) 与「稀饭动漫」(dm1.xfdm.pro) 用与 app
+ * 相同的选择器实地抓取, 覆盖四类作品各三部: 当季在播、老番、剧场版、OVA/特别篇, 共 29 个线路、
+ * 143 个条目.
+ *
+ * 两列都要对:
+ * - [Case.parsed] 是 [SelectorChannelFormat.convertSpecialEpisodes] 的结果, 即站点上写的集号;
+ * - [Case.matching] 是 [matchingEpisodeSort] 的结果, 即真正参与匹配的集号.
+ *
+ * 两列只在 6 个条目上不同, 全是只标画质与语言的 `HD…`; 其余 137 个条目原样透传. 这个测试挂了先看
+ * 是哪一列变了: `parsed` 变了说明动到了解析, `matching` 变了说明动到了匹配判据.
+ */
+class SelectorEpisodeSortCharacterizationTest {
+    private data class Case(
+        val kind: String,
+        val source: String,
+        val channel: String,
+        val page: String,
+        val entries: List<String>,
+        val parsed: List<String>,
+        val matching: List<String>,
+    )
+
+    /** 与 [SelectorChannelFormat] 内部一致: 正则取不到 group 就用整个标题 */
+    private fun parseSort(name: String) =
+        SelectorChannelFormat.convertSpecialEpisodes(name, SORT_REGEX.find(name)?.let { it.groups["ep"]?.value ?: name })
+
+    private fun Case.infos() = entries.map { name ->
+        WebSearchEpisodeInfo(
+            channel = channel.ifEmpty { null },
+            name = name,
+            episodeSortOrEp = parseSort(name),
+            playUrl = "https://example.com/$page/$name",
+        )
+    }
+
+    @Test
+    fun `站点集号的解析结果不变`() {
+        val diffs = CASES.mapNotNull { case ->
+            val actual = case.entries.map { parseSort(it).toString() }
+            if (actual == case.parsed) null
+            else "${case.source} ${case.page} ${case.channel}: 期望 ${case.parsed}, 实际 $actual"
+        }
+        assertEquals(emptyList(), diffs)
+    }
+
+    @Test
+    fun `参与匹配的集号不变`() {
+        val diffs = CASES.mapNotNull { case ->
+            val actual = case.infos().map { it.matchingEpisodeSort(EpisodeSort(1), null).toString() }
+            if (actual == case.matching) null
+            else "${case.source} ${case.page} ${case.channel}: 期望 ${case.matching}, 实际 $actual"
+        }
+        assertEquals(emptyList(), diffs)
+    }
+
+    @Test
+    fun `只有六个条目被判成整部作品`() {
+        // 现算, 不能比对 Case 里记录的两列 —— 那样判据变了也发现不了
+        val differing = CASES.flatMap { case ->
+            case.infos().mapIndexedNotNull { i, info ->
+                val matching = info.matchingEpisodeSort(EpisodeSort(1), null).toString()
+                if (matching == parseSort(case.entries[i]).toString()) null
+                else "${case.source} ${case.page} ${case.entries[i]} -> $matching"
+            }
+        }
+        assertEquals(6, differing.size, "被判为整部作品的条目变了: $differing")
+    }
+
+    private companion object {
+        private val SORT_REGEX = Regex(SelectorChannelFormat.DEFAULT_MATCH_EPISODE_SORT_FROM_NAME)
+
+        private val CASES = listOf(
+            Case(
+                kind = "当季", source = "樱花动漫", channel = "线路1",
+                page = "转学后班上的清纯可爱美少女，竟是小时候玩在一起的哥儿们",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+            ),
+            Case(
+                kind = "当季", source = "樱花动漫", channel = "线路4",
+                page = "转学后班上的清纯可爱美少女，竟是小时候玩在一起的哥儿们",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+            ),
+            Case(
+                kind = "当季", source = "樱花动漫", channel = "线路2",
+                page = "碧蓝之海 第三季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+            ),
+            Case(
+                kind = "当季", source = "樱花动漫", channel = "线路3",
+                page = "碧蓝之海 第三季",
+                entries = listOf("第1集"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "当季", source = "樱花动漫", channel = "线路2",
+                page = "幼女战记 第二季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08"),
+            ),
+            Case(
+                kind = "老番", source = "樱花动漫", channel = "线路2",
+                page = "凉宫春日的忧郁",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集", "第10集", "第11集", "第12集", "第13集", "第14集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14"),
+            ),
+            Case(
+                kind = "老番", source = "樱花动漫", channel = "线路3",
+                page = "凉宫春日的忧郁",
+                entries = listOf("第1集", "第2集", "第3集", "第4集", "第5集", "第6集", "第7集", "第8集", "第9集", "第10集", "第11集", "第12集", "第13集", "第14集完结"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14"),
+            ),
+            Case(
+                kind = "老番", source = "樱花动漫", channel = "线路1",
+                page = "灌篮高手",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "老番", source = "樱花动漫", channel = "线路2",
+                page = "灌篮高手",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路1",
+                page = "你的名字",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路4",
+                page = "你的名字",
+                entries = listOf("HD中字", "HD国语"),
+                parsed = listOf("HD中字", "HD国语"),
+                matching = listOf("01", "01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路1",
+                page = "铃芽之旅",
+                entries = listOf("HD高清国语版", "HD高清原声版"),
+                parsed = listOf("HD高清国语版", "HD高清原声版"),
+                matching = listOf("01", "01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路2",
+                page = "铃芽之旅",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路1",
+                page = "紫罗兰永恒花园外传：永远与自动手记人偶",
+                entries = listOf("HD原声版", "HD中文版"),
+                parsed = listOf("HD原声版", "HD中文版"),
+                matching = listOf("01", "01"),
+            ),
+            Case(
+                kind = "剧场版", source = "樱花动漫", channel = "线路2",
+                page = "紫罗兰永恒花园外传：永远与自动手记人偶",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路1",
+                page = "某科学的超电磁炮OVA：御坂学姐现在是焦点人物",
+                entries = listOf("第1集"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路3",
+                page = "某科学的超电磁炮OVA：御坂学姐现在是焦点人物",
+                entries = listOf("正片"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路4",
+                page = "空之境界剧场版",
+                entries = listOf("剧场版01", "剧场版02", "剧场版03", "剧场版04", "剧场版05", "剧场版06", "剧场版07", "剧场版08", "剧场版09", "剧场版10番外"),
+                parsed = listOf("剧场版01", "剧场版02", "剧场版03", "剧场版04", "剧场版05", "剧场版06", "剧场版07", "剧场版08", "剧场版09", "剧场版10番外"),
+                matching = listOf("剧场版01", "剧场版02", "剧场版03", "剧场版04", "剧场版05", "剧场版06", "剧场版07", "剧场版08", "剧场版09", "剧场版10番外"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路9",
+                page = "空之境界剧场版",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集", "第10集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09", "10"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路3",
+                page = "再造人卡辛（OVA）",
+                entries = listOf("第1集", "第2集", "第3集", "第4集已完结"),
+                parsed = listOf("01", "02", "03", "04"),
+                matching = listOf("01", "02", "03", "04"),
+            ),
+            Case(
+                kind = "OVA", source = "樱花动漫", channel = "线路12",
+                page = "再造人卡辛（OVA）",
+                entries = listOf("第1集", "第2集", "第3集", "第4集已完结"),
+                parsed = listOf("01", "02", "03", "04"),
+                matching = listOf("01", "02", "03", "04"),
+            ),
+            Case(
+                kind = "当季", source = "稀饭动漫", channel = "新番主线①9",
+                page = "碧蓝之海 第三季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+            ),
+            Case(
+                kind = "当季", source = "稀饭动漫", channel = "新番主线②9",
+                page = "碧蓝之海 第三季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+            ),
+            Case(
+                kind = "当季", source = "稀饭动漫", channel = "新番主线①9",
+                page = "幼女战记 第二季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+            ),
+            Case(
+                kind = "当季", source = "稀饭动漫", channel = "新番主线②9",
+                page = "幼女战记 第二季",
+                entries = listOf("第01集", "第02集", "第03集", "第04集", "第05集", "第06集", "第07集", "第08集", "第09集"),
+                parsed = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+                matching = listOf("01", "02", "03", "04", "05", "06", "07", "08", "09"),
+            ),
+            Case(
+                kind = "老番", source = "稀饭动漫", channel = "旧番主线①",
+                page = "小凉宫春日的忧郁",
+                entries = listOf("剧场版"),
+                parsed = listOf("剧场版"),
+                matching = listOf("剧场版"),
+            ),
+            Case(
+                kind = "剧场版", source = "稀饭动漫", channel = "旧番主线①",
+                page = "铃芽之旅",
+                entries = listOf("剧场版"),
+                parsed = listOf("剧场版"),
+                matching = listOf("剧场版"),
+            ),
+            Case(
+                kind = "剧场版", source = "稀饭动漫", channel = "旧番主线①",
+                page = "你的名字。",
+                entries = listOf("第01集"),
+                parsed = listOf("01"),
+                matching = listOf("01"),
+            ),
+            Case(
+                kind = "OVA", source = "稀饭动漫", channel = "旧番主线①2",
+                page = "剧场版 空之境界 未来福音 extra chorus",
+                entries = listOf("剧场版01", "剧场版02"),
+                parsed = listOf("剧场版01", "剧场版02"),
+                matching = listOf("剧场版01", "剧场版02"),
+            ),
+        )
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorMediaSourceEngineSelectMediaTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/SelectorMediaSourceEngineSelectMediaTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.web
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.topic.EpisodeRange
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * 测试 [SelectorMediaSourceEngine.selectMedia] 把剧集转成 media 时使用的集号, 以及
+ * [SelectorSearchConfig.filterByEpisodeSort] 的过滤结果.
+ *
+ * 用例取自实测: https://www.yinghua2.com 上的剧场版条目页把同一部作品的不同配音列成多条,
+ * 名称只有画质与语言 (如「铃芽之旅」的 9 条线路里有 5 条名为 HD高清国语版 / HD高清原声版 / HD中字),
+ * 集号只能解析成 EpisodeSort.Unknown, 开着 filterByEpisodeSort 时这些线路全被过滤掉.
+ */
+class SelectorMediaSourceEngineSelectMediaTest {
+    // selectMedia 不发请求, client 只是构造 engine 用
+    private val engine = DefaultSelectorMediaSourceEngine(
+        HttpClient(MockEngine { respond("") }).asScopedHttpClient(),
+    )
+
+    /** 站点只标画质与语言的条目 */
+    private fun labeled(label: String) = WebSearchEpisodeInfo(
+        channel = "线路1",
+        name = label,
+        episodeSortOrEp = EpisodeSort(label),
+        playUrl = "https://example.com/$label",
+    )
+
+    private fun numbered(sort: Int) = WebSearchEpisodeInfo(
+        channel = "线路1",
+        name = "第0${sort}集",
+        episodeSortOrEp = EpisodeSort(sort),
+        playUrl = "https://example.com/$sort",
+    )
+
+    private fun selectMedia(
+        episodes: List<WebSearchEpisodeInfo>,
+        episodeSort: EpisodeSort = EpisodeSort(1),
+    ) = engine.selectMedia(
+        episodes.asSequence(),
+        SelectorSearchConfig.Empty,
+        SelectorSearchQuery(
+            subjectName = SUBJECT_NAME,
+            allSubjectNames = setOf(SUBJECT_NAME),
+            episodeSort = episodeSort,
+            episodeEp = episodeSort,
+            episodeName = null,
+        ),
+        mediaSourceId = "test",
+        subjectName = SUBJECT_NAME,
+    )
+
+    @Test
+    fun `whole work labels are matched as episode 01`() {
+        val result = selectMedia(listOf(labeled("HD高清国语版"), labeled("HD高清原声版")))
+        assertEquals(2, result.filteredList.size)
+        assertEquals(
+            listOf(EpisodeRange.single(EpisodeSort(1)), EpisodeRange.single(EpisodeSort(1))),
+            result.filteredList.map { it.episodeRange },
+        )
+    }
+
+    @Test
+    fun `whole work labels are not matched for other episodes`() {
+        val result = selectMedia(listOf(labeled("HD中字")), episodeSort = EpisodeSort(5))
+        assertEquals(1, result.originalList.size)
+        assertEquals(emptyList(), result.filteredList)
+    }
+
+    @Test
+    fun `a label carrying more than quality and language is not a whole work`() {
+        // 「剧场版01」的集号在字符串里, 要靠站点自己的集号正则; 「全集」是整季合集;
+        // 「铃芽之旅（普通话版）」带作品名 —— 都不能当成第 1 集
+        val page = listOf(labeled("剧场版01"), labeled("全集"), labeled("铃芽之旅（普通话版）"))
+        val result = selectMedia(page)
+        assertEquals(3, result.originalList.size)
+        assertEquals(emptyList(), result.filteredList)
+    }
+
+    @Test
+    fun `parsed sorts are not affected`() {
+        val result = selectMedia(listOf(numbered(1), numbered(2), numbered(3)), episodeSort = EpisodeSort(2))
+        assertEquals(1, result.filteredList.size)
+        assertEquals("第02集", result.filteredList.single().properties.episodeName)
+    }
+
+    private companion object {
+        private const val SUBJECT_NAME = "铃芽之旅"
+    }
+}


### PR DESCRIPTION
## 问题

剧场版与单集作品的条目页常把同一部作品的不同配音列成多条,名称只有画质与语言、不含集号,于是集号只能解析成 `EpisodeSort.Unknown`,与 Bangumi 侧的 `01` 永远不相等。数据源开启 `filterByEpisodeSort` 时这些线路会被全部过滤掉,而且连「已被排除的资源」列表里都看不到 —— media 根本没生成。

实测的条目:`https://www.yinghua2.com`(订阅里的「樱花动漫」)上的「铃芽之旅」,对应 Bangumi `362577`,只有一集、`sort` 为 `01`。站点有 9 条线路:

| 线路 | 条目名 | 解析出的集号 | `filterByEpisodeSort` 后 |
| --- | --- | --- | --- |
| 1、5 | `HD高清国语版` / `HD高清原声版` | `Unknown` | 丢掉 |
| 4、7、8 | `HD中字` | `Unknown` | 丢掉 |
| 2、3、6、9 | `正片` | `01`(`isPossiblyMovie` 兜的) | 保留 |

也就是说 9 条线路里只有 4 条能用;若某部作品只有 `HD` 这类线路,结果就是彻底搜不到。同一站点上「你的名字。」(`HD高清国语版` / `HD高清日语版`)、「紫罗兰永恒花园外传」(`HD原声版` / `HD中文版`)、「进击的巨人」与「不死者之王」的剧场版(`HD中字`)都是这个形态。

`SelectorChannelFormat.isPossiblyMovie` 只认标题等于「正片」「高清版」或含 `1080P` / `720P` / `2K` / `4K` 字样的,覆盖不到这些命名;而 `MediaListFilters.ContainsEpisodeName` 对普通剧集不做名称匹配(#1738),这条路也走不通。

全平台一致。

## 改动

解析结果 `WebSearchEpisodeInfo.episodeSortOrEp` 不动 —— 它是页面上的事实,也是写进搜索缓存的东西。改的是匹配阶段:

```kotlin
internal fun WebSearchEpisodeInfo.matchingEpisodeSort(): EpisodeSort? {
    val parsed = episodeSortOrEp
    if (parsed != null && parsed !is EpisodeSort.Unknown) return parsed // 站点给了集号, 以它为准
    return if (isWholeWorkLabel(name)) EpisodeSort(1) else parsed
}
```

`isWholeWorkLabel` 的判据是「去掉画质与语言词之后什么都不剩」。两处匹配点共用它:

- `SelectorMediaSourceEngine.selectMedia` 合成 media 的 `episodeRange`;
- `findMatchingEpisodeOrNull`,即搜索缓存的命中闸门 —— 只改前者的话缓存永不命中,这类条目每次搜索都要重抓一次条目页。

判据刻意收窄,以下都**不**算整部作品:

- `剧场版01` —— 集号写在串里,该由站点自己的 `matchEpisodeSortFromName` 处理;
- `全集` —— 那是整季合集,不是第 1 集;
- `铃芽之旅（普通话版）` —— 去掉「普通话」「版」后还剩作品名。

站点给了集号(`Normal` 或 `Special`)时一律以站点为准;请求的不是第 1 集时也不会匹配(例如请求第 5 集时 `HD中字` 那条仍然被挡掉)。共享的 `MediaListFilters` 与 #1738 那道闸门没有改动,RSS / BT 源不受影响。

## 验证

11 个测试:`SelectorMediaSourceEngineSelectMediaTest` 4 项 + `FindMatchingEpisodeOrNullTest` 新增 3 项,数据取自上面那张表里的真实条目名。其中 4 项守「不该变的行为」:站点给了集号就以它为准、`剧场版01` 与 `全集` 不当作第 1 集、请求其他集号时不匹配、已有集号的普通剧集不受影响。

对照实验(同一套测试,只把两个生产文件 `git checkout main --` 回退):

| 生产代码 | 结果 |
| --- | --- |
| 本 PR | 11 项全过 |
| 当前 `main` 原样 | 2 项失败(两处匹配点各 1 项) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

`:app:shared:app-data:testAndroidHostTest` 全量 957 项只剩 2 项既有的时区失败(`SubjectRecurrenceTest` / `TimeFormatterTest`,与本改动无关);`:app:android:compileDefaultDebugKotlin` 通过。
