### PR TITLE
fix(bangumi): 合并页 ViewModel 原子更新列表与选择, 消除 BangumiMergeViewModelTest flaky

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/bangumi/merge/BangumiMergeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/bangumi/merge/BangumiMergeViewModel.kt
@@ -171,14 +171,15 @@ internal val BangumiMergeState.isSyncSettled: Boolean
 /**
  * @param syncPollInterval 服务端全量同步尚未完成时, 静默刷新冲突列表的间隔.
  * @param syncPollTimeout 轮询的时间上限, 超过后停止轮询 (与 [BangumiConflictChecker] 一致), 避免同步失败时无限轮询.
- * @param pollCoroutineContext 轮询协程的额外 context. 测试时传入 `StandardTestDispatcher(testScheduler)` 以用虚拟时间驱动轮询.
+ * @param backgroundCoroutineContext 见 [AbstractViewModel]. 测试时传入 `StandardTestDispatcher(testScheduler)`,
+ * 状态流合并、加载、提交与轮询全部跑在测试的虚拟时间调度器上.
  */
 @Stable
 class BangumiMergeViewModel(
     private val syncPollInterval: Duration = 5.seconds,
     private val syncPollTimeout: Duration = 10.minutes,
-    pollCoroutineContext: CoroutineContext = EmptyCoroutineContext,
-) : AbstractViewModel(), KoinComponent {
+    backgroundCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+) : AbstractViewModel(backgroundCoroutineContext), KoinComponent {
     private val mergeRepository: BangumiMergeRepository by inject()
     private val conflictChecker: BangumiConflictChecker by inject()
 
@@ -191,7 +192,17 @@ class BangumiMergeViewModel(
         ) : LoadState()
     }
 
-    private val loadState = MutableStateFlow<LoadState>(LoadState.Loading)
+    /**
+     * 服务端状态与用户的选择. 二者放在同一个 [MutableStateFlow] 里一次更新:
+     * 选择依附于冲突列表, 列表被替换 (静默刷新 / 提交后的剩余) 时必须与过滤后的选择同帧发布,
+     * 分开两个流更新会让 [uiState] 出现 "新列表 + 旧选择" 的中间帧 (界面闪一下错误的进度, 测试也会读到).
+     */
+    private data class Model(
+        val load: LoadState,
+        val choices: Map<BangumiConflictKey, BangumiMergeSide>,
+    )
+
+    private val model = MutableStateFlow(Model(LoadState.Loading, emptyMap()))
     private val loadTasker = MonoTasker(backgroundScope)
 
     /**
@@ -199,13 +210,12 @@ class BangumiMergeViewModel(
      */
     private val loadStarted = atomic(false)
 
-    private val choices = MutableStateFlow<Map<BangumiConflictKey, BangumiMergeSide>>(emptyMap())
     private val isApplying = MutableStateFlow(false)
     private val applyOutcome = MutableStateFlow<BangumiMergeApplyOutcome?>(null)
 
     val uiState: StateFlow<BangumiMergeUiState> = combine(
-        loadState, choices, isApplying, applyOutcome,
-    ) { load, choices, isApplying, applyOutcome ->
+        model, isApplying, applyOutcome,
+    ) { (load, choices), isApplying, applyOutcome ->
         BangumiMergeUiState(
             isLoading = load is LoadState.Loading,
             loadError = (load as? LoadState.Failed)?.error,
@@ -223,9 +233,9 @@ class BangumiMergeViewModel(
 
     init {
         // 服务端全量同步尚未完成 (进行中, 或从未同步过) 时冲突列表可能不完整, 静默轮询直到同步结束或超时; 用户已做的选择保留.
-        backgroundScope.launch(pollCoroutineContext) {
-            loadState
-                .map { (it as? LoadState.Ready)?.mergeState?.isSyncSettled == false }
+        backgroundScope.launch {
+            model
+                .map { (it.load as? LoadState.Ready)?.mergeState?.isSyncSettled == false }
                 .distinctUntilChanged()
                 .collectLatest { unsettled ->
                     if (!unsettled) return@collectLatest
@@ -241,23 +251,24 @@ class BangumiMergeViewModel(
     }
 
     /**
-     * 重新拉取, 清空已有选择.
+     * 重新拉取, 清空已有选择. 进入加载态与清空选择同帧发布, 不会出现 "旧列表 + 空选择" 的中间帧.
      */
     fun reload() {
-        choices.value = emptyMap()
+        model.update { it.copy(load = LoadState.Loading, choices = emptyMap()) }
         startLoad()
     }
 
     private fun startLoad() {
+        model.update { it.copy(load = LoadState.Loading) }
         loadTasker.launch {
-            loadState.value = LoadState.Loading
-            loadState.value = try {
+            val loaded = try {
                 mergeRepository.getMergeState().toReadyState()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 LoadState.Failed(LoadError.fromException(e))
             }
+            model.update { it.copy(load = loaded) }
         }
     }
 
@@ -278,17 +289,21 @@ class BangumiMergeViewModel(
 
     private fun BangumiMergeState.toReadyState() = LoadState.Ready(this, toConflictGroups())
 
+    /**
+     * 用 [ready] 替换服务端状态, 同时去掉已不在列表中的选择 (一次原子更新).
+     */
     private fun replaceReadyState(ready: LoadState.Ready) {
         val remainingKeys = ready.groups.flatMapTo(mutableSetOf()) { it.conflictKeys }
-        loadState.value = ready
-        choices.update { current -> current.filterKeys { it in remainingKeys } }
+        model.update { current ->
+            current.copy(load = ready, choices = current.choices.filterKeys { it in remainingKeys })
+        }
     }
 
     /**
      * 为单个冲突选择一侧.
      */
     fun select(key: BangumiConflictKey, side: BangumiMergeSide) {
-        choices.update { it + (key to side) }
+        model.update { it.copy(choices = it.choices + (key to side)) }
     }
 
     /**
@@ -296,10 +311,10 @@ class BangumiMergeViewModel(
      * 无法确定较新一侧的冲突 (评分行, Bangumi 侧已删除的行) 保持原状.
      */
     fun adoptNewer() {
-        val ready = loadState.value as? LoadState.Ready ?: return
-        choices.update { current ->
-            buildMap {
-                putAll(current)
+        model.update { current ->
+            val ready = current.load as? LoadState.Ready ?: return@update current
+            val newChoices = buildMap {
+                putAll(current.choices)
                 for (group in ready.groups) {
                     for (conflict in group.conflicts) {
                         val newer = conflict.newerSide ?: continue
@@ -307,6 +322,7 @@ class BangumiMergeViewModel(
                     }
                 }
             }
+            current.copy(choices = newChoices)
         }
     }
 
@@ -314,9 +330,9 @@ class BangumiMergeViewModel(
      * 列头 "全选": 为所有冲突选择 [side].
      */
     fun selectAll(side: BangumiMergeSide) {
-        val ready = loadState.value as? LoadState.Ready ?: return
-        choices.update {
-            ready.groups.flatMap { group -> group.conflictKeys }.associateWith { side }
+        model.update { current ->
+            val ready = current.load as? LoadState.Ready ?: return@update current
+            current.copy(choices = ready.groups.flatMap { group -> group.conflictKeys }.associateWith { side })
         }
     }
 
@@ -345,10 +361,10 @@ class BangumiMergeViewModel(
      * 收尾 (仓库内失效本地缓存, 这里触发冲突数检查) 必须完成, 否则收藏页与冲突数会停留在合并前的状态.
      */
     suspend fun apply(): BangumiMergeApplyOutcome? {
-        val ready = loadState.value as? LoadState.Ready ?: return null
+        val (load, currentChoices) = model.value
+        val ready = load as? LoadState.Ready ?: return null
         if (ready.groups.isEmpty()) return null
         val allKeys = ready.groups.flatMap { it.conflictKeys }
-        val currentChoices = choices.value
         if (!allKeys.all { it in currentChoices }) return null
         if (!isApplying.compareAndSet(expect = false, update = true)) return null
         return try {

--- a/app/shared/src/commonTest/kotlin/ui/bangumi/merge/BangumiMergeTestSupport.kt
+++ b/app/shared/src/commonTest/kotlin/ui/bangumi/merge/BangumiMergeTestSupport.kt
@@ -25,6 +25,8 @@ import me.him188.ani.app.data.repository.subject.OfflineSubjectDisplayInfo
 import me.him188.ani.app.data.repository.subject.SubjectCollectionRepository
 import me.him188.ani.app.domain.bangumi.BangumiConflictChecker
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Instant
 
 /**
@@ -155,12 +157,17 @@ internal class StubSubjectCollectionRepository : SubjectCollectionRepository() {
 
 /**
  * 用 [repository] 构造一个真实的 [BangumiConflictChecker] (固定时钟, 不轮询).
+ *
+ * @param parentCoroutineContext 后台检查协程的 context. 传入 `StandardTestDispatcher(testScheduler)` 可让检查跑在测试的调度器上
+ * (不要传入 `TestScope` 的 `Job`, 否则 `runTest` 会等待检查协程结束).
  */
 internal fun createTestConflictChecker(
     repository: BangumiMergeRepository,
     getCurrentTimeMillis: () -> Long = { 1_000_000L },
+    parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
 ): BangumiConflictChecker = BangumiConflictChecker(
     mergeRepository = repository,
     subjectCollectionRepository = StubSubjectCollectionRepository(),
+    parentCoroutineContext = parentCoroutineContext,
     getCurrentTimeMillis = getCurrentTimeMillis,
 )

--- a/app/shared/src/commonTest/kotlin/ui/bangumi/merge/BangumiMergeViewModelTest.kt
+++ b/app/shared/src/commonTest/kotlin/ui/bangumi/merge/BangumiMergeViewModelTest.kt
@@ -10,8 +10,6 @@
 package me.him188.ani.app.ui.bangumi.merge
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
@@ -21,8 +19,6 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import me.him188.ani.app.data.models.bangumi.BangumiConflictField
 import me.him188.ani.app.data.models.bangumi.BangumiConflictFieldType
 import me.him188.ani.app.data.models.bangumi.BangumiConflictKey
@@ -47,8 +43,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -57,7 +51,11 @@ import kotlin.time.Instant
 
 /**
  * 覆盖 [BangumiMergeViewModel]: 加载 / 选择 / 采用较新的 / 全选 / 应用门控 / 提交与剩余状态 / 失败 /
- * 同步未完成 (进行中或从未同步) 时轮询与上限 (轮询协程跑在 runTest 的调度器上, 用虚拟时间驱动) / 作用域取消时提交仍完成.
+ * 同步未完成 (进行中或从未同步) 时轮询与上限 / 作用域取消时提交仍完成.
+ *
+ * ViewModel 的后台作用域与 [BangumiConflictChecker] 都跑在 `runTest` 的调度器上 (单线程, 虚拟时间):
+ * 状态流的合并、加载、提交、轮询和测试体按确定的顺序交替执行, 不涉及真实线程, 断言读到的每一帧都是确定的.
+ * 测试体挂起等待 `uiState` 时, `runTest` 会推进虚拟时间, `delay` / `withTimeoutOrNull` 自动到期.
  */
 @OptIn(TestOnly::class, ExperimentalCoroutinesApi::class)
 class BangumiMergeViewModelTest {
@@ -72,8 +70,11 @@ class BangumiMergeViewModelTest {
 
     private lateinit var checker: BangumiConflictChecker
 
-    private fun startTestKoin(repository: FakeBangumiMergeRepository) {
-        checker = createTestConflictChecker(repository)
+    private fun TestScope.startTestKoin(repository: FakeBangumiMergeRepository) {
+        checker = createTestConflictChecker(
+            repository,
+            parentCoroutineContext = StandardTestDispatcher(testScheduler),
+        )
         startKoin {
             modules(
                 module {
@@ -89,24 +90,14 @@ class BangumiMergeViewModelTest {
      */
     private val viewModels = mutableListOf<BangumiMergeViewModel>()
 
-    private fun newViewModel(
+    private fun TestScope.newViewModel(
         syncPollInterval: Duration = 5.seconds,
         syncPollTimeout: Duration = 10.minutes,
-        pollCoroutineContext: CoroutineContext = EmptyCoroutineContext,
-    ): BangumiMergeViewModel = BangumiMergeViewModel(syncPollInterval, syncPollTimeout, pollCoroutineContext)
-        .also { viewModels += it }
-
-    /**
-     * 轮询协程跑在 runTest 的调度器上: `delay` / `withTimeoutOrNull` 用虚拟时间, 测试体挂起等待时 runTest 会自动推进.
-     */
-    private fun TestScope.newPollingViewModel(
-        syncPollInterval: Duration = 5.seconds,
-        syncPollTimeout: Duration = 10.minutes,
-    ): BangumiMergeViewModel = newViewModel(
+    ): BangumiMergeViewModel = BangumiMergeViewModel(
         syncPollInterval,
         syncPollTimeout,
-        pollCoroutineContext = StandardTestDispatcher(testScheduler),
-    )
+        backgroundCoroutineContext = StandardTestDispatcher(testScheduler),
+    ).also { viewModels += it }
 
     @AfterTest
     fun tearDown() {
@@ -115,15 +106,9 @@ class BangumiMergeViewModelTest {
         stopKoin()
     }
 
-    // 不用 withTimeout: runTest 的虚拟时间会在真实 Default 线程完成前触发超时.
-    // runTest 自带 60s 真实超时兜底.
+    // 加载在测试调度器上完成, 挂起等待即可; runTest 自带 60s 真实超时兜底.
     private suspend fun BangumiMergeViewModel.awaitLoaded(): BangumiMergeUiState =
         uiState.first { !it.isLoading }
-
-    // 在真实线程上等待 (带真实超时): runTest 的虚拟时间会让 withTimeout 立刻触发, 所以切到 Default.
-    private suspend fun <T> awaitReal(deferred: Deferred<T>): T = withContext(Dispatchers.Default) {
-        withTimeout(10.seconds) { deferred.await() }
-    }
 
     private fun testRepository(
         resolveHandler: suspend (List<BangumiConflictResolution>) -> BangumiMergeState = {
@@ -349,8 +334,7 @@ class BangumiMergeViewModelTest {
         assertTrue(resolutions.filterNot { it.subjectId == 2 && it.fieldType == BangumiConflictFieldType.RATING }
             .all { it.side == BangumiMergeSide.BANGUMI })
 
-        // 状态替换为剩余 (空), 选择清空; 服务端返回的剩余状态带同步时间, 不会被当成 "同步中".
-        // 剩余状态先于 isApplying 复位发布, 等两者都到位再断言, 避免读到中间帧.
+        // 状态替换为剩余 (空), 选择清空 (与列表同帧); 服务端返回的剩余状态带同步时间, 不会被当成 "同步中".
         val after = vm.uiState.first { !it.hasConflicts && !it.isApplying }
         assertTrue(after.choices.isEmpty())
         assertFalse(after.isApplying)
@@ -522,7 +506,7 @@ class BangumiMergeViewModelTest {
             },
         )
         startTestKoin(repository)
-        val vm = newPollingViewModel(syncPollInterval = 20.milliseconds)
+        val vm = newViewModel(syncPollInterval = 20.milliseconds)
 
         val loading = vm.awaitLoaded()
         assertTrue(loading.syncInProgress)
@@ -552,7 +536,7 @@ class BangumiMergeViewModelTest {
             },
         )
         startTestKoin(repository)
-        val vm = newPollingViewModel(syncPollInterval = 20.milliseconds)
+        val vm = newViewModel(syncPollInterval = 20.milliseconds)
 
         val unsettled = vm.awaitLoaded()
         assertNull(unsettled.lastSyncedAt)
@@ -572,7 +556,7 @@ class BangumiMergeViewModelTest {
         val repository = FakeBangumiMergeRepository({ BangumiMergeState.Empty })
         startTestKoin(repository)
         // 上限不取间隔的整数倍, 避免最后一次轮询与超时同时到期
-        val vm = newPollingViewModel(syncPollInterval = 10.milliseconds, syncPollTimeout = 75.milliseconds)
+        val vm = newViewModel(syncPollInterval = 10.milliseconds, syncPollTimeout = 75.milliseconds)
 
         assertTrue(vm.awaitLoaded().syncInProgress)
         assertEquals(1, repository.stateCalls)
@@ -604,15 +588,16 @@ class BangumiMergeViewModelTest {
         vm.uiState.first { it.allResolved }
 
         vm.startApply()
-        awaitReal(repository.resolveStarted)
+        repository.resolveStarted.await()
 
         // 离开界面: ViewModel 清除时取消后台作用域, 而请求已经发出.
         vm.backgroundScope.cancel()
         repository.resolveGate!!.complete(Unit)
 
-        // 提交仍然完成, 并触发了冲突数的强制检查 (仓库内的缓存失效也在同一不可取消块内).
-        awaitReal(repository.resolveFinished)
-        awaitReal(repository.summaryRequested)
+        // 提交仍然完成 (NonCancellable 块在已取消的作用域里继续被调度), 并触发了冲突数的强制检查
+        // (仓库内的缓存失效也在同一不可取消块内).
+        repository.resolveFinished.await()
+        repository.summaryRequested.await()
         checker.joinCheck()
         assertEquals(1, repository.resolveCalls.size)
         assertEquals(1, repository.summaryCalls)

--- a/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/AbstractViewModel.kt
+++ b/app/shared/ui-foundation/src/commonMain/kotlin/ui/foundation/AbstractViewModel.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.cancel
 import me.him188.ani.utils.logging.error
 import me.him188.ani.utils.logging.thisLogger
 import me.him188.ani.utils.logging.trace
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * 带有 [backgroundScope], 当 [AbstractViewModel] 被 forget 时自动 close scope 以防资源泄露.
@@ -28,11 +30,17 @@ import me.him188.ani.utils.logging.trace
  *
  * 注意: 通过 androidx `viewModel {}` 取得的实例不会被 remember, [onRemembered] / [init] 永远不会执行 (作用域由 [onCleared] 关闭);
  * 这类 ViewModel 需要在构造时启动的后台收集应放在 Kotlin `init {}` 块里.
+ *
+ * @param backgroundCoroutineContext [backgroundScope] 的额外 context, 默认为空 (使用 `Dispatchers.Default`).
+ * 测试时可传入 `StandardTestDispatcher(testScheduler)`, 让 ViewModel 的全部后台协程 (状态流合并、加载、轮询) 与测试体跑在同一个
+ * 单线程的虚拟时间调度器上, 状态帧的顺序完全确定. 不应传入 [kotlinx.coroutines.Job] (作用域自带 [SupervisorJob]).
  */ // We can't use Android's Viewmodel because it's not available in Desktop platforms. 
-abstract class AbstractViewModel : RememberObserver, ViewModel(), HasBackgroundScope {
+abstract class AbstractViewModel(
+    backgroundCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+) : RememberObserver, ViewModel(), HasBackgroundScope {
     val logger by lazy { thisLogger() }
 
-    private var _backgroundScope = createBackgroundScope()
+    private var _backgroundScope = createBackgroundScope(backgroundCoroutineContext)
     override val backgroundScope: CoroutineScope
         get() {
             return _backgroundScope
@@ -61,9 +69,9 @@ abstract class AbstractViewModel : RememberObserver, ViewModel(), HasBackgroundS
         }
     }
 
-    private fun createBackgroundScope(): CoroutineScope {
+    private fun createBackgroundScope(additionalContext: CoroutineContext): CoroutineScope {
         return CoroutineScope(
-            CoroutineExceptionHandler { coroutineContext, throwable ->
+            additionalContext + CoroutineExceptionHandler { coroutineContext, throwable ->
                 logger.error(throwable) { "Unhandled exception in background scope for viewmodel ${this::class.qualifiedName}, coroutineContext: $coroutineContext" }
             } + SupervisorJob(),
         )


### PR DESCRIPTION
## 问题

`BangumiMergeViewModelTest` 偶发失败。根源是 `BangumiMergeViewModel` 的 `backgroundScope` 跑在多线程的 `Dispatchers.Default` 上，而测试体跑在 `runTest` 的单线程虚拟时间调度器上，两边没有任何同步，测试只能靠 `uiState.first { 谓词 }` 等待，谓词满足的那一帧不一定是最终帧。

把可疑断言各循环 300 次，四处竞态都稳定复现：

| 测试 | 断言 | 复现 / 300 |
|---|---|---|
| VM-12 | `after.choices == {key3Rating: ANIMEKO}` | 52 |
| VM-08 | `repository.stateCalls == 2` | 22 |
| VM-17 | `settled.choices[key1Collection] == null` | 16 |
| VM-19 | `awaitLoaded()` 后 `stateCalls == 1` | 14 |

1. **中间帧**（VM-12 / VM-17，VM-11 概率更低）：`replaceReadyState` 先写 `loadState` 再写 `choices`，`combine` 的各源协程在 `Default` 上竞争，会发出「新列表 + 旧选择」的一帧。谓词只看列表字段，正好命中，随后对 `choices` 的断言失败。线上界面也会闪一下错误的进度。
2. **旧帧先满足谓词**（VM-08）：`reload()` 先同步清空 `choices` 再 launch 加载，「旧 Ready + 空选择」这一帧立刻满足 `!isLoading && choices.isEmpty() && mergeState != null`，加载协程还没调 `getMergeState`。
3. **虚拟时间被提前推进**（VM-19）：`runTest` 在测试体挂起等待外部线程时循环 `advanceUntilIdle()`（kotlinx-coroutines-test 1.11.0 `runTestCoroutineLegacy`）。`loadState` 变 Ready 的瞬间轮询协程已投递到测试调度器，而唤醒测试体要经过 `combine → stateIn → first` 多跳，轮询先跑了若干次。

## 修复

- `AbstractViewModel` 新增 `backgroundCoroutineContext` 构造参数（默认空，行为不变），测试可注入 `StandardTestDispatcher(testScheduler)`。
- `BangumiMergeViewModel` 把服务端状态与用户选择放进同一个 `MutableStateFlow` 一次更新：替换列表时与过滤后的选择同帧发布，`reload` 时加载态与清空选择同帧发布。原先的 `pollCoroutineContext` 参数由 `backgroundCoroutineContext` 取代。
- 测试把 ViewModel 与 `BangumiConflictChecker` 都放到 `runTest` 的调度器上，删掉切到 `Dispatchers.Default` 的真实线程等待（`awaitReal`）。所有协程在单线程上按确定顺序交替执行。

## 验证

- `:app:shared:desktopTest --tests "me.him188.ani.app.ui.bangumi.merge.*"` 全部通过（含 screenshot / interaction / notifier 测试）。
- 修复后用同样的 300 次循环压力测试复跑，四处均 0 次失败（压力测试为临时文件，未提交）。
- `BangumiMergeViewModelTest` 连续 `--rerun` 5 次全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
