### PR TITLE
fix(ui): Animeko 图标固有尺寸 108dp 撑大列表行

### DIFF
--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/icons/AnimekoIcon.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/icons/AnimekoIcon.kt
@@ -29,8 +29,9 @@ public val Icons.Filled.Animeko: ImageVector
         }
         _animekoIcon = Builder(
             name = "AnimekoIcon",
-            defaultWidth = 108.0.dp,
-            defaultHeight = 108.0.dp,
+            // Icon 按矢量的固有尺寸渲染, 108dp (launcher icon 画布) 会撑大列表行
+            defaultWidth = 24.0.dp,
+            defaultHeight = 24.0.dp,
             viewportWidth = 108.0f,
             viewportHeight = 108.0f,
         ).apply {


### PR DESCRIPTION
## 问题

`Icons.Filled.Animeko` 的 `defaultWidth` / `defaultHeight` 是 `108.dp`（照搬了 launcher icon 的画布尺寸）。

`Icon` 在调用方没有给尺寸时按矢量的固有尺寸渲染，而设置里的代理测试列表正是这种写法（`Icon(item.case.icon)`）。于是这一枚图标比旁边的 Material 图标大四倍半，把整行的行高也顶了起来。

复现：设置 → 代理 → 测试连接，看 Animeko 那一项与相邻项的对比。全平台一致。

## 改动

固有尺寸改成与 Material 图标一致的 `24.dp`。`viewportWidth` / `viewportHeight` 不动（路径坐标仍是 108 的画布），显示效果等比缩放。

## 验证

本改动 cherry-pick 到当前 `main` 后 `:app:android:compileDefaultDebugKotlin` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
