### PR TITLE
fix(ui): 强制指定移动端顶端时间文本颜色，以解决看不清文本的问题

### DIFF
--- a/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/VideoScaffold.kt
@@ -216,7 +216,9 @@ fun VideoScaffold(
                                     .padding(top = 8.dp),
                                 contentAlignment = Alignment.TopCenter,
                             ) {
-                                centerOverlay()
+                                CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+                                    centerOverlay()
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
使用时发现浅色模式下播放器顶端时间部分为黑色字体
于是照着番剧标题套了一层
现在是白色字体了