### PR TITLE
fix(desktop): 修复登录按钮 hover 阴影重叠

### DIFF
--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/session/SelfAvatar.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/session/SelfAvatar.kt
@@ -9,7 +9,6 @@
 
 package me.him188.ani.app.ui.foundation.session
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -65,34 +64,31 @@ fun SelfAvatar(
     val signInText = stringResource(Lang.login_sign_in)
 
     @Composable
-    fun Content(onClick: () -> Unit) {
-        if (state.isLoading) {
+    fun AvatarSurface(content: @Composable () -> Unit) = if (onClick == null) {
+        Surface(modifier, shape = CircleShape, content = content)
+    } else {
+        Surface(onClick, modifier, shape = CircleShape, content = content)
+    }
+
+    if (state.isLoading) {
+        AvatarSurface {
             // 加载中时展示 placeholder
             AvatarImage(
                 url = state.selfInfo?.avatarUrl,
                 Modifier.size(size).clip(CircleShape).placeholder(state.selfInfo == null),
             )
+        }
+    } else {
+        if (state.isSessionValid == false || state.selfInfo == null) {
+            TextButton(onClick ?: {}, modifier = modifier) {
+                Text(signInText)
+            }
         } else {
-            if (state.isSessionValid == false || state.selfInfo == null) {
-                TextButton(onClick) {
-                    Text(signInText)
-                }
-            } else {
+            AvatarSurface {
                 AvatarImage(
                     url = state.selfInfo.avatarUrl,
                     modifier = Modifier.size(size).clip(CircleShape),
                 )
-            }
-        }
-    }
-    Box {
-        if (onClick != null) {
-            Surface(onClick, modifier, shape = CircleShape) {
-                Content(onClick)
-            }
-        } else {
-            Surface(modifier = modifier, shape = CircleShape) {
-                Content { }
             }
         }
     }


### PR DESCRIPTION
Closes #1988

## 问题

#1988 描述了桌面端登录按钮在 hover 时视觉高度异常的问题。实际原因是未登录状态下，外层 clickable `Surface` 和内层 `TextButton` 都会在 hover 时绘制阴影，导致阴影重叠，视觉上表现为按钮高度增加。

此外，外层 `Surface` 还为登录按钮绘制了独立的容器背景。主页面滚动后 TopBar 颜色发生变化时，登录按钮仍然保留原来的浅色背景，与 TopBar 的当前背景色不一致。

## 修改

- 未登录状态下直接渲染 `TextButton`，移除外层 clickable `Surface`，避免重复的 hover 阴影。
- 移除外层 `Surface` 提供的独立容器背景，使登录按钮的背景随 TopBar 颜色变化。
- 加载中和已登录状态继续使用 `Surface`，保留原有的显示和点击行为。
- 移除包裹 `SelfAvatar` 的冗余 `Box` 和 `Content` 封装。

## 验证

测试了以下场景：

- Windows：
  - 未登录状态下 hover 登录按钮时，现在只显示 `TextButton` 的阴影。
  - 主页面滚动、TopBar 颜色发生变化后，登录按钮背景会与 TopBar 保持一致。
  - 未登录状态下，按钮大小和点击行为与修改前一致。
  - 已登录状态下，头像的样式、大小和点击行为与修改前一致。

- Android：
  - 未登录和已登录状态下，组件显示和点击行为正常，未发现可见回归。

## 修改后 UI 截图

### Windows

| 状态 | 普通 | Hover |
| --- | --- | --- |
| 未登录 | <img width="220" alt="未登录" src="https://github.com/user-attachments/assets/21912829-eaf8-4674-bd3b-7a7d050e4b8e"> | <img width="220" alt="未登录时 hover" src="https://github.com/user-attachments/assets/b7c62727-c03a-4a36-bc6f-b8cb20b02246"> |
| 已登录 | <img width="220" alt="已登录" src="https://github.com/user-attachments/assets/eaf9ec6c-1991-4486-9eda-b96ebb6203c4"> | <img width="220" alt="已登录时 hover" src="https://github.com/user-attachments/assets/676888a3-f1af-4a23-b1a8-4ee8a663cc74"> |

### TopBar 滚动后的登录按钮背景

| 修改前 | 修改后 |
| --- | --- |
| <img width="205" height="112" alt="image" src="https://github.com/user-attachments/assets/c04704fa-b41e-41a2-a8d3-779db06b5faa" /> | <img width="194" height="130" alt="image" src="https://github.com/user-attachments/assets/29c6506e-376c-4eb2-ac6b-49fbe25d9de3" /> |