### PR TITLE
fix(ui): Toast 配色跟随系统深浅色而非应用主题

### DIFF
--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
@@ -166,9 +166,6 @@ fun Toast(
             }
         },
     ) {
-        // 配色取自主题 (同更新提示气泡的 surfaceContainerHigh): 之前按 isSystemInDarkTheme()
-        // 在纯黑/纯白之间二选一 —— 那是**系统**的深浅色, 与应用内的主题设置 (深色/浅色/主题色)
-        // 无关, 于是应用切了主题 toast 还是同一套黑白, 在 TV 上尤其突兀
         Surface(
             modifier = Modifier.padding(horizontal = 60.dp),
             shape = RoundedCornerShape(15.dp),

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
@@ -13,13 +13,13 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -29,7 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -167,14 +166,16 @@ fun Toast(
             }
         },
     ) {
-        val isDarkTheme = isSystemInDarkTheme()
+        // 配色取自主题 (同更新提示气泡的 surfaceContainerHigh): 之前按 isSystemInDarkTheme()
+        // 在纯黑/纯白之间二选一 —— 那是**系统**的深浅色, 与应用内的主题设置 (深色/浅色/主题色)
+        // 无关, 于是应用切了主题 toast 还是同一套黑白, 在 TV 上尤其突兀
         Surface(
             modifier = Modifier.padding(horizontal = 60.dp),
             shape = RoundedCornerShape(15.dp),
-            color = (if (isDarkTheme) Color.White else Color.Black).copy(alpha = 0.7f),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
             shadowElevation = 4.dp,
         ) {
-            CompositionLocalProvider(LocalContentColor provides (if (isDarkTheme) Color.Black else Color.White)) {
+            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
                 Row(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
                     currentContent()
                 }


### PR DESCRIPTION
## 问题

`Toast` 的配色取自 `isSystemInDarkTheme()`，在纯黑与纯白之间二选一：

```kotlin
val isDarkTheme = isSystemInDarkTheme()
color = (if (isDarkTheme) Color.White else Color.Black).copy(alpha = 0.7f)
```

`isSystemInDarkTheme()` 是**系统**的深浅色，与应用内的主题设置（深色 / 浅色 / 主题色）无关。于是在应用里把主题切成与系统相反的一侧时，toast 仍是另一套黑白，与周围界面对不上。

复现：系统浅色 + 应用内主题设为深色（或反过来），触发任意 toast。全平台一致。

## 改动

改用 `MaterialTheme.colorScheme.surfaceContainerHigh` / `onSurface`，与应用内其他浮层（如更新提示气泡）一致，自动跟随应用主题与主题色。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
