### PR TITLE
feat(danmaku): 支持发送彩色弹幕和选择弹幕位置（顶部 / 滚动 / 底部）

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/DanmakuSettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/DanmakuSettings.kt
@@ -11,15 +11,31 @@ package me.him188.ani.app.data.models.preference
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import me.him188.ani.danmaku.api.DanmakuLocation
 
 @Serializable
 data class DanmakuSettings(
     val useGlobal: Boolean? = null,
 
+    /**
+     * 发送弹幕时使用的颜色, RGB (不含 alpha), 例如白色为 `0xFFFFFF`.
+     */
+    val sendColor: Int = DEFAULT_SEND_COLOR,
+
+    /**
+     * 发送弹幕时使用的位置.
+     */
+    val sendLocation: DanmakuLocation = DanmakuLocation.NORMAL,
+
     @Suppress("PropertyName")
     @Transient val _placeholder: Int = 0,
 ) {
     companion object {
+        /**
+         * 白色
+         */
+        const val DEFAULT_SEND_COLOR: Int = 0xFFFFFF
+
         val Default = DanmakuSettings()
     }
 }

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -1196,6 +1196,9 @@
     <string name="episode_danmaku_match_select_subject">选择条目</string>
     <string name="episode_danmaku_match_select_episode">选择剧集</string>
     <string name="episode_send_danmaku">发送弹幕</string>
+    <string name="danmaku_send_style">弹幕样式</string>
+    <string name="danmaku_send_style_color">颜色</string>
+    <string name="danmaku_send_style_location">位置</string>
     <string name="exploration_search_back_to_top">回到顶部</string>
     <string name="exploration_search_results_shown">已显示 %1$d 个结果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -1199,6 +1199,7 @@
     <string name="danmaku_send_style">弹幕样式</string>
     <string name="danmaku_send_style_color">颜色</string>
     <string name="danmaku_send_style_location">位置</string>
+    <string name="danmaku_send_style_custom_color">自定义颜色</string>
     <string name="exploration_search_back_to_top">回到顶部</string>
     <string name="exploration_search_results_shown">已显示 %1$d 个结果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -1172,6 +1172,7 @@
     <string name="danmaku_send_style">彈幕樣式</string>
     <string name="danmaku_send_style_color">顏色</string>
     <string name="danmaku_send_style_location">位置</string>
+    <string name="danmaku_send_style_custom_color">自訂顏色</string>
     <string name="exploration_search_back_to_top">回到頂部</string>
     <string name="exploration_search_results_shown">已顯示 %1$d 個結果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -1169,6 +1169,9 @@
     <string name="episode_danmaku_match_select_subject">選擇條目</string>
     <string name="episode_danmaku_match_select_episode">選擇劇集</string>
     <string name="episode_send_danmaku">發送彈幕</string>
+    <string name="danmaku_send_style">彈幕樣式</string>
+    <string name="danmaku_send_style_color">顏色</string>
+    <string name="danmaku_send_style_location">位置</string>
     <string name="exploration_search_back_to_top">回到頂部</string>
     <string name="exploration_search_results_shown">已顯示 %1$d 個結果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -1162,6 +1162,7 @@
     <string name="danmaku_send_style">彈幕樣式</string>
     <string name="danmaku_send_style_color">顏色</string>
     <string name="danmaku_send_style_location">位置</string>
+    <string name="danmaku_send_style_custom_color">自訂顏色</string>
     <string name="exploration_search_back_to_top">回到頂部</string>
     <string name="exploration_search_results_shown">已顯示 %1$d 個結果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -1159,6 +1159,9 @@
     <string name="episode_danmaku_match_select_subject">選擇條目</string>
     <string name="episode_danmaku_match_select_episode">選擇劇集</string>
     <string name="episode_send_danmaku">發送彈幕</string>
+    <string name="danmaku_send_style">彈幕樣式</string>
+    <string name="danmaku_send_style_color">顏色</string>
+    <string name="danmaku_send_style_location">位置</string>
     <string name="exploration_search_back_to_top">回到頂部</string>
     <string name="exploration_search_results_shown">已顯示 %1$d 個結果</string>
     <string name="exploration_search_sort_match">最佳匹配</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -1156,6 +1156,9 @@
     <string name="episode_danmaku_match_select_subject">Select subject</string>
     <string name="episode_danmaku_match_select_episode">Select episode</string>
     <string name="episode_send_danmaku">Send</string>
+    <string name="danmaku_send_style">Danmaku style</string>
+    <string name="danmaku_send_style_color">Color</string>
+    <string name="danmaku_send_style_location">Position</string>
     <string name="exploration_search_back_to_top">Back to top</string>
     <string name="exploration_search_results_shown">%1$d results shown</string>
     <string name="exploration_search_sort_match">Best match</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -1159,6 +1159,7 @@
     <string name="danmaku_send_style">Danmaku style</string>
     <string name="danmaku_send_style_color">Color</string>
     <string name="danmaku_send_style_location">Position</string>
+    <string name="danmaku_send_style_custom_color">Custom color</string>
     <string name="exploration_search_back_to_top">Back to top</string>
     <string name="exploration_search_results_shown">%1$d results shown</string>
     <string name="exploration_search_sort_match">Best match</string>

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
@@ -32,8 +32,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -49,7 +47,6 @@ import me.him188.ani.app.videoplayer.ui.playerTextInputFocus
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults
 import me.him188.ani.app.videoplayer.ui.rememberAlwaysOnRequester
 import me.him188.ani.danmaku.api.DanmakuContent
-import me.him188.ani.danmaku.api.DanmakuLocation
 import org.jetbrains.compose.resources.stringResource
 import org.openani.mediamp.MediampPlayer
 
@@ -73,6 +70,8 @@ fun PlayerDanmakuEditor(
             danmakuEditorState.post(it)
         },
         danmakuTextPlaceholder, playerState, videoScaffoldConfig, playerControllerState, modifier, onEscape,
+        style = danmakuEditorState.style,
+        onStyleChange = { danmakuEditorState.updateStyle(it) },
     )
 }
 
@@ -89,8 +88,11 @@ fun PlayerDanmakuEditor(
     playerControllerState: PlayerControllerState,
     modifier: Modifier = Modifier,
     onEscape: (() -> Unit)? = null,
+    style: DanmakuSendStyle = DanmakuSendStyle.Default,
+    onStyleChange: (DanmakuSendStyle) -> Unit = {},
 ) {
     val danmakuEditorRequester = rememberAlwaysOnRequester(playerControllerState, "danmakuEditor")
+    val stylePickerRequester = rememberAlwaysOnRequester(playerControllerState, "danmakuStylePicker")
 
     val playerFocusState = playerControllerState.focusState
 
@@ -98,8 +100,16 @@ fun PlayerDanmakuEditor(
      * 是否设置了暂停
      */
     var didSetPaused by rememberSaveable { mutableStateOf(false) }
-    Row(modifier = modifier) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         val scope = rememberCoroutineScope()
+        DanmakuStylePicker(
+            style = style,
+            onStyleChange = onStyleChange,
+            onExpandedChanged = { expanded ->
+                // 弹层打开期间保持控制器显示
+                if (expanded) stylePickerRequester.request() else stylePickerRequester.cancelRequest()
+            },
+        )
         PlayerDanmakuEditor(
             text = text,
             onTextChange = onTextChange,
@@ -112,8 +122,8 @@ fun PlayerDanmakuEditor(
                         DanmakuContent(
                             playerState.currentPositionMillis.value,
                             text = text,
-                            color = Color.White.toArgb(),
-                            location = DanmakuLocation.NORMAL,
+                            color = style.color,
+                            location = style.location,
                         ),
                     )
                     playerFocusState.preferPlayer()

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditor.kt
@@ -102,14 +102,6 @@ fun PlayerDanmakuEditor(
     var didSetPaused by rememberSaveable { mutableStateOf(false) }
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         val scope = rememberCoroutineScope()
-        DanmakuStylePicker(
-            style = style,
-            onStyleChange = onStyleChange,
-            onExpandedChanged = { expanded ->
-                // 弹层打开期间保持控制器显示
-                if (expanded) stylePickerRequester.request() else stylePickerRequester.cancelRequest()
-            },
-        )
         PlayerDanmakuEditor(
             text = text,
             onTextChange = onTextChange,
@@ -146,6 +138,17 @@ fun PlayerDanmakuEditor(
             }.weight(1f),
             playerFocusState = playerFocusState,
             onEscape = onEscape,
+            // 样式按钮放在输入框内部的最前面, 表示"这条弹幕的样式"
+            leadingIcon = {
+                DanmakuStylePicker(
+                    style = style,
+                    onStyleChange = onStyleChange,
+                    onExpandedChanged = { expanded ->
+                        // 弹层打开期间保持控制器显示
+                        if (expanded) stylePickerRequester.request() else stylePickerRequester.cancelRequest()
+                    },
+                )
+            },
         )
     }
 }
@@ -162,11 +165,13 @@ fun PlayerDanmakuEditor(
     onEscape: (() -> Unit)? = null,
     colors: TextFieldColors = PlayerControllerDefaults.inVideoDanmakuTextFieldColors(),
     style: TextStyle = MaterialTheme.typography.bodyMedium,
+    leadingIcon: (@Composable () -> Unit)? = null,
 ) {
     PlayerControllerDefaults.DanmakuTextField(
         text,
         onValueChange = onTextChange,
         modifier = modifier.playerTextInputFocus(playerFocusState, onEscape),
+        leadingIcon = leadingIcon,
         onSend = {
             if (text.isEmpty()) return@DanmakuTextField
             onSend(text)

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditorState.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuEditorState.kt
@@ -23,8 +23,25 @@ class DanmakuEditorState(
     private val onPost: suspend (me.him188.ani.danmaku.api.DanmakuContent) -> me.him188.ani.danmaku.api.DanmakuInfo,
     private val onPostSuccess: suspend (me.him188.ani.danmaku.api.DanmakuInfo) -> Unit,
     uiScope: CoroutineScope,
+    initialStyle: DanmakuSendStyle = DanmakuSendStyle.Default,
+    private val onStyleChange: (DanmakuSendStyle) -> Unit = {},
 ) {
     var text: String by mutableStateOf("")
+
+    /**
+     * 发送弹幕使用的样式 (颜色, 位置).
+     *
+     * 直接赋值仅更新本地状态 (用于从设置同步), 不会触发 [onStyleChange]; 用户主动修改请用 [updateStyle].
+     */
+    var style: DanmakuSendStyle by mutableStateOf(initialStyle)
+
+    /**
+     * 用户主动修改样式: 立即更新本地状态, 并通过 [onStyleChange] 通知持久化.
+     */
+    fun updateStyle(style: DanmakuSendStyle) {
+        this.style = style
+        onStyleChange(style)
+    }
 
     private val sendDanmakuTasker = MonoTasker(uiScope)
     val isSending: StateFlow<Boolean> get() = sendDanmakuTasker.isRunning

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -21,29 +21,37 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.VerticalAlignBottom
 import androidx.compose.material.icons.rounded.VerticalAlignTop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,12 +64,16 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -72,12 +84,14 @@ import me.him188.ani.app.ui.foundation.theme.AniTheme
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.danmaku_send_style
 import me.him188.ani.app.ui.lang.danmaku_send_style_color
+import me.him188.ani.app.ui.lang.danmaku_send_style_custom_color
 import me.him188.ani.app.ui.lang.danmaku_send_style_location
 import me.him188.ani.app.ui.lang.subject_episode_video_settings_bottom
 import me.him188.ani.app.ui.lang.subject_episode_video_settings_floating
 import me.him188.ani.app.ui.lang.subject_episode_video_settings_top
 import me.him188.ani.danmaku.api.DanmakuLocation
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.roundToInt
 
 /**
  * 用户发送弹幕时选择的样式: 颜色和位置.
@@ -102,21 +116,20 @@ fun DanmakuSettings.toDanmakuSendStyle(): DanmakuSendStyle = DanmakuSendStyle(se
 
 object DanmakuSendColors {
     /**
-     * 可选的预设颜色, RGB.
+     * 可选的预设颜色, RGB. 都偏亮, 在视频画面上可读; 面板里最后一格是自定义颜色.
      */
     val Presets: List<Int> = listOf(
         0xFFFFFF, // 白
-        0xFE0302, // 红
-        0xFF7204, // 橙
-        0xFFAA02, // 金
-        0xFFD302, // 黄
-        0xA0EE00, // 黄绿
-        0x00CD00, // 绿
-        0x019899, // 青
-        0x4266BE, // 蓝
-        0x89D5FF, // 浅蓝
-        0xCC0273, // 紫
-        0x000000, // 黑
+        0xFF4D4D, // 红
+        0xFF7A2F, // 橙
+        0xFFC53D, // 黄
+        0xA6F03A, // 黄绿
+        0x3DDC84, // 绿
+        0x22D3EE, // 青
+        0x5AB4FF, // 天蓝
+        0x7C8CFF, // 蓝
+        0xC084FC, // 紫
+        0xFF6FB5, // 粉
     )
 
     /**
@@ -131,6 +144,8 @@ object DanmakuSendColors {
 
 const val TAG_DANMAKU_STYLE_BUTTON = "danmakuStyleButton"
 const val TAG_DANMAKU_STYLE_PANEL = "danmakuStylePanel"
+const val TAG_DANMAKU_CUSTOM_COLOR_SWATCH = "danmakuCustomColorSwatch"
+const val TAG_DANMAKU_CUSTOM_COLOR_HEX = "danmakuCustomColorHex"
 
 fun danmakuLocationTileTag(location: DanmakuLocation): String = "danmakuLocationTile-${location.name}"
 fun danmakuColorSwatchTag(color: Int): String = "danmakuColorSwatch-${color.toRgbHex()}"
@@ -263,6 +278,8 @@ fun DanmakuStylePanel(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        // 当前颜色不在预设里时, 说明是自定义颜色; 用户点了自定义格之后即使颜色仍等于某个预设, 也保持在自定义模式
+        var customMode by remember { mutableStateOf(style.color !in DanmakuSendColors.Presets) }
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -270,12 +287,167 @@ fun DanmakuStylePanel(
             for (color in DanmakuSendColors.Presets) {
                 DanmakuColorSwatch(
                     color = color,
-                    selected = style.color == color,
-                    onClick = { onStyleChange(style.copy(color = color)) },
+                    selected = !customMode && style.color == color,
+                    onClick = {
+                        customMode = false
+                        onStyleChange(style.copy(color = color))
+                    },
                     modifier = Modifier.testTag(danmakuColorSwatchTag(color)),
                 )
             }
+            DanmakuCustomColorSwatch(
+                color = style.color,
+                selected = customMode,
+                onClick = { customMode = true },
+                modifier = Modifier.testTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH),
+            )
         }
+        if (customMode) {
+            DanmakuCustomColorEditor(
+                color = style.color,
+                onColorChange = { onStyleChange(style.copy(color = it)) },
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+/**
+ * 自定义颜色入口: 彩虹环, 选中时中间显示当前颜色.
+ */
+@Composable
+private fun DanmakuCustomColorSwatch(
+    color: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(Lang.danmaku_send_style_custom_color)
+    val rainbow = remember {
+        Brush.sweepGradient(
+            listOf(
+                Color(0xFFFF4D4D), Color(0xFFFFC53D), Color(0xFF3DDC84),
+                Color(0xFF22D3EE), Color(0xFF7C8CFF), Color(0xFFC084FC), Color(0xFFFF4D4D),
+            ),
+        )
+    }
+    Box(
+        modifier
+            .size(32.dp)
+            .clip(CircleShape)
+            .background(rainbow)
+            .then(
+                if (selected) Modifier.border(2.dp, MaterialTheme.colorScheme.primary, CircleShape) else Modifier,
+            )
+            .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Box(Modifier.size(18.dp).clip(CircleShape).background(color.rgbToColor()))
+        } else {
+            Icon(Icons.Rounded.Add, null, Modifier.size(18.dp), tint = Color.White)
+        }
+    }
+}
+
+/**
+ * 自定义颜色编辑: 十六进制输入 + R/G/B 三个滑条, 任一改动立即回调.
+ */
+@Composable
+private fun DanmakuCustomColorEditor(
+    color: Int,
+    onColorChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scheme = MaterialTheme.colorScheme
+    var hexText by remember { mutableStateOf(color.toRgbHex()) }
+    // 滑条 (或外部) 改了颜色时同步输入框; 用户正在输入的不完整文本不被覆盖
+    LaunchedEffect(color) {
+        if (parseRgbHex(hexText) != color) hexText = color.toRgbHex()
+    }
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                Modifier.size(24.dp).clip(CircleShape).background(color.rgbToColor())
+                    .border(1.dp, scheme.outline, CircleShape),
+            )
+            Text("#", style = MaterialTheme.typography.labelLarge, color = scheme.onSurfaceVariant)
+            BasicTextField(
+                value = hexText,
+                onValueChange = { input ->
+                    val filtered = input.filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+                        .take(6).uppercase()
+                    hexText = filtered
+                    parseRgbHex(filtered)?.let(onColorChange)
+                },
+                modifier = Modifier.width(96.dp).testTag(TAG_DANMAKU_CUSTOM_COLOR_HEX),
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = scheme.onSurface,
+                    fontFamily = FontFamily.Monospace,
+                ),
+                singleLine = true,
+                cursorBrush = SolidColor(scheme.primary),
+                decorationBox = { inner ->
+                    Box(
+                        Modifier
+                            .border(1.dp, scheme.outline, RoundedCornerShape(8.dp))
+                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                    ) {
+                        if (hexText.isEmpty()) {
+                            Text(
+                                "RRGGBB",
+                                style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                                color = scheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            )
+                        }
+                        inner()
+                    }
+                },
+            )
+        }
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 24.dp) {
+            ChannelSlider("R", (color shr 16) and 0xFF, Color(0xFFFF4D4D)) { onColorChange((color and 0x00FFFF) or (it shl 16)) }
+            ChannelSlider("G", (color shr 8) and 0xFF, Color(0xFF3DDC84)) { onColorChange((color and 0xFF00FF) or (it shl 8)) }
+            ChannelSlider("B", color and 0xFF, Color(0xFF5AB4FF)) { onColorChange((color and 0xFFFF00) or it) }
+        }
+    }
+}
+
+@Composable
+private fun ChannelSlider(
+    label: String,
+    value: Int,
+    tint: Color,
+    onValueChange: (Int) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            label,
+            Modifier.width(12.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Slider(
+            value = value.toFloat(),
+            onValueChange = { onValueChange(it.roundToInt().coerceIn(0, 255)) },
+            modifier = Modifier.weight(1f).height(28.dp),
+            valueRange = 0f..255f,
+            colors = SliderDefaults.colors(thumbColor = tint, activeTrackColor = tint),
+        )
+        Text(
+            value.toString(),
+            Modifier.width(28.dp),
+            style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = "tnum"),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.End,
+        )
     }
 }
 
@@ -421,6 +593,11 @@ private fun DanmakuLocation.displayName(): String = when (this) {
 private fun Int.rgbToColor(): Color = Color(0xFF_00_00_00L or (this.toLong() and 0xFF_FF_FFL))
 
 private fun Int.toRgbHex(): String = (this and 0xFF_FF_FF).toString(16).uppercase().padStart(6, '0')
+
+/**
+ * 解析 6 位十六进制 RGB (不带 #), 不合法返回 null.
+ */
+private fun parseRgbHex(text: String): Int? = if (text.length == 6) text.toIntOrNull(16) else null
 
 /**
  * 在 [background] 上清晰可见的前景色.

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.danmaku
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.VerticalAlignBottom
+import androidx.compose.material.icons.rounded.VerticalAlignTop
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import me.him188.ani.app.data.models.preference.DanmakuSettings
+import me.him188.ani.app.data.models.preference.DarkMode
+import me.him188.ani.app.ui.foundation.dialogs.PlatformPopupProperties
+import me.him188.ani.app.ui.foundation.theme.AniTheme
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.danmaku_send_style
+import me.him188.ani.app.ui.lang.danmaku_send_style_color
+import me.him188.ani.app.ui.lang.danmaku_send_style_location
+import me.him188.ani.app.ui.lang.subject_episode_video_settings_bottom
+import me.him188.ani.app.ui.lang.subject_episode_video_settings_floating
+import me.him188.ani.app.ui.lang.subject_episode_video_settings_top
+import me.him188.ani.danmaku.api.DanmakuLocation
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * 用户发送弹幕时选择的样式: 颜色和位置.
+ */
+@Immutable
+data class DanmakuSendStyle(
+    /**
+     * RGB, 不含 alpha. 例如白色为 `0xFFFFFF`.
+     */
+    val color: Int,
+    val location: DanmakuLocation,
+) {
+    companion object {
+        val Default = DanmakuSendStyle(
+            color = DanmakuSettings.DEFAULT_SEND_COLOR,
+            location = DanmakuLocation.NORMAL,
+        )
+    }
+}
+
+fun DanmakuSettings.toDanmakuSendStyle(): DanmakuSendStyle = DanmakuSendStyle(sendColor, sendLocation)
+
+object DanmakuSendColors {
+    /**
+     * 可选的预设颜色, RGB.
+     */
+    val Presets: List<Int> = listOf(
+        0xFFFFFF, // 白
+        0xFE0302, // 红
+        0xFF7204, // 橙
+        0xFFAA02, // 金
+        0xFFD302, // 黄
+        0xA0EE00, // 黄绿
+        0x00CD00, // 绿
+        0x019899, // 青
+        0x4266BE, // 蓝
+        0x89D5FF, // 浅蓝
+        0xCC0273, // 紫
+        0x000000, // 黑
+    )
+
+    /**
+     * 可供 [DanmakuStylePanel] 选择的位置, 按 UI 显示顺序.
+     */
+    val Locations: List<DanmakuLocation> = listOf(
+        DanmakuLocation.TOP,
+        DanmakuLocation.NORMAL,
+        DanmakuLocation.BOTTOM,
+    )
+}
+
+const val TAG_DANMAKU_STYLE_BUTTON = "danmakuStyleButton"
+const val TAG_DANMAKU_STYLE_PANEL = "danmakuStylePanel"
+
+fun danmakuLocationChipTag(location: DanmakuLocation): String = "danmakuLocationChip-${location.name}"
+fun danmakuColorSwatchTag(color: Int): String = "danmakuColorSwatch-${color.toRgbHex()}"
+
+/**
+ * 弹幕样式入口按钮与弹层. 点击按钮在上方弹出 [DanmakuStylePanel].
+ *
+ * @param onExpandedChanged 弹层展开状态变化时回调, 可用于让播放器控制器保持显示.
+ */
+@Composable
+fun DanmakuStylePicker(
+    style: DanmakuSendStyle,
+    onStyleChange: (DanmakuSendStyle) -> Unit,
+    modifier: Modifier = Modifier,
+    onExpandedChanged: (expanded: Boolean) -> Unit = {},
+) {
+    var expanded by remember { mutableStateOf(false) }
+    fun setExpanded(value: Boolean) {
+        if (expanded == value) return
+        expanded = value
+        onExpandedChanged(value)
+    }
+
+    Box(modifier, contentAlignment = Alignment.Center) {
+        DanmakuStyleButton(style, onClick = { setExpanded(!expanded) })
+
+        if (expanded) {
+            Popup(
+                popupPositionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                    positioning = TooltipAnchorPosition.Above,
+                    spacingBetweenTooltipAndAnchor = 8.dp,
+                ),
+                onDismissRequest = { setExpanded(false) },
+                // 不抢焦点, 这样输入框保持聚焦, 视频也不会因为失焦而恢复播放
+                properties = PlatformPopupProperties(focusable = false, clippingEnabled = false),
+            ) {
+                AniTheme(darkModeOverride = DarkMode.DARK) {
+                    Surface(
+                        Modifier.width(300.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        shadowElevation = 8.dp,
+                    ) {
+                        DanmakuStylePanel(style, onStyleChange, Modifier.padding(16.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 显示当前样式的按钮: 一个当前颜色的圆点, 非滚动位置时叠加一个方向图标.
+ */
+@Composable
+fun DanmakuStyleButton(
+    style: DanmakuSendStyle,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(Lang.danmaku_send_style)
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .testTag(TAG_DANMAKU_STYLE_BUTTON)
+            // 不抢输入框的焦点 (桌面端鼠标点击会请求焦点)
+            .focusProperties { canFocus = false }
+            .semantics { contentDescription = description },
+    ) {
+        val fill = style.color.rgbToColor()
+        Box(
+            Modifier.size(22.dp)
+                .clip(CircleShape)
+                .background(fill)
+                .border(1.dp, LocalContentColor.current.copy(alpha = 0.6f), CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (style.location) {
+                DanmakuLocation.TOP -> Icon(
+                    Icons.Rounded.VerticalAlignTop, null,
+                    Modifier.size(16.dp), tint = contentColorOn(fill),
+                )
+
+                DanmakuLocation.BOTTOM -> Icon(
+                    Icons.Rounded.VerticalAlignBottom, null,
+                    Modifier.size(16.dp), tint = contentColorOn(fill),
+                )
+
+                DanmakuLocation.NORMAL -> {}
+            }
+        }
+    }
+}
+
+/**
+ * 弹幕样式选择面板: 位置 (顶部/滚动/底部) 和预设颜色.
+ */
+@Composable
+fun DanmakuStylePanel(
+    style: DanmakuSendStyle,
+    onStyleChange: (DanmakuSendStyle) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier
+            .testTag(TAG_DANMAKU_STYLE_PANEL)
+            // 面板内的选项都不抢焦点, 输入框保持聚焦
+            .focusProperties { canFocus = false },
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            stringResource(Lang.danmaku_send_style_location),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            for (location in DanmakuSendColors.Locations) {
+                val selected = style.location == location
+                FilterChip(
+                    selected = selected,
+                    onClick = { onStyleChange(style.copy(location = location)) },
+                    label = { Text(location.displayName(), maxLines = 1) },
+                    modifier = Modifier.testTag(danmakuLocationChipTag(location)),
+                    leadingIcon = if (selected) {
+                        { Icon(Icons.Rounded.Check, null, Modifier.size(18.dp)) }
+                    } else null,
+                )
+            }
+        }
+
+        Text(
+            stringResource(Lang.danmaku_send_style_color),
+            Modifier.padding(top = 4.dp),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            for (color in DanmakuSendColors.Presets) {
+                DanmakuColorSwatch(
+                    color = color,
+                    selected = style.color == color,
+                    onClick = { onStyleChange(style.copy(color = color)) },
+                    modifier = Modifier.testTag(danmakuColorSwatchTag(color)),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DanmakuColorSwatch(
+    color: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val fill = color.rgbToColor()
+    val description = "#" + color.toRgbHex()
+    Box(
+        modifier
+            .size(32.dp)
+            .clip(CircleShape)
+            .background(fill)
+            .border(
+                width = if (selected) 2.dp else 1.dp,
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                shape = CircleShape,
+            )
+            .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Icon(Icons.Rounded.Check, null, Modifier.size(18.dp), tint = contentColorOn(fill))
+        }
+    }
+}
+
+@Composable
+private fun DanmakuLocation.displayName(): String = when (this) {
+    DanmakuLocation.TOP -> stringResource(Lang.subject_episode_video_settings_top)
+    DanmakuLocation.NORMAL -> stringResource(Lang.subject_episode_video_settings_floating)
+    DanmakuLocation.BOTTOM -> stringResource(Lang.subject_episode_video_settings_bottom)
+}
+
+/**
+ * 把 RGB int (不含 alpha) 转换为不透明的 [Color].
+ */
+private fun Int.rgbToColor(): Color = Color(0xFF_00_00_00L or (this.toLong() and 0xFF_FF_FFL))
+
+private fun Int.toRgbHex(): String = (this and 0xFF_FF_FF).toString(16).uppercase().padStart(6, '0')
+
+/**
+ * 在 [background] 上清晰可见的前景色.
+ */
+private fun contentColorOn(background: Color): Color =
+    if (background.luminance() > 0.5f) Color.Black else Color.White

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -19,9 +19,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -142,6 +144,9 @@ object DanmakuSendColors {
         DanmakuLocation.BOTTOM,
     )
 }
+
+/** 颜色色块直径 */
+private val SwatchSize = 32.dp
 
 const val TAG_DANMAKU_STYLE_BUTTON = "danmakuStyleButton"
 const val TAG_DANMAKU_STYLE_PANEL = "danmakuStylePanel"
@@ -329,27 +334,38 @@ fun DanmakuStylePanel(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            for (color in DanmakuSendColors.Presets) {
-                DanmakuColorSwatch(
-                    color = color,
-                    selected = !customMode && style.color == color,
-                    onClick = {
-                        onCustomModeChange(false)
-                        onStyleChange(style.copy(color = color))
-                    },
-                    modifier = Modifier.testTag(danmakuColorSwatchTag(color)),
+        // 色块按可用宽度排成网格并铺满整行: 列数取最多能放下的 (最小间距 8dp), 每行 SpaceBetween 撑满,
+        // 这样桌面弹层里 6 列正好和上面的位置缩略屏一样宽, 右边不会空出一截; 手机端更宽则列数更多.
+        // 最后一行不满时用透明占位补齐, 保证各行对齐同一套列.
+        BoxWithConstraints(Modifier.fillMaxWidth()) {
+            val itemCount = DanmakuSendColors.Presets.size + 1
+            val columns = (((maxWidth + 8.dp) / (SwatchSize + 8.dp)).toInt()).coerceIn(1, itemCount)
+            val fillers = (columns - itemCount % columns) % columns
+            FlowRow(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                maxItemsInEachRow = columns,
+            ) {
+                for (color in DanmakuSendColors.Presets) {
+                    DanmakuColorSwatch(
+                        color = color,
+                        selected = !customMode && style.color == color,
+                        onClick = {
+                            onCustomModeChange(false)
+                            onStyleChange(style.copy(color = color))
+                        },
+                        modifier = Modifier.testTag(danmakuColorSwatchTag(color)),
+                    )
+                }
+                DanmakuCustomColorSwatch(
+                    color = style.color,
+                    selected = customMode,
+                    onClick = { onCustomModeChange(true) },
+                    modifier = Modifier.testTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH),
                 )
+                repeat(fillers) { Spacer(Modifier.size(SwatchSize)) }
             }
-            DanmakuCustomColorSwatch(
-                color = style.color,
-                selected = customMode,
-                onClick = { onCustomModeChange(true) },
-                modifier = Modifier.testTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH),
-            )
         }
         if (customMode) {
             DanmakuCustomColorEditor(
@@ -387,7 +403,7 @@ private fun DanmakuCustomColorSwatch(
     }
     Box(
         modifier
-            .size(32.dp)
+            .size(SwatchSize)
             .clip(CircleShape)
             .background(rainbow)
             .then(
@@ -524,6 +540,8 @@ private fun DanmakuLocationTile(
     Column(
         modifier
             .width(84.dp)
+            // hover / ripple 跟着圆角走, 不然是一块直角矩形
+            .clip(RoundedCornerShape(8.dp))
             // 选项不抢焦点, 弹幕输入框保持聚焦 (不能放在面板整体上, 否则十六进制输入框也无法聚焦)
             .focusProperties { canFocus = false }
             .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
@@ -621,7 +639,7 @@ private fun DanmakuColorSwatch(
     val description = "#" + color.toRgbHex()
     Box(
         modifier
-            .size(32.dp)
+            .size(SwatchSize)
             .clip(CircleShape)
             .background(fill)
             .border(

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -36,8 +36,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
-import androidx.compose.material.icons.rounded.VerticalAlignBottom
-import androidx.compose.material.icons.rounded.VerticalAlignTop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
@@ -68,6 +66,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -199,7 +198,8 @@ fun DanmakuStylePicker(
 }
 
 /**
- * 显示当前样式的按钮: 一个当前颜色的圆点, 非滚动位置时叠加一个方向图标. 放在弹幕输入框内部最前面.
+ * 显示当前样式的按钮: 一个迷你屏幕图标, 弹幕条画在当前位置 (与面板里的缩略屏同一套语言), 弹幕条用当前颜色.
+ * 放在弹幕输入框内部最前面.
  */
 @Composable
 fun DanmakuStyleButton(
@@ -217,26 +217,42 @@ fun DanmakuStyleButton(
             .focusProperties { canFocus = false }
             .semantics { contentDescription = description },
     ) {
-        val fill = style.color.rgbToColor()
-        Box(
-            Modifier.size(20.dp)
-                .clip(CircleShape)
-                .background(fill)
-                .border(1.dp, LocalContentColor.current.copy(alpha = 0.6f), CircleShape),
-            contentAlignment = Alignment.Center,
-        ) {
-            when (style.location) {
-                DanmakuLocation.TOP -> Icon(
-                    Icons.Rounded.VerticalAlignTop, null,
-                    Modifier.size(16.dp), tint = contentColorOn(fill),
-                )
+        DanmakuStyleIcon(style, Modifier.size(22.dp, 16.dp))
+    }
+}
 
-                DanmakuLocation.BOTTOM -> Icon(
-                    Icons.Rounded.VerticalAlignBottom, null,
-                    Modifier.size(16.dp), tint = contentColorOn(fill),
-                )
-
-                DanmakuLocation.NORMAL -> {}
+/**
+ * 迷你屏幕: 圆角框 + 当前位置的弹幕条. 框用当前内容色, 弹幕条用 [DanmakuSendStyle.color].
+ */
+@Composable
+private fun DanmakuStyleIcon(style: DanmakuSendStyle, modifier: Modifier = Modifier) {
+    val frameColor = LocalContentColor.current.copy(alpha = 0.7f)
+    val barColor = style.color.rgbToColor()
+    Canvas(modifier) {
+        val stroke = 1.5.dp.toPx()
+        drawRoundRect(
+            color = frameColor,
+            topLeft = Offset(stroke / 2, stroke / 2),
+            size = Size(size.width - stroke, size.height - stroke),
+            cornerRadius = CornerRadius(2.5.dp.toPx()),
+            style = Stroke(stroke),
+        )
+        val barHeight = 2.dp.toPx()
+        val radius = CornerRadius(1.dp.toPx())
+        fun bar(x: Float, y: Float, w: Float, alpha: Float = 1f) = drawRoundRect(
+            color = barColor.copy(alpha = alpha),
+            topLeft = Offset(x.dp.toPx(), y.dp.toPx()),
+            size = Size(w.dp.toPx(), barHeight),
+            cornerRadius = radius,
+        )
+        when (style.location) {
+            DanmakuLocation.TOP -> bar(6f, 3.5f, 10f)
+            DanmakuLocation.BOTTOM -> bar(6f, 10.5f, 10f)
+            // 三条错开的弹幕条, 和面板缩略屏一致
+            DanmakuLocation.NORMAL -> {
+                bar(4f, 3.5f, 7f)
+                bar(9f, 7f, 9f, 0.85f)
+                bar(5.5f, 10.5f, 6f, 0.6f)
             }
         }
     }

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -199,7 +199,7 @@ fun DanmakuStylePicker(
 }
 
 /**
- * 显示当前样式的按钮: 一个当前颜色的圆点, 非滚动位置时叠加一个方向图标.
+ * 显示当前样式的按钮: 一个当前颜色的圆点, 非滚动位置时叠加一个方向图标. 放在弹幕输入框内部最前面.
  */
 @Composable
 fun DanmakuStyleButton(
@@ -211,6 +211,7 @@ fun DanmakuStyleButton(
     IconButton(
         onClick = onClick,
         modifier = modifier
+            .size(32.dp)
             .testTag(TAG_DANMAKU_STYLE_BUTTON)
             // 不抢输入框的焦点 (桌面端鼠标点击会请求焦点)
             .focusProperties { canFocus = false }
@@ -218,7 +219,7 @@ fun DanmakuStyleButton(
     ) {
         val fill = style.color.rgbToColor()
         Box(
-            Modifier.size(22.dp)
+            Modifier.size(20.dp)
                 .clip(CircleShape)
                 .background(fill)
                 .border(1.dp, LocalContentColor.current.copy(alpha = 0.6f), CircleShape),

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -168,28 +169,40 @@ fun DanmakuStylePicker(
         expanded = value
         onExpandedChanged(value)
     }
+    // 自定义模式提升到这里, 这样弹层因 focusable 变化而重建时不会丢失
+    var customMode by remember { mutableStateOf(style.color !in DanmakuSendColors.Presets) }
 
     Box(modifier, contentAlignment = Alignment.Center) {
         DanmakuStyleButton(style, onClick = { setExpanded(!expanded) })
 
         if (expanded) {
-            Popup(
-                popupPositionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                    positioning = TooltipAnchorPosition.Above,
-                    spacingBetweenTooltipAndAnchor = 8.dp,
-                ),
-                onDismissRequest = { setExpanded(false) },
-                // 不抢焦点, 这样输入框保持聚焦, 视频也不会因为失焦而恢复播放
-                properties = PlatformPopupProperties(focusable = false, clippingEnabled = false),
-            ) {
-                AniTheme(darkModeOverride = DarkMode.DARK) {
-                    Surface(
-                        Modifier.width(300.dp),
-                        shape = RoundedCornerShape(16.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        shadowElevation = 8.dp,
-                    ) {
-                        DanmakuStylePanel(style, onStyleChange, Modifier.padding(16.dp))
+            // 只选预设时不抢焦点, 弹幕输入框保持聚焦, 视频不会因为失焦而恢复播放;
+            // 展开自定义颜色后需要键入十六进制, 非 focusable 的弹层内文本框拿不到焦点, 此时改为可聚焦.
+            // 桌面端 Popup 不支持运行时切换 focusable, 用 key 重建.
+            key(customMode) {
+                Popup(
+                    popupPositionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                        positioning = TooltipAnchorPosition.Above,
+                        spacingBetweenTooltipAndAnchor = 8.dp,
+                    ),
+                    onDismissRequest = { setExpanded(false) },
+                    properties = PlatformPopupProperties(focusable = customMode, clippingEnabled = false),
+                ) {
+                    AniTheme(darkModeOverride = DarkMode.DARK) {
+                        Surface(
+                            Modifier.width(300.dp),
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            shadowElevation = 8.dp,
+                        ) {
+                            DanmakuStylePanel(
+                                style,
+                                onStyleChange,
+                                customMode = customMode,
+                                onCustomModeChange = { customMode = it },
+                                modifier = Modifier.padding(16.dp),
+                            )
+                        }
                     }
                 }
             }
@@ -259,7 +272,7 @@ private fun DanmakuStyleIcon(style: DanmakuSendStyle, modifier: Modifier = Modif
 }
 
 /**
- * 弹幕样式选择面板: 位置 (顶部/滚动/底部) 和预设颜色.
+ * 弹幕样式选择面板: 位置 (顶部/滚动/底部), 预设颜色和自定义颜色. 自定义模式的状态由面板自己保存.
  */
 @Composable
 fun DanmakuStylePanel(
@@ -267,11 +280,31 @@ fun DanmakuStylePanel(
     onStyleChange: (DanmakuSendStyle) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // 当前颜色不在预设里时, 说明是自定义颜色; 用户点了自定义格之后即使颜色仍等于某个预设, 也保持在自定义模式
+    var customMode by remember { mutableStateOf(style.color !in DanmakuSendColors.Presets) }
+    DanmakuStylePanel(
+        style,
+        onStyleChange,
+        customMode = customMode,
+        onCustomModeChange = { customMode = it },
+        modifier = modifier,
+    )
+}
+
+/**
+ * [DanmakuStylePanel] 的无状态版本, [customMode] 为是否展开自定义颜色编辑区.
+ */
+@Composable
+fun DanmakuStylePanel(
+    style: DanmakuSendStyle,
+    onStyleChange: (DanmakuSendStyle) -> Unit,
+    customMode: Boolean,
+    onCustomModeChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier
-            .testTag(TAG_DANMAKU_STYLE_PANEL)
-            // 面板内的选项都不抢焦点, 输入框保持聚焦
-            .focusProperties { canFocus = false },
+            .testTag(TAG_DANMAKU_STYLE_PANEL),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
@@ -296,8 +329,6 @@ fun DanmakuStylePanel(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        // 当前颜色不在预设里时, 说明是自定义颜色; 用户点了自定义格之后即使颜色仍等于某个预设, 也保持在自定义模式
-        var customMode by remember { mutableStateOf(style.color !in DanmakuSendColors.Presets) }
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -307,7 +338,7 @@ fun DanmakuStylePanel(
                     color = color,
                     selected = !customMode && style.color == color,
                     onClick = {
-                        customMode = false
+                        onCustomModeChange(false)
                         onStyleChange(style.copy(color = color))
                     },
                     modifier = Modifier.testTag(danmakuColorSwatchTag(color)),
@@ -316,7 +347,7 @@ fun DanmakuStylePanel(
             DanmakuCustomColorSwatch(
                 color = style.color,
                 selected = customMode,
-                onClick = { customMode = true },
+                onClick = { onCustomModeChange(true) },
                 modifier = Modifier.testTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH),
             )
         }
@@ -362,6 +393,8 @@ private fun DanmakuCustomColorSwatch(
             .then(
                 if (selected) Modifier.border(2.dp, MaterialTheme.colorScheme.primary, CircleShape) else Modifier,
             )
+            // 选项不抢焦点, 弹幕输入框保持聚焦 (不能放在面板整体上, 否则十六进制输入框也无法聚焦)
+            .focusProperties { canFocus = false }
             .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
             .semantics { contentDescription = description },
         contentAlignment = Alignment.Center,
@@ -461,7 +494,7 @@ private fun ChannelSlider(
         Slider(
             value = value.toFloat(),
             onValueChange = { onValueChange(it.roundToInt().coerceIn(0, 255)) },
-            modifier = Modifier.weight(1f).height(28.dp),
+            modifier = Modifier.weight(1f).height(28.dp).focusProperties { canFocus = false },
             valueRange = 0f..255f,
             colors = SliderDefaults.colors(thumbColor = tint, activeTrackColor = tint),
         )
@@ -491,6 +524,8 @@ private fun DanmakuLocationTile(
     Column(
         modifier
             .width(84.dp)
+            // 选项不抢焦点, 弹幕输入框保持聚焦 (不能放在面板整体上, 否则十六进制输入框也无法聚焦)
+            .focusProperties { canFocus = false }
             .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
             .semantics { contentDescription = label },
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -594,6 +629,8 @@ private fun DanmakuColorSwatch(
                 color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
                 shape = CircleShape,
             )
+            // 选项不抢焦点, 弹幕输入框保持聚焦 (不能放在面板整体上, 否则十六进制输入框也无法聚焦)
+            .focusProperties { canFocus = false }
             .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
             .semantics { contentDescription = description },
         contentAlignment = Alignment.Center,

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -9,12 +9,19 @@
 
 package me.him188.ani.app.ui.danmaku
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
@@ -44,7 +51,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.testTag
@@ -300,16 +311,14 @@ private fun DanmakuLocationTile(
                     shape = RoundedCornerShape(6.dp),
                 ),
         ) {
-            val y = when (location) {
-                DanmakuLocation.TOP -> 8.dp
-                DanmakuLocation.NORMAL -> 23.dp
-                DanmakuLocation.BOTTOM -> 38.dp
-            }
-            DanmakuBar(x = 24.dp, y = y, width = 36.dp, color = barColor)
-            if (location == DanmakuLocation.NORMAL) {
-                // 拖尾: 表示这条弹幕在向左滚动
-                DanmakuBar(x = 10.dp, y = y, width = 22.dp, color = barColor.copy(alpha = 0.55f))
-                DanmakuBar(x = 66.dp, y = y, width = 14.dp, color = barColor.copy(alpha = 0.3f))
+            when (location) {
+                DanmakuLocation.TOP -> DanmakuBar(x = 24.dp, y = 8.dp, width = 36.dp, color = barColor)
+                DanmakuLocation.BOTTOM -> DanmakuBar(x = 24.dp, y = 38.dp, width = 36.dp, color = barColor)
+                DanmakuLocation.NORMAL -> ScrollingDanmakuBars(
+                    barColor,
+                    // 留出描边的宽度, 弹幕条出界时被裁在描边内侧
+                    Modifier.fillMaxSize().padding(2.dp).clipToBounds(),
+                )
             }
         }
         Text(
@@ -318,6 +327,44 @@ private fun DanmakuLocationTile(
             color = if (selected) scheme.onSurface else scheme.onSurfaceVariant,
             maxLines = 1,
         )
+    }
+}
+
+/**
+ * 滚动弹幕示例: 三条轨道上错开的弹幕条持续向左滚动, 出界后从右边回来.
+ */
+@Composable
+private fun ScrollingDanmakuBars(color: Color, modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "scrollingDanmaku")
+    val progress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(durationMillis = 6000, easing = LinearEasing)),
+        label = "progress",
+    )
+    Canvas(modifier) {
+        val width = size.width
+        val barHeight = 4.dp.toPx()
+        val radius = CornerRadius(2.dp.toPx())
+        // (轨道 y, 初始 x, 宽度, 透明度): 每条以自己的周期循环, 位置错开, 看起来像真实的弹幕流
+        val bars = listOf(
+            Triple(7.dp, 12.dp, 30.dp) to 1f,
+            Triple(21.dp, 46.dp, 34.dp) to 0.8f,
+            Triple(35.dp, 26.dp, 24.dp) to 0.6f,
+        )
+        for ((bar, alpha) in bars) {
+            val (y, x0, w) = bar
+            val barWidth = w.toPx()
+            val period = width + barWidth
+            val travelled = progress * period * 1.5f // 6 秒走 1.5 个周期
+            val x = ((x0.toPx() - travelled) % period + period) % period - barWidth
+            drawRoundRect(
+                color = color.copy(alpha = alpha),
+                topLeft = Offset(x, y.toPx()),
+                size = Size(barWidth, barHeight),
+                cornerRadius = radius,
+            )
+        }
     }
 }
 

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -306,7 +307,12 @@ fun DanmakuStylePanel(
             DanmakuCustomColorEditor(
                 color = style.color,
                 onColorChange = { onStyleChange(style.copy(color = it)) },
-                modifier = Modifier.padding(top = 4.dp),
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainer)
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
             )
         }
     }
@@ -366,8 +372,9 @@ private fun DanmakuCustomColorEditor(
     LaunchedEffect(color) {
         if (parseRgbHex(hexText) != color) hexText = color.toRgbHex()
     }
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Row(
+            Modifier.padding(bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {

--- a/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
+++ b/app/shared/src/commonMain/kotlin/ui/danmaku/DanmakuStylePicker.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
@@ -25,7 +27,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.VerticalAlignBottom
 import androidx.compose.material.icons.rounded.VerticalAlignTop
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
@@ -50,6 +51,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import me.him188.ani.app.data.models.preference.DanmakuSettings
@@ -119,7 +121,7 @@ object DanmakuSendColors {
 const val TAG_DANMAKU_STYLE_BUTTON = "danmakuStyleButton"
 const val TAG_DANMAKU_STYLE_PANEL = "danmakuStylePanel"
 
-fun danmakuLocationChipTag(location: DanmakuLocation): String = "danmakuLocationChip-${location.name}"
+fun danmakuLocationTileTag(location: DanmakuLocation): String = "danmakuLocationTile-${location.name}"
 fun danmakuColorSwatchTag(color: Int): String = "danmakuColorSwatch-${color.toRgbHex()}"
 
 /**
@@ -233,20 +235,13 @@ fun DanmakuStylePanel(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             for (location in DanmakuSendColors.Locations) {
-                val selected = style.location == location
-                FilterChip(
-                    selected = selected,
+                DanmakuLocationTile(
+                    location = location,
+                    selected = style.location == location,
                     onClick = { onStyleChange(style.copy(location = location)) },
-                    label = { Text(location.displayName(), maxLines = 1) },
-                    modifier = Modifier.testTag(danmakuLocationChipTag(location)),
-                    leadingIcon = if (selected) {
-                        { Icon(Icons.Rounded.Check, null, Modifier.size(18.dp)) }
-                    } else null,
+                    modifier = Modifier.testTag(danmakuLocationTileTag(location)),
                 )
             }
         }
@@ -271,6 +266,70 @@ fun DanmakuStylePanel(
             }
         }
     }
+}
+
+/**
+ * 位置选项: 一个迷你屏幕, 把弹幕条画在对应位置 (滚动带拖尾), 所见即所得.
+ */
+@Composable
+private fun DanmakuLocationTile(
+    location: DanmakuLocation,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scheme = MaterialTheme.colorScheme
+    val barColor = if (selected) scheme.primary else scheme.onSurfaceVariant
+    val label = location.displayName()
+    Column(
+        modifier
+            .width(84.dp)
+            .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
+            .semantics { contentDescription = label },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            Modifier
+                .size(84.dp, 50.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(if (selected) scheme.surfaceContainerHighest else scheme.surfaceContainerLowest)
+                .border(
+                    width = if (selected) 2.dp else 1.dp,
+                    color = if (selected) scheme.primary else scheme.outlineVariant,
+                    shape = RoundedCornerShape(6.dp),
+                ),
+        ) {
+            val y = when (location) {
+                DanmakuLocation.TOP -> 8.dp
+                DanmakuLocation.NORMAL -> 23.dp
+                DanmakuLocation.BOTTOM -> 38.dp
+            }
+            DanmakuBar(x = 24.dp, y = y, width = 36.dp, color = barColor)
+            if (location == DanmakuLocation.NORMAL) {
+                // 拖尾: 表示这条弹幕在向左滚动
+                DanmakuBar(x = 10.dp, y = y, width = 22.dp, color = barColor.copy(alpha = 0.55f))
+                DanmakuBar(x = 66.dp, y = y, width = 14.dp, color = barColor.copy(alpha = 0.3f))
+            }
+        }
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = if (selected) scheme.onSurface else scheme.onSurfaceVariant,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun DanmakuBar(x: Dp, y: Dp, width: Dp, color: Color) {
+    Box(
+        Modifier
+            .offset(x, y)
+            .size(width, 4.dp)
+            .clip(RoundedCornerShape(2.dp))
+            .background(color),
+    )
 }
 
 @Composable

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -69,7 +69,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -95,6 +94,7 @@ import me.him188.ani.app.ui.comment.CommentReportHost
 import me.him188.ani.app.ui.comment.CommentReportState
 import me.him188.ani.app.ui.comment.CommentState
 import me.him188.ani.app.ui.danmaku.DanmakuEditorState
+import me.him188.ani.app.ui.danmaku.DanmakuStylePanel
 import me.him188.ani.app.ui.danmaku.DummyDanmakuEditor
 import me.him188.ani.app.ui.danmaku.PlayerDanmakuEditor
 import me.him188.ani.app.ui.danmaku.PlayerDanmakuHost
@@ -168,7 +168,6 @@ import me.him188.ani.app.videoplayer.ui.progress.rememberMediaProgressFramePrevi
 import me.him188.ani.app.videoplayer.ui.progress.rememberMediaProgressSliderState
 import me.him188.ani.app.videoplayer.ui.rememberPlayerFullscreenState
 import me.him188.ani.danmaku.api.DanmakuContent
-import me.him188.ani.danmaku.api.DanmakuLocation
 import me.him188.ani.danmaku.ui.DanmakuHostState
 import me.him188.ani.danmaku.ui.DanmakuPresentation
 import me.him188.ani.datasources.api.source.MediaFetchRequest
@@ -341,7 +340,12 @@ private fun EpisodeScreenContent(
                             }
                         },
                         scope,
+                        onStyleChange = { vm.setDanmakuSendStyle(it) },
                     )
+                }
+                LaunchedEffect(danmakuEditorState) {
+                    // 只读取一次初始值. 之后用户的修改由 onStyleChange 持久化, 不再回流, 避免连续点选时闪动.
+                    danmakuEditorState.style = vm.danmakuSendStyleFlow.first()
                 }
 
                 WatchTogetherPopupVisibilityEffect(
@@ -822,8 +826,8 @@ private fun EpisodeScreenContentPhone(
                             DanmakuContent(
                                 vm.player.currentPositionMillis.value,
                                 text = text,
-                                color = Color.White.toArgb(),
-                                location = DanmakuLocation.NORMAL,
+                                color = danmakuEditorState.style.color,
+                                location = danmakuEditorState.style.location,
                             ),
                         )
                         dismiss()
@@ -863,6 +867,11 @@ private fun DetachedDanmakuEditorLayout(
             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
             onEscape = onDismiss,
             colors = OutlinedTextFieldDefaults.colors(),
+        )
+        DanmakuStylePanel(
+            style = danmakuEditorState.style,
+            onStyleChange = { danmakuEditorState.updateStyle(it) },
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -36,6 +36,8 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -854,7 +856,11 @@ private fun DetachedDanmakuEditorLayout(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier.padding(all = 16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    // 展开自定义颜色后内容会超出半高的 bottom sheet, 允许滚动 (sheet 会先展开到全高, 再滚动内容)
+    Column(
+        modifier.verticalScroll(rememberScrollState()).padding(all = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
         Text(stringResource(Lang.episode_send_danmaku), style = MaterialTheme.typography.titleMedium)
         val isSending = danmakuEditorState.isSending.collectAsStateWithLifecycle()
         PlayerDanmakuEditor(

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -125,7 +125,9 @@ import me.him188.ani.app.ui.comment.EditCommentSticker
 import me.him188.ani.app.ui.comment.UICommentSource
 import me.him188.ani.app.ui.comment.reportSnapshotText
 import me.him188.ani.app.ui.comment.toDataReason
+import me.him188.ani.app.ui.danmaku.DanmakuSendStyle
 import me.him188.ani.app.ui.danmaku.UIDanmakuEvent
+import me.him188.ani.app.ui.danmaku.toDanmakuSendStyle
 import me.him188.ani.app.ui.episode.PlayingEpisodeSummary
 import me.him188.ani.app.ui.episode.danmaku.MatchingDanmakuPresenter
 import me.him188.ani.app.ui.episode.danmaku.MatchingDanmakuUiState
@@ -1014,6 +1016,20 @@ class EpisodeViewModel(
     suspend fun postDanmaku(danmaku: DanmakuContent): DanmakuInfo {
         return withContext(Dispatchers.Default) {
             danmakuRepository.post(fetchPlayState.getCurrentEpisodeId(), danmaku)
+        }
+    }
+
+    /**
+     * 发送弹幕时使用的样式 (颜色, 位置), 持久化在 [SettingsRepository.danmakuSettings].
+     */
+    val danmakuSendStyleFlow: Flow<DanmakuSendStyle> =
+        settingsRepository.danmakuSettings.flow.map { it.toDanmakuSendStyle() }
+
+    fun setDanmakuSendStyle(style: DanmakuSendStyle) {
+        launchInBackground {
+            settingsRepository.danmakuSettings.update {
+                copy(sendColor = style.color, sendLocation = style.location)
+            }
         }
     }
 

--- a/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
@@ -59,7 +59,7 @@ class DanmakuStylePickerTest {
             waitUntil { onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).exists() }
         }
         onNodeWithTag(danmakuColorSwatchTag(0xFFFFFF)).assertIsSelected()
-        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.NORMAL)).assertIsSelected()
+        onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.NORMAL)).assertIsSelected()
 
         onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).performClick()
         runOnIdle {
@@ -67,11 +67,11 @@ class DanmakuStylePickerTest {
         }
         onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).assertIsSelected()
 
-        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.TOP)).performClick()
+        onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.TOP)).performClick()
         runOnIdle {
             assertEquals(DanmakuSendStyle(0xFE0302, DanmakuLocation.TOP), style)
         }
-        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.TOP)).assertIsSelected()
+        onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.TOP)).assertIsSelected()
 
         // 选择后弹层保持打开, 方便继续调整
         onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).assertExists()
@@ -91,7 +91,7 @@ class DanmakuStylePickerTest {
             runOnIdle { assertEquals(color, style.color) }
         }
         for (location in DanmakuSendColors.Locations) {
-            onNodeWithTag(danmakuLocationChipTag(location)).performClick()
+            onNodeWithTag(danmakuLocationTileTag(location)).performClick()
             runOnIdle { assertEquals(location, style.location) }
         }
     }

--- a/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -93,6 +94,9 @@ class DanmakuStylePickerTest {
         // 进入自定义模式不改变颜色
         runOnIdle { assertEquals(0xFFFFFF, style.color) }
 
+        // 面板设置了 canFocus = false, 十六进制输入框必须能单独获得焦点, 否则实际运行时无法键入
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).performClick()
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).assertIsFocused()
         onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).performTextReplacement("ff00aa")
         runOnIdle { assertEquals(0xFF00AA, style.color) }
 

--- a/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.danmaku
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.data.models.preference.DarkMode
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.framework.doesNotExist
+import me.him188.ani.app.ui.framework.exists
+import me.him188.ani.app.ui.framework.runAniComposeUiTest
+import me.him188.ani.danmaku.api.DanmakuLocation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DanmakuStylePickerTest {
+    @Test
+    fun `default style is white and floating`() {
+        assertEquals(0xFFFFFF, DanmakuSendStyle.Default.color)
+        assertEquals(DanmakuLocation.NORMAL, DanmakuSendStyle.Default.location)
+    }
+
+    @Test
+    fun `picker - click button opens panel, selecting color and location updates style`() = runAniComposeUiTest {
+        var style by mutableStateOf(DanmakuSendStyle.Default)
+        setContent {
+            ProvideCompositionLocalsForPreview(darkMode = DarkMode.DARK) {
+                // 弹层在按钮上方, 所以把按钮放在底部留出空间
+                Box(Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.BottomStart) {
+                    DanmakuStylePicker(style, onStyleChange = { style = it })
+                }
+            }
+        }
+
+        runOnIdle {
+            waitUntil { onNodeWithTag(TAG_DANMAKU_STYLE_BUTTON).exists() }
+            waitUntil { onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).doesNotExist() }
+        }
+
+        onNodeWithTag(TAG_DANMAKU_STYLE_BUTTON).performClick()
+        runOnIdle {
+            waitUntil { onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).exists() }
+        }
+        onNodeWithTag(danmakuColorSwatchTag(0xFFFFFF)).assertIsSelected()
+        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.NORMAL)).assertIsSelected()
+
+        onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).performClick()
+        runOnIdle {
+            assertEquals(DanmakuSendStyle(0xFE0302, DanmakuLocation.NORMAL), style)
+        }
+        onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).assertIsSelected()
+
+        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.TOP)).performClick()
+        runOnIdle {
+            assertEquals(DanmakuSendStyle(0xFE0302, DanmakuLocation.TOP), style)
+        }
+        onNodeWithTag(danmakuLocationChipTag(DanmakuLocation.TOP)).assertIsSelected()
+
+        // 选择后弹层保持打开, 方便继续调整
+        onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).assertExists()
+    }
+
+    @Test
+    fun `panel - every preset color and location is selectable`() = runAniComposeUiTest {
+        var style by mutableStateOf(DanmakuSendStyle.Default)
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                DanmakuStylePanel(style, onStyleChange = { style = it })
+            }
+        }
+
+        for (color in DanmakuSendColors.Presets) {
+            onNodeWithTag(danmakuColorSwatchTag(color)).performClick()
+            runOnIdle { assertEquals(color, style.color) }
+        }
+        for (location in DanmakuSendColors.Locations) {
+            onNodeWithTag(danmakuLocationChipTag(location)).performClick()
+            runOnIdle { assertEquals(location, style.location) }
+        }
+    }
+}

--- a/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/danmaku/DanmakuStylePickerTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.models.preference.DarkMode
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
@@ -61,20 +62,48 @@ class DanmakuStylePickerTest {
         onNodeWithTag(danmakuColorSwatchTag(0xFFFFFF)).assertIsSelected()
         onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.NORMAL)).assertIsSelected()
 
-        onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).performClick()
+        onNodeWithTag(danmakuColorSwatchTag(0xFF4D4D)).performClick()
         runOnIdle {
-            assertEquals(DanmakuSendStyle(0xFE0302, DanmakuLocation.NORMAL), style)
+            assertEquals(DanmakuSendStyle(0xFF4D4D, DanmakuLocation.NORMAL), style)
         }
-        onNodeWithTag(danmakuColorSwatchTag(0xFE0302)).assertIsSelected()
+        onNodeWithTag(danmakuColorSwatchTag(0xFF4D4D)).assertIsSelected()
 
         onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.TOP)).performClick()
         runOnIdle {
-            assertEquals(DanmakuSendStyle(0xFE0302, DanmakuLocation.TOP), style)
+            assertEquals(DanmakuSendStyle(0xFF4D4D, DanmakuLocation.TOP), style)
         }
         onNodeWithTag(danmakuLocationTileTag(DanmakuLocation.TOP)).assertIsSelected()
 
         // 选择后弹层保持打开, 方便继续调整
         onNodeWithTag(TAG_DANMAKU_STYLE_PANEL).assertExists()
+    }
+
+    @Test
+    fun `panel - custom color via hex input`() = runAniComposeUiTest {
+        var style by mutableStateOf(DanmakuSendStyle.Default)
+        setContent {
+            ProvideCompositionLocalsForPreview {
+                DanmakuStylePanel(style, onStyleChange = { style = it })
+            }
+        }
+
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).assertDoesNotExist()
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH).performClick()
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_SWATCH).assertIsSelected()
+        // 进入自定义模式不改变颜色
+        runOnIdle { assertEquals(0xFFFFFF, style.color) }
+
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).performTextReplacement("ff00aa")
+        runOnIdle { assertEquals(0xFF00AA, style.color) }
+
+        // 不完整的输入不生效
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).performTextReplacement("12")
+        runOnIdle { assertEquals(0xFF00AA, style.color) }
+
+        // 选回预设后退出自定义模式
+        onNodeWithTag(danmakuColorSwatchTag(0xFF4D4D)).performClick()
+        runOnIdle { assertEquals(0xFF4D4D, style.color) }
+        onNodeWithTag(TAG_DANMAKU_CUSTOM_COLOR_HEX).assertDoesNotExist()
     }
 
     @Test

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onChild
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -203,6 +205,12 @@ class EpisodeVideoControllerTest {
         get() = onNodeWithTag(TAG_PROGRESS_SLIDER, useUnmergedTree = true)
     private val SemanticsNodeInteractionsProvider.danmakuEditor
         get() = onNodeWithTag(TAG_DANMAKU_EDITOR, useUnmergedTree = true)
+
+    /**
+     * 弹幕编辑器里的文本输入框 (编辑器行里还有样式选择按钮).
+     */
+    private val SemanticsNodeInteractionsProvider.danmakuEditorTextField
+        get() = danmakuEditor.onChildren().filterToOne(hasSetTextAction())
     private val SemanticsNodeInteractionsProvider.danmakuIconButton
         get() = onNodeWithTag(TAG_DANMAKU_ICON_BUTTON, useUnmergedTree = true)
     private val SemanticsNodeInteractionsProvider.player
@@ -1032,7 +1040,7 @@ class EpisodeVideoControllerTest {
 
         videoGestureHost.assertIsFocused()
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
         danmakuEditor.performKeyInput {
             pressKey(Key.B)
             pressKey(Key.Spacebar)
@@ -1087,7 +1095,7 @@ class EpisodeVideoControllerTest {
         }
 
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
         danmakuEditor.performKeyInput {
             pressKey(Key.Tab)
         }
@@ -1134,7 +1142,7 @@ class EpisodeVideoControllerTest {
             waitForIdle()
 
             danmakuEditor.performClick()
-            danmakuEditor.onChild().assertIsFocused()
+            danmakuEditorTextField.assertIsFocused()
             danmakuEditor.performKeyInput {
                 pressKey(Key.Escape)
             }
@@ -1169,7 +1177,7 @@ class EpisodeVideoControllerTest {
 
         videoGestureHost.assertIsFocused()
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
 
         videoGestureHost.slightlyMoveFromCenterToRight()
         waitForIdle()
@@ -1197,7 +1205,7 @@ class EpisodeVideoControllerTest {
         }
 
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
         runOnIdle {
             showDanmakuEditor = false
         }
@@ -1322,7 +1330,7 @@ class EpisodeVideoControllerTest {
 
         videoGestureHost.assertIsFocused()
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
 
         videoGestureHost.slightlyMoveFromCenterToRight()
         waitForIdle()
@@ -1366,15 +1374,15 @@ class EpisodeVideoControllerTest {
         waitForIdle()
 
         danmakuEditor.performClick()
-        danmakuEditor.onChild().assertIsFocused()
+        danmakuEditorTextField.assertIsFocused()
 
         fullScreenButton.performClick()
         waitForIdle()
-        danmakuEditor.onChild().assertIsNotFocused()
+        danmakuEditorTextField.assertIsNotFocused()
 
         fullScreenButton.performClick()
         waitForIdle()
-        danmakuEditor.onChild().assertIsNotFocused()
+        danmakuEditorTextField.assertIsNotFocused()
     }
 
     private fun AniComposeUiTest.testClickAndWaitForHide() {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -472,7 +472,13 @@ object PlayerControllerDefaults {
                     singleLine = singleLine,
                     visualTransformation = VisualTransformation.None,
                     interactionSource = interactionSource,
-                    contentPadding = PaddingValues(vertical = 7.dp, horizontal = 16.dp),
+                    contentPadding = PaddingValues(
+                        // 有 leadingIcon 时它自带 48dp 的最小宽度, 文字前不再留 16dp
+                        start = if (leadingIcon != null) 4.dp else 16.dp,
+                        end = 16.dp,
+                        top = 7.dp,
+                        bottom = 7.dp,
+                    ),
                     colors = colors,
                     placeholder = {
                         Row(


### PR DESCRIPTION
## 概述

发弹幕时可以选择颜色和位置了。默认白色、滚动，选择会记住。

## 改动

- **设置**：`DanmakuSettings` 新增 `sendColor`（RGB）和 `sendLocation`，持久化用户上次选择的样式。
- **播放器内**：输入框内部最前面（`DanmakuTextField` 的 `leadingIcon`）新增样式按钮（`DanmakuStylePicker`）：22×16 的迷你屏幕图标，弹幕条画在当前位置（顶部 / 三条滚动 / 底部）并用当前颜色，和面板里的缩略屏同一套语言；有 leadingIcon 时输入框文字前的 padding 从 16dp 减到 4dp。点击在上方弹出面板：位置用三个 84×50 的缩略屏选择（弹幕条画在顶部 / 底部；滚动格是三条轨道错开的弹幕条持续向左滚动），颜色为 11 个偏亮的预设色（在视频画面上可读）加一格自定义，色块按可用宽度排成网格并撑满整行（桌面弹层 6 列，和位置缩略屏同宽；手机端更宽则列数更多）：彩虹环，选中后在 `surfaceContainer` 底色的圆角容器里展开十六进制输入框和 R / G / B 三个滑条。
- **手机端**：发弹幕底部弹窗（`DetachedDanmakuEditorLayout`）在输入框下方内嵌同一面板（`DanmakuStylePanel`）；展开自定义颜色后内容超出半高的 sheet，弹窗内容改为可滚动（上滑先展开 sheet 再滚动内容）。
- **焦点**：只选预设时弹层 `focusable = false`，位置/颜色选项和滑条 `canFocus = false`，桌面端点选时弹幕输入框不丢焦点，"编辑弹幕时暂停"的视频不会被意外恢复；展开自定义颜色后需要键入十六进制，非 focusable 弹层里的文本框拿不到焦点，此时弹层改为可聚焦（`key(customMode)` 重建 Popup）。弹层打开期间通过 `AlwaysOnRequester` 保持控制器显示。
- **接线**：`DanmakuEditorState` 新增 `style` / `updateStyle()`；`EpisodeViewModel` 新增 `danmakuSendStyleFlow` / `setDanmakuSendStyle()`；播放器内和底部弹窗两条发送路径都使用所选颜色和位置。
- **文案**：新增 `danmaku_send_style` / `danmaku_send_style_color` / `danmaku_send_style_location`；位置标签复用显示设置里已有的"顶部 / 滚动 / 底部"。

## 截图

真实运行截图：桌面端为 macOS 开发版实际播放中截图，手机端为 Android 模拟器（API 35）。

| 播放器内样式弹层（深色） | 自定义颜色展开 | 手机端底部弹窗内嵌面板（浅色） |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/46eedc93-65bf-4e13-80a2-7bdec45e2ed7" width="300"> | <img src="https://github.com/user-attachments/assets/3dc24382-94ab-4838-8ef7-709c5f5da82a" width="300"> | <img src="https://github.com/user-attachments/assets/b32e1e17-30c0-4c7b-ab02-7cc4bce2e49a" width="360"> |

左：已选红色 + 滚动。中：自定义 #7B61FF + 顶部（十六进制手动键入）。右：手机端，自定义 #7B61FF + 滚动，sheet 上滑展开后。

输入框里的样式按钮三种状态（白色滚动 / 红色顶部 / 蓝色底部）：

<img src="https://github.com/user-attachments/assets/5c73ac47-9124-4c8c-84d8-db1a6c81086c" width="320">

## 测试

- 新增 `DanmakuStylePickerTest`：默认值、点按钮开面板并选色选位置、全部预设可选、自定义颜色（十六进制输入框点击后获得焦点、输入生效、不完整输入不生效、选回预设收起）。
- `EpisodeVideoControllerTest` 中取编辑器子节点的 `onChild()` 改为按可输入文本查找（编辑器行现在多了一个按钮），相关用例通过。
- 在 macOS 开发版（真实播放）和 Android 模拟器上实际操作验证：开面板、选位置/颜色、键入十六进制、拖滑条、手机端 sheet 展开与滚动。真机验证发现并修复了两个问题：桌面端弹层内十六进制输入框无法聚焦，手机端半高 sheet 截断自定义编辑区。
- 渲染仍受显示设置里"彩色"开关控制。iOS 未验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
