### PR TITLE
fix(collection): 收藏分类末页不满一页时无限重复刷新, 导致列表反复重排

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectCollectionRepository.kt
@@ -114,7 +114,7 @@ sealed class SubjectCollectionRepository(
     abstract fun subjectCollectionsPager(
         query: CollectionsFilterQuery = CollectionsFilterQuery.Empty,
         pagingConfig: PagingConfig = PagingConfig(
-            pageSize = 10,
+            pageSize = 30,
             prefetchDistance = 30,
         ),
     ): Flow<PagingData<SubjectCollectionInfo>>
@@ -466,6 +466,7 @@ class SubjectCollectionRepositoryImpl(
                     ?: return@withContext MediatorResult.Success(endOfPaginationReached = true)
                 logger.debug { "${loadType}, Loading $offset, limit=$limit" }
 
+                var endOfPaginationReached = false
                 fetchAndSaveSubjectCollectionsWithEpisodes(
                     type = query.type,
                     limit = limit,
@@ -477,13 +478,13 @@ class SubjectCollectionRepositoryImpl(
                             subjectCollectionDao.deleteAll(query.type)
                         }
 
-                        if (items.isEmpty()) {
-                            return@withContext MediatorResult.Success(endOfPaginationReached = items.isEmpty())
-                        }
+                        // 拿到的数量小于请求的 limit 就代表这是最后一页, 否则总数不是 limit 整数倍时
+                        // 会永远在同一个 offset 重复请求, 造成无限刷新循环 (列表反复重排/跳动)
+                        endOfPaginationReached = items.size < limit
                     },
                 )
 
-                MediatorResult.Success(endOfPaginationReached = false)
+                MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
             }
         } catch (e: Exception) {
             MediatorResult.Error(RepositoryException.wrapOrThrowCancellation(e))


### PR DESCRIPTION
RemoteMediator 判断"是否读完"只看这次是否拿到 0 条, 没检查拿到的数量是否
小于请求的 limit. 只要某个收藏分类的总数不是 pageSize 的整数倍, 最后一页
必定不满 limit 但也不为空, 于是永远在同一个 offset 判定"还没读完", 不断
重新请求、写回本地数据库, 每次写入都触发列表重新排序 —— 表现为收藏页卡片
不断跳动/自动多滚动几格.

改为 items.size < limit 才是真正的末页判断. 同时把 pageSize 从 10 提到 30, 减少首次加载时的分页次数, 降低期间列表重排的观感抖动.