### PR TITLE
Fix Emby season matching when isolated series include specials

### DIFF
--- a/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
+++ b/datasource/jellyfin/src/commonMain/kotlin/BaseJellyfinMediaSource.kt
@@ -231,8 +231,10 @@ abstract class BaseJellyfinMediaSource(
                             isExplicitSeasonTitle && candidate.hasExactContainerTitle(searchName)
                         val hasIsolatedSeriesEvidence =
                             seriesSubjectMatch == ProviderIdMatch.MATCH || matchesExplicitSeasonTitle
-                        val usesLocalSeasonNumbering =
-                            seasons.size == 1 && hasIsolatedSeriesEvidence
+                        // S00 specials do not make an isolated series a multi-season library.
+                        // Only its sole non-special season can use the series' subject identity.
+                        val locallyNumberedSeason = seasons.singleOrNull { it.IndexNumber != 0 }
+                            ?.takeIf { hasIsolatedSeriesEvidence }
                         val matchedSeasons = seasons.mapNotNull { season ->
                             val seasonSubjectMatch = season.containerSubjectIdMatch(query)
                             when {
@@ -240,7 +242,7 @@ abstract class BaseJellyfinMediaSource(
                                 seasonSubjectMatch == ProviderIdMatch.MATCH ->
                                     MatchedSeason(season, inheritedSubjectMatch = true)
 
-                                usesLocalSeasonNumbering ->
+                                season == locallyNumberedSeason ->
                                     MatchedSeason(
                                         season,
                                         inheritedSubjectMatch =

--- a/datasource/jellyfin/src/commonTest/kotlin/LocalSeasonNumberingTest.kt
+++ b/datasource/jellyfin/src/commonTest/kotlin/LocalSeasonNumberingTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.datasources.jellyfin
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.source.MatchKind
+import me.him188.ani.datasources.api.source.MediaFetchRequest
+import me.him188.ani.datasources.api.source.MediaSourceConfig
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LocalSeasonNumberingTest {
+    @Test
+    fun `isolated Yuru Camp seasons with specials return only the regular episode`() = runTest {
+        for (season in 1..3) {
+            assertSeasonSelection(subjectName = "Yuru Camp Season $season")
+        }
+    }
+
+    @Test
+    fun `matching series provider id permits local numbering with specials`() = runTest {
+        assertSeasonSelection(seriesName = "Yuru Camp", seriesProviderId = "123")
+    }
+
+    @Test
+    fun `generic series with specials does not supply a missing later season`() = runTest {
+        assertSeasonSelection(seriesName = "Yuru Camp", expectedSeasons = emptyList())
+    }
+
+    @Test
+    fun `multiple regular seasons still select the requested global season`() = runTest {
+        assertSeasonSelection(seasons = listOf(0, 1, 2), expectedSeasons = listOf(2))
+    }
+
+    @Test
+    fun `multiple regular seasons do not supply a missing later season`() = runTest {
+        assertSeasonSelection(
+            subjectName = "Yuru Camp Season 3",
+            seasons = listOf(0, 1, 2),
+            expectedSeasons = emptyList(),
+        )
+    }
+
+    @Test
+    fun `specials alone are not reinterpreted as a regular season`() = runTest {
+        assertSeasonSelection(seasons = listOf(0), expectedSeasons = emptyList())
+    }
+
+    @Test
+    fun `conflicting season provider id rejects local numbering with specials`() = runTest {
+        assertSeasonSelection(
+            seriesProviderId = "123",
+            seasonProviderId = "other-subject",
+            expectedSeasons = emptyList(),
+        )
+    }
+
+    @Test
+    fun `conflicting episode provider ids reject locally numbered episodes with specials`() = runTest {
+        for (providerIds in listOf(
+            """{"BangumiSubject":"other-subject"}""",
+            """{"Bangumi":"other-episode"}""",
+        )) {
+            assertSeasonSelection(
+                seriesProviderId = "123",
+                episodeProviderIds = providerIds,
+                expectedEpisodeSeasons = emptyList(),
+            )
+        }
+    }
+
+    private suspend fun assertSeasonSelection(
+        subjectName: String = "Yuru Camp Season 2",
+        seriesName: String = subjectName,
+        seasons: List<Int> = listOf(0, 1),
+        seriesProviderId: String? = null,
+        seasonProviderId: String? = null,
+        episodeProviderIds: String = "{}",
+        expectedSeasons: List<Int> = listOf(1),
+        expectedEpisodeSeasons: List<Int> = expectedSeasons,
+    ) {
+        val seasonItems = seasons.joinToString(",") { season ->
+            """
+            {"Name":"${seasonName(season)}","Type":"Season","Id":"season-$season",
+             "IndexNumber":$season,"ProviderIds":${subjectProviderIds(seasonProviderId)}}
+            """.trimIndent()
+        }
+        val episodes = seasons.associateWith { season ->
+            """
+            {"Name":"S${season}E01","SeriesName":"$seriesName","SeasonName":"${seasonName(season)}",
+             "Type":"Episode","Id":"episode-$season-1","IndexNumber":1,"ParentIndexNumber":$season,
+             "ProviderIds":$episodeProviderIds}
+            """.trimIndent()
+        }
+
+        for (factory in listOf(JellyfinMediaSource.Factory(), EmbyMediaSource.Factory())) {
+            val requestedSeasons = mutableListOf<Int>()
+            val client = HttpClient(MockEngine { request ->
+                val items = when {
+                    request.url.parameters["searchTerm"] != null -> """
+                        {"Name":"$seriesName","Type":"Series","Id":"series",
+                         "ProviderIds":${subjectProviderIds(seriesProviderId)}}
+                    """.trimIndent()
+
+                    request.url.encodedPath == "/Shows/series/Seasons" -> seasonItems
+                    request.url.encodedPath == "/Shows/series/Episodes" -> {
+                        val season = checkNotNull(request.url.parameters["Season"]).toInt()
+                        requestedSeasons += season
+                        episodes.getValue(season)
+                    }
+
+                    request.url.parameters["parentId"] == "series" -> episodes.values.joinToString(",")
+                    request.url.parameters["ids"] != null -> {
+                        val ids = request.url.parameters["ids"]!!.split(",")
+                        episodes.filterKeys { "episode-$it-1" in ids }.values.joinToString(",")
+                    }
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+                respond(
+                    content = """{"Items":[$items]}""",
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            }
+            try {
+                val source = factory.create(
+                    mediaSourceId = factory.factoryId.value,
+                    config = MediaSourceConfig(
+                        arguments = mapOf(
+                            "baseUrl" to "https://media.example",
+                            "userId" to "user-id",
+                            "apikey" to "api-key",
+                        ),
+                    ),
+                    client = client.asScopedHttpClient(),
+                )
+                val result = source.fetch(
+                    MediaFetchRequest(
+                        subjectId = "123",
+                        episodeId = "456",
+                        subjectNameCN = subjectName,
+                        subjectNames = listOf(subjectName),
+                        episodeSort = EpisodeSort(1),
+                        episodeEp = EpisodeSort(1),
+                        episodeName = "Expected episode",
+                    ),
+                ).results.toList()
+
+                val context = "${factory.factoryId}: $subjectName / $seriesName / $seasons"
+                assertEquals(expectedEpisodeSeasons.map { "episode-$it-1" }, result.map { it.media.mediaId }, context)
+                assertEquals(expectedSeasons, requestedSeasons.distinct(), context)
+                assertTrue(result.all { it.kind == MatchKind.FUZZY }, context)
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    private fun seasonName(season: Int) = if (season == 0) "Specials" else "Season $season"
+
+    private fun subjectProviderIds(id: String?) = id?.let { """{"Bangumi":"$it"}""" } ?: "{}"
+}


### PR DESCRIPTION
Closes #3383

Fix Emby/Jellyfin lookup for libraries that store each anime season as a separate Series containing S00 specials and S01 regular episodes. An exact title such as `Yuru Camp Season 2` or `Yuru Camp Season 3` now resolves its locally numbered S01 instead of returning no resources.

Ignore S00 when identifying the sole regular season, and apply the local-numbering exception only to that season. Exact season-title or matching series Bangumi-ID evidence is still required; provider-ID conflicts and global season checks remain in place.

Add eight regression tests that exercise the real `fetch()` pipeline through both Emby and Jellyfin factories using Ktor MockEngine. Coverage includes Yuru Camp seasons 1–3 with specials, series provider-ID matching, generic titles, multiple regular seasons, specials-only libraries, and conflicting season/episode provider IDs.

Verification with JDK 21:

- Before the fix, the new desktop test class failed 4 of 8 tests, including the reported isolated-series case.
- `./gradlew :datasource:jellyfin:desktopTest :datasource:jellyfin:testAndroidHostTest` passed: 43 tests on each target, with no failures or skips.
- `./gradlew check` passed across the repository.
- `git diff --check` passed.

This change is confined to datasource matching and tests; it does not modify UI components. Verification uses simulated server responses, not a connection to the reporter's Emby server.
