### PR TITLE
fix(collection): 修复追番条目菜单自动关闭

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
@@ -375,6 +375,12 @@ fun CollectionPage(
                     items,
                     item = { collection ->
                         var nsfwModeState: NsfwMode by rememberSaveable(collection) { mutableStateOf(collection.nsfwMode) }
+                        val editableSubjectCollectionTypeState = remember(
+                            collection.subjectId,
+                            collection.collectionType,
+                        ) {
+                            state.createEditableSubjectCollectionTypeState(collection)
+                        }
                         NsfwMask(
                             nsfwModeState,
                             onTemporarilyDisplay = { nsfwModeState = NsfwMode.DISPLAY },
@@ -384,7 +390,7 @@ fun CollectionPage(
                                 collection,
                                 { onCollectionUpdate(collection.subjectId, it) },
                                 state.subjectProgressStateFactory,
-                                state.createEditableSubjectCollectionTypeState(collection),
+                                editableSubjectCollectionTypeState,
                             )
                         }
                     },

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
@@ -41,12 +41,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.AndroidUiModes.UI_MODE_NIGHT_YES
 import androidx.compose.ui.tooling.preview.AndroidUiModes.UI_MODE_TYPE_NORMAL
@@ -226,6 +230,8 @@ private fun SubjectCollectionItemContent(
     playButton: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showEditCollectionTypeMenu by remember { mutableStateOf(false) }
+
     Column(modifier) {
         // 标题和右上角菜单
         Row(
@@ -243,13 +249,18 @@ private fun SubjectCollectionItemContent(
 
             Box {
                 IconButton(
-                    { editableSubjectCollectionTypeState.showDropdown = true },
-                    Modifier.fillMaxHeight().padding(),
+                    { showEditCollectionTypeMenu = true },
+                    Modifier.fillMaxHeight().padding().testTag(SubjectCollectionItemTestTags.MoreButton),
                 ) {
                     Icon(Icons.Outlined.MoreVert, null, Modifier.size(24.dp))
                 }
 
-                EditCollectionTypeDropDown(editableSubjectCollectionTypeState)
+                EditCollectionTypeDropDown(
+                    editableSubjectCollectionTypeState,
+                    expanded = showEditCollectionTypeMenu,
+                    onDismissRequest = { showEditCollectionTypeMenu = false },
+                    modifier = Modifier.testTag(SubjectCollectionItemTestTags.EditCollectionTypeMenu),
+                )
             }
         }
 
@@ -283,6 +294,11 @@ private fun SubjectCollectionItemContent(
             Box(Modifier.width(IntrinsicSize.Min)) { playButton() }
         }
     }
+}
+
+object SubjectCollectionItemTestTags {
+    const val MoreButton = "SubjectCollectionItemMoreButton"
+    const val EditCollectionTypeMenu = "SubjectCollectionItemEditCollectionTypeMenu"
 }
 
 

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditCollectionTypeDropDown.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditCollectionTypeDropDown.kt
@@ -38,6 +38,8 @@ import org.jetbrains.compose.resources.*
 @Composable
 fun EditCollectionTypeDropDown(
     state: EditableSubjectCollectionTypeState,
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val presentation by state.presentationFlow.collectAsStateWithLifecycle()
@@ -46,10 +48,9 @@ fun EditCollectionTypeDropDown(
 
     EditCollectionTypeDropDown(
         currentType = presentation.selfCollectionType,
-        expanded = state.showDropdown,
-        onDismissRequest = { state.showDropdown = false },
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
         onClick = {
-            state.showDropdown = false
             scope.launch {
                 val error = state.setSelfCollectionType(it.type)
                 if (error != null) {

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditableSubjectCollectionTypeButton.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/components/EditableSubjectCollectionTypeButton.kt
@@ -21,10 +21,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -77,11 +75,6 @@ class EditableSubjectCollectionTypeState(
      * 是否显示 "将所有剧集标记为看过" 对话框
      */
     private val showSetAllEpisodesDoneDialogFlow = MutableStateFlow(false)
-
-    /**
-     * 是否显示下拉菜单, 选择需要修改为的状态
-     */
-    var showDropdown by mutableStateOf(false)
 
     /**
      * [setSelfCollectionType] 的后台任务

--- a/app/shared/ui-subject/src/desktopTest/kotlin/ui/subject/collection/SubjectCollectionItemTest.kt
+++ b/app/shared/ui-subject/src/desktopTest/kotlin/ui/subject/collection/SubjectCollectionItemTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.collection
+
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.flow.MutableStateFlow
+import me.him188.ani.app.data.models.subject.TestSubjectCollections
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.app.ui.subject.collection.components.createTestEditableSubjectCollectionTypeState
+import me.him188.ani.utils.platform.annotations.TestOnly
+import kotlin.test.Test
+
+@OptIn(TestOnly::class)
+class SubjectCollectionItemTest {
+    @Test
+    fun `edit collection menu stays open when action state is replaced`() = runAniComposeUiTest {
+        val recompositionTrigger = mutableIntStateOf(0)
+
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                val collection = TestSubjectCollections.first()
+                val collectionType = remember { MutableStateFlow(collection.collectionType) }
+                val backgroundScope = rememberCoroutineScope()
+                recompositionTrigger.intValue
+                val editableState = createTestEditableSubjectCollectionTypeState(
+                    collectionType,
+                    backgroundScope,
+                )
+
+                SubjectCollectionItem(
+                    item = collection,
+                    editableSubjectCollectionTypeState = editableState,
+                    onClick = {},
+                    onShowEpisodeList = {},
+                    playButton = {},
+                )
+            }
+        }
+
+        onNodeWithTag(SubjectCollectionItemTestTags.MoreButton).performClick()
+        onNodeWithTag(SubjectCollectionItemTestTags.EditCollectionTypeMenu).assertIsDisplayed()
+
+        runOnIdle { recompositionTrigger.intValue++ }
+
+        onNodeWithTag(SubjectCollectionItemTestTags.EditCollectionTypeMenu).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## 修复内容

- 将追番条目菜单的展开状态移至列表项本地 Compose 状态
- 按条目与收藏类型稳定复用收藏操作状态，避免列表重组时重建
- 解耦菜单 UI 状态与收藏业务操作状态
- 添加列表项重组后的菜单状态回归测试

## 验证

- `:app:shared:ui-subject:desktopTest --tests 'me.him188.ani.app.ui.subject.collection.SubjectCollectionItemTest'`
- `:app:shared:ui-subject:compileKotlinDesktop`
- `git diff --check`