### PR TITLE
Fix: 移除 AniApp 根节点 clickable，避免语义合并触发 Layout Inspector 崩溃

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/main/AniApp.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniApp.kt
@@ -9,9 +9,6 @@
 
 package me.him188.ani.app.ui.main
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
@@ -19,10 +16,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.flow.Flow
@@ -55,6 +49,7 @@ import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.input.ActiveInputSourceState
 import me.him188.ani.app.ui.foundation.input.LocalActiveInputSource
 import me.him188.ani.app.ui.foundation.input.trackActiveInputSource
+import me.him188.ani.app.ui.foundation.interaction.clearFocusOnUnhandledTap
 import me.him188.ani.app.ui.foundation.navigation.LocalBackDispatcher
 import me.him188.ani.app.ui.foundation.navigation.onBackNavigationInput
 import me.him188.ani.app.ui.foundation.rememberAniSketchInstance
@@ -150,8 +145,6 @@ fun AniApp(
         LocalPlatformFontFamily provides rememberPlatformFontFamily(appState.platformFont),
         LocalActiveInputSource provides remember { ActiveInputSourceState() },
     ) {
-        val focusManager by rememberUpdatedState(LocalFocusManager.current)
-        val keyboard by rememberUpdatedState(LocalSoftwareKeyboardController.current)
         val backDispatcher = LocalBackDispatcher.current
 
         AniTheme {
@@ -160,13 +153,7 @@ fun AniApp(
                     .trackActiveInputSource(LocalActiveInputSource.current)
                     .onBackNavigationInput(backDispatcher::onBackPressed)
                     .ifThen(LocalPlatform.current.isMobile()) {
-                        focusable(false).clickable(
-                            remember { MutableInteractionSource() },
-                            null,
-                        ) {
-                            keyboard?.hide()
-                            focusManager.clearFocus()
-                        }
+                        clearFocusOnUnhandledTap()
                     },
             ) {
                 Box {

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/interaction/Ime.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/interaction/Ime.kt
@@ -1,5 +1,6 @@
 package me.him188.ani.app.ui.foundation.interaction
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
@@ -17,8 +18,29 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+
+/**
+ * 当后代没有消费 tap 时清除焦点并隐藏软键盘.
+ *
+ * 清除焦点是 pointer side effect, 并不是可访问的 click action, 因此这里刻意使用不带语义的
+ * pointer input. 若在 APP 根节点使用 `clickable`, 会合并整个后代语义树, 并把本来不是控件的背景
+ * 暴露为无障碍点击操作.
+ */
+fun Modifier.clearFocusOnUnhandledTap(): Modifier = composed {
+    val focusManager by rememberUpdatedState(LocalFocusManager.current)
+    val keyboard by rememberUpdatedState(LocalSoftwareKeyboardController.current)
+
+    pointerInput(Unit) {
+        detectTapGestures {
+            keyboard?.hide()
+            focusManager.clearFocus()
+        }
+    }
+}
 
 @OptIn(ExperimentalLayoutApi::class)
 fun Modifier.clearFocusOnKeyboardDismiss(onClear: (() -> Unit)? = null): Modifier = composed {

--- a/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/interaction/ClearFocusOnTapTest.kt
+++ b/app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/interaction/ClearFocusOnTapTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.foundation.interaction
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClearFocusOnTapTest {
+    @Test
+    fun `does not merge a descendant pane title`() = runAniComposeUiTest {
+        setContent {
+            Box(
+                Modifier
+                    .size(100.dp)
+                    .clearFocusOnUnhandledTap()
+                    .testTag("root"),
+            ) {
+                Box(Modifier.semantics { paneTitle = "Reminder" })
+            }
+        }
+
+        // Layout Inspector reads the merged tree. This used to throw while merging PaneTitle.
+        onNodeWithTag("root").fetchSemanticsNode()
+    }
+
+    @Test
+    fun `handled descendant tap keeps focus while background tap clears it`() = runAniComposeUiTest {
+        val focusRequester = FocusRequester()
+        val keyboard = RecordingSoftwareKeyboardController()
+        setContent {
+            CompositionLocalProvider(LocalSoftwareKeyboardController provides keyboard) {
+                Box(
+                    Modifier
+                        .size(100.dp)
+                        .clearFocusOnUnhandledTap()
+                        .testTag("root"),
+                ) {
+                    Box(
+                        Modifier
+                            .size(40.dp)
+                            .focusRequester(focusRequester)
+                            .clickable {}
+                            .testTag("child"),
+                    )
+                }
+            }
+        }
+
+        runOnIdle { focusRequester.requestFocus() }
+        onNodeWithTag("child")
+            .assertIsFocused()
+            .performTouchInput { click() }
+            .assertIsFocused()
+        runOnIdle { assertEquals(0, keyboard.hideCount) }
+
+        onNodeWithTag("root", useUnmergedTree = true).performTouchInput {
+            click(bottomRight - Offset(1f, 1f))
+        }
+        onNodeWithTag("child").assertIsNotFocused()
+        runOnIdle { assertEquals(1, keyboard.hideCount) }
+    }
+
+    private class RecordingSoftwareKeyboardController : SoftwareKeyboardController {
+        var hideCount = 0
+            private set
+
+        override fun show() = Unit
+
+        override fun hide() {
+            hideCount++
+        }
+    }
+}


### PR DESCRIPTION
### 背景

在特定场景下（Snackbar 出现时打开 Layout Inspector）会触发 `IllegalStateException`。此前一度怀疑与 Layout Inspector 本身或 Compose 版本有关，但排查后确认这只是外部诱因,真正的问题出在应用自身的语义树结构上。

### 根因

`AniApp` 的根节点上挂了 `focusable(false).clickable(...)`，用来实现"点击空白处收起键盘"。但 `clickable` 会自动为其启用**后代语义合并**（merge descendant semantics）——这意味着整个应用树的语义都会被合并到根节点上。

问题在于 `Snackbar` 内部的 `PaneTitle` 语义节点明确禁止被合并。当 Snackbar 出现、根节点又在合并所有后代语义时,两者产生冲突,Layout Inspector 读取合并树时就会抛出异常。

也就是说：

- Snackbar 只是触发条件
- Layout Inspector 只是把这个本来就存在的问题求值暴露了出来
- 真正的 bug 是根节点上不该有的 `clickable`

参考：[Compose 语义文档](https://developer.android.com/develop/ui/compose/accessibility/semantics)、[PaneTitle 源码](https://github.com/androidx/androidx/blob/androidx-main/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/semantics/SemanticsProperties.kt)、[#3377](https://github.com/open-ani/animeko/issues/3377)

### 修复内容

- 新增 `clearFocusOnUnhandledTap()`(`app/shared/ui-foundation/.../interaction/Ime.kt:26`),用无语义的 `pointerInput + detectTapGestures` 实现背景点击检测
- 移除 `AniApp.kt:151` 根节点上的 `focusable(false).clickable(...)`
- 行为保持不变：点击未处理的空白区域仍会收起键盘;点击按钮、输入框等已消费事件的子控件不会误清焦点
- 不再把整个 App 伪装成一个可点击的无障碍控件——对于只需要手势、不需要语义/焦点/hover 行为的场景，官方也推荐下沉到 `pointerInput`([官方手势指南](https://developer.android.com/develop/ui/compose/touch-input/pointer-input/tap-and-press))

### 测试

新增回归测试：`app/shared/ui-foundation/src/desktopTest/kotlin/ui/foundation/interaction/ClearFocusOnTapTest.kt:31`

旧实现可稳定复现相同的 `PaneTitle` 异常；修复后以下均验证通过：

- [x] 合并语义树读取正常
- [x] 子控件点击后焦点保持不变
- [x] 背景点击可正常清除焦点
- [x] Desktop 主模块编译通过
- [x] Android 主模块编译通过

closes #3377