### PR TITLE
Extend subject relations cache expiry from 1 hour to 3 days

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectRelationsRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectRelationsRepository.kt
@@ -42,6 +42,7 @@ import me.him188.ani.utils.platform.collections.mapToIntArray
 import me.him188.ani.utils.platform.currentTimeMillis
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -75,7 +76,8 @@ class DefaultSubjectRelationsRepository(
     private val aniSubjectRelationIndexService: AniSubjectRelationIndexService,
     defaultDispatcher: CoroutineContext = Dispatchers.Default,
     private val autoRefreshPeriod: Duration = 1.hours,
-    private val cacheExpiry: Duration = 1.hours,
+    // 角色与制作人员几乎不变, 过期时间不宜太短: 该接口曾占服务端出站流量的一半以上.
+    private val cacheExpiry: Duration = 3.days,
 ) : SubjectRelationsRepository(defaultDispatcher) {
     override fun subjectSequelSubjectIdsFlow(subjectId: Int): Flow<List<Int>> = flow {
         emit(


### PR DESCRIPTION
## Summary

- `SubjectRelationsRepository.cacheExpiry` 从 1 小时改为 3 天。角色与制作人员几乎不变，但每次打开条目页超过 1 小时就会重新下载 50–60 KB。
- 服务端日志抽样显示 `/v2/subjects/{id}/characters` 和 `/staff` 占 API 出站流量约 60%。配套的服务端改动在 open-ani/ani-api-server 的 "Cut egress" PR 里（列表接口去掉 person summary/infobox）。

## Test plan

- [x] `:app:shared:app-data:compileKotlinDesktop` 通过
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)