### PR TITLE
fix(desktop): force JCEF to the X11 backend on Wayland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1943,3 +1943,11 @@ jobs:
         ANI_APPIMAGE="${{ github.workspace }}/ci-helper/verify/Animeko-x86_64.AppImage"
         chmod +x "$ANI_APPIMAGE"
         ANIMEKO_DESKTOP_TEST_TASK="sqlite-bundled-load-test" "$ANI_APPIMAGE"
+    - id: 'step-7'
+      name: 'Check that JCEF can be initialized'
+      timeout-minutes: 5
+      shell: 'bash'
+      run: |-
+        ANI_APPIMAGE="${{ github.workspace }}/ci-helper/verify/Animeko-x86_64.AppImage"
+        chmod +x "$ANI_APPIMAGE"
+        XDG_SESSION_TYPE=wayland WAYLAND_DISPLAY=wayland-0 xvfb-run --auto-servernum env ANIMEKO_DESKTOP_TEST_TASK="jcef-init-test" "$ANI_APPIMAGE"

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -650,6 +650,10 @@ fun getVerifyJobBody(
          * 指定此项, 则在所有的 Runner 上执行, 但在指定的 Runner 上不执行.
          */
         val disabledOn: List<Runner>? = null,
+        /**
+         * 在虚拟 X11 显示器中运行此任务.
+         */
+        val runWithXvfb: Boolean = false,
     )
 
     val tasksToExecute = listOf(
@@ -685,6 +689,12 @@ fun getVerifyJobBody(
             name = "sqlite-bundled-load-test",
             step = "Check that bundled SQLite can be loaded",
             enabledOnlyOn = listOf(Runner.GithubWindows11Arm64, Runner.GithubUbuntu2404),
+        ),
+        VerifyTask(
+            name = "jcef-init-test",
+            step = "Check that JCEF can be initialized",
+            enabledOnlyOn = listOf(Runner.GithubUbuntu2404),
+            runWithXvfb = true,
         ),
     ).filter { task ->
         // Filter task that should execute on this runner.
@@ -752,6 +762,11 @@ fun getVerifyJobBody(
             tasksToExecute.forEach { task ->
                 val appimagePath =
                     """${expr { github.workspace }}/ci-helper/verify/Animeko-x86_64.AppImage"""
+                val commandPrefix = if (task.runWithXvfb) {
+                    "XDG_SESSION_TYPE=wayland WAYLAND_DISPLAY=wayland-0 xvfb-run --auto-servernum env " + ""
+                } else {
+                    ""
+                }
                 run(
                     name = task.step,
                     shell = Shell.Bash,
@@ -759,7 +774,7 @@ fun getVerifyJobBody(
                         $$"""
                             ANI_APPIMAGE="$$appimagePath"
                             chmod +x "$ANI_APPIMAGE"
-                            ANIMEKO_DESKTOP_TEST_TASK="$${task.name}" "$ANI_APPIMAGE"
+                            $${commandPrefix}ANIMEKO_DESKTOP_TEST_TASK="$${task.name}" "$ANI_APPIMAGE"
                         """.trimIndent(),
                     ),
                     `if` = task.`if`,

--- a/app/desktop/src/main/kotlin/TestTasks.kt
+++ b/app/desktop/src/main/kotlin/TestTasks.kt
@@ -16,6 +16,7 @@ import me.him188.ani.app.domain.foundation.ScopedHttpClientUserAgent
 import me.him188.ani.app.data.persistent.database.BundledSqliteInterpositionGuard
 import me.him188.ani.app.data.persistent.database.SqliteGlobalScopeProbe
 import me.him188.ani.app.domain.foundation.get
+import me.him188.ani.app.platform.AniCefApp
 import me.him188.ani.app.platform.DesktopContext
 import me.him188.ani.app.platform.currentAniBuildConfig
 import me.him188.ani.app.tools.update.DefaultFileDownloader
@@ -58,6 +59,11 @@ object TestTasks {
                 exitProcess(0)
             }
 
+            "jcef-init-test" -> {
+                checkJcef(context)
+                exitProcess(0)
+            }
+
             "download-update-and-install" -> {
                 downloadUpdateAndInstall(args, context)
             }
@@ -97,6 +103,20 @@ object TestTasks {
             FFmpegKit().execute(listOf("-version"))
         }
         check(result.isSuccess) { "FFmpeg smoke test failed: $result" }
+    }
+
+    // Asserts that JCEF can reach the INITIALIZED state under the same X11-fallback path
+    // that the AppImage's CI verify job exercises (xvfb-run with XDG_SESSION_TYPE=wayland),
+    // which is the Wayland session that crashes Chromium's default display backend (#3359).
+    private fun checkJcef(context: DesktopContext) {
+        runBlocking {
+            AniCefApp.initialize(
+                logDir = context.logsDir,
+                cacheDir = context.cacheDir.resolve("jcef-cache"),
+            )
+        }
+        logger.info { "JCEF initialization check succeeded." }
+        AniCefApp.disposeBlocking()
     }
 
     private fun checkBundledSqlite() {

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt
@@ -148,6 +148,11 @@ object AniCefApp {
                 add("--use-gl=angle")
                 add("--use-angle=swiftshader-webgl")
 
+                // Chromium's default display backend crashes the CEF browser process (SIGTRAP)
+                // on Wayland sessions before the GPU process is usable, so JCEF never reaches
+                // the INITIALIZED state. Force the X11 (XWayland) backend, which is stable.
+                add("--ozone-platform=x11")
+
                 // will cause 139 (segfault)
                 // add("--disable-gpu")
                 // add("--disable-software-rasterizer")


### PR DESCRIPTION
## What

Chromium's default display backend crashes the CEF browser process (SIGTRAP) on **Wayland** sessions before the GPU process is usable, so JCEF never reaches `INITIALIZED`. ani then throws `JCEFInitializationException ... state: TERMINATED` shortly after launch, which breaks the in-app login page and any embedded-browser flow on Wayland desktops.

This forces the **X11 (XWayland)** backend for the Linux JCEF args via `--ozone-platform=x11`, the same stable fallback already used next to the stricter `--use-gl=angle` / `--use-angle=swiftshader-webgl` settings.

## Why it matters

- Desktop on a Wayland session (e.g. Ubuntu 26.04 / GNOME Wayland) fails to initialize JCEF **every launch** (`CefApp.init ... TERMINATED`), while Windows/macOS/X11 desktops work.
- The **Android** app works on the same sources because it uses the platform WebView instead of JCEF — this restores parity on Linux/Wayland.

## Verification

Built and ran the desktop app on Wayland with and without the flag:

- **Without**: `JCEFInitializationException: Failed to initialize JCEF, state: TERMINATED` on every launch.
- **With**: `app.platform.AniCefApp: JCEF is initialized.` in ~0.4s; the `jcef_helper --type=zygote` subprocess starts normally.

## Related

Related JCEF-on-Linux stabilization work:
- #3145 uses SwiftShader for JCEF on Linux
- #3144 / #3214 stabilize the Linux native runtime startup
- #3010 adds missing JCEF resources/locales on Linux packaging