### PR TITLE
fix(player): 让「选择数据源后自动关闭」这个设置真正生效

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
@@ -69,7 +69,7 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
     /**
      * 在点击选择剧集后, 立即隐藏 media selector
      */
-    val hideSelectorOnSelect: Boolean = false,
+    val hideSelectorOnSelect: Boolean = true,
     /**
      * 横屏时自动全屏
      */
@@ -228,7 +228,7 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
             videoEnhancementDefaultMode = VideoEnhancementDefaultMode.OFF,
             pauseVideoOnEditDanmaku = false,
             autoMarkDone = false,
-            hideSelectorOnSelect = false,
+            hideSelectorOnSelect = true,
             autoFullscreenOnLandscapeMode = false,
             autoPlayNext = false,
             autoSkipOpEd = false,

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/VideoScaffoldConfig.kt
@@ -228,7 +228,7 @@ data class VideoScaffoldConfig @SerializationOnly constructor(
             videoEnhancementDefaultMode = VideoEnhancementDefaultMode.OFF,
             pauseVideoOnEditDanmaku = false,
             autoMarkDone = false,
-            hideSelectorOnSelect = true,
+            hideSelectorOnSelect = false,
             autoFullscreenOnLandscapeMode = false,
             autoPlayNext = false,
             autoSkipOpEd = false,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -577,6 +577,7 @@ private fun EpisodeScreenTabletVeryWide(
                                     { page.mediaSourceResultListPresentation },
                                     page.selfInfo,
                                     modifier = Modifier.fillMaxSize(),
+                                    hideSelectorOnSelect = vm.videoScaffoldConfig.hideSelectorOnSelect,
                                     onSwitchEpisode = { episodeId ->
                                         if (!vm.episodeSelectorState.selectEpisodeId(episodeId)) {
                                             navigator.navigateEpisodeDetails(vm.subjectId, episodeId)
@@ -746,6 +747,7 @@ private fun EpisodeScreenContentPhone(
                     page.mediaSelectorState,
                     { page.mediaSourceResultListPresentation },
                     page.selfInfo,
+                    hideSelectorOnSelect = vm.videoScaffoldConfig.hideSelectorOnSelect,
                     onSwitchEpisode = { episodeId ->
                         if (!vm.episodeSelectorState.selectEpisodeId(episodeId)) {
                             navigator.navigateEpisodeDetails(vm.subjectId, episodeId)
@@ -1161,6 +1163,7 @@ private fun EpisodeVideo(
                             onDismissRequest = { goBack() },
                             onRefresh = { vm.refreshFetch() },
                             onRestartSource = { vm.restartSource(it) },
+                            hideOnSelect = vm.videoScaffoldConfig.hideSelectorOnSelect,
                         )
                     }
                 },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -220,6 +220,7 @@ fun EpisodeDetails(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
     danmakuListState: DanmakuListState? = null,
+    hideSelectorOnSelect: Boolean = true,
 ) {
     var showSubjectDetails by rememberSaveable {
         mutableStateOf(false)
@@ -410,7 +411,9 @@ fun EpisodeDetails(
                                 stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
                                 onClickItem = {
                                     mediaSelectorState.select(it)
-                                    showMediaSelector = false
+                                    if (hideSelectorOnSelect) {
+                                        showMediaSelector = false
+                                    }
                                 },
                                 scrollable = true,
                             )
@@ -444,7 +447,9 @@ fun EpisodeDetails(
                             stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
                             onClickItem = {
                                 mediaSelectorState.select(it)
-                                showMediaSelector = false
+                                if (hideSelectorOnSelect) {
+                                    showMediaSelector = false
+                                }
                             },
                             scrollable = sheetState.targetValue == SheetValue.Expanded,
                         )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
@@ -57,6 +57,7 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
     onRefresh: () -> Unit,
     onRestartSource: (instanceId: String) -> Unit,
     modifier: Modifier = Modifier,
+    hideOnSelect: Boolean = true,
 ) {
     val selectMediaSourceText = stringResource(Lang.subject_episode_select_media_source)
     val closeSelectorText = stringResource(Lang.subject_episode_close_selector)
@@ -86,7 +87,9 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
             stickyHeaderBackgroundColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             onClickItem = {
                 mediaSelectorState.select(it)
-                onDismissRequest()
+                if (hideOnSelect) {
+                    onDismissRequest()
+                }
             },
             singleLineFilter = true,
         )


### PR DESCRIPTION
## 问题

`VideoScaffoldConfig.hideSelectorOnSelect` 是个**死开关**: 字段在、设置页里的 `SwitchItem` 也在
(`AppSettingsTab.kt`), 但**没有任何地方读它**。三处选中数据源的位置都是无条件关闭面板:

- `EpisodeDetails.kt` 两处 `onClickItem` 里的 `showMediaSelector = false`
- `EpisodeVideoMediaSelectorSideSheet.kt` 的 `onClickItem` 里的 `onDismissRequest()`

用户拨动这个开关不会有任何变化。

以前没暴露是因为默认值 `false` 与"没接线"的表现恰好一致 —— 面板反正都会关, 看不出开关有没有生效。

## 影响范围

所有形态。开关本身对用户可见 (设置 - 播放器)，所以是"设置改了没用"这一类。

## 改动

1. 接线三处调用点: `EpisodeDetails` 新增 `hideSelectorOnSelect`、`MediaSelectorSheet` 新增
   `hideOnSelect`，由 `EpisodePage` 传 `vm.videoScaffoldConfig.hideSelectorOnSelect`。
2. **默认值 `false` → `true`** (字段声明与 `VideoScaffoldConfig.Default` 两处)。

第 2 点是必需的: 现有行为就是"选完即关", 只接线而不改默认值的话, 所有现存用户的行为会在
升级的一刻被翻转成"选完不关"。改成 `true` 之后**默认行为一字不变**, 只是开关终于能用了。

两个新参数都给了 `= true` 的默认值, 其它调用方 (若有) 行为不变。

## 验证

`./gradlew :app:android:compileDefaultDebugKotlin` BUILD SUCCESSFUL。

手动: 设置 - 播放器 - 「选择数据源后自动关闭」关掉后, 在播放页与详情页的数据源面板里连续切换
不同的源, 面板保持打开; 打开该项则恢复原来的行为。
