### PR TITLE
style(ui): 桌面端顶栏头像尺寸从 48dp 改为 40dp, 与图标按钮对齐

### DIFF
--- a/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniTopAppBar.kt
+++ b/app/shared/ui-adaptive/src/commonMain/kotlin/ui/adaptive/AniTopAppBar.kt
@@ -189,7 +189,7 @@ fun AniTopAppBar(
                         if (windowSizeClass.isWidthAtLeastMedium
                             && windowSizeClass.isHeightAtLeastMedium
                         ) {
-                            48.dp
+                            40.dp
                         } else {
                             36.dp
                         }


### PR DESCRIPTION
## 问题

首页 / 追番页右上角的头像在桌面端（窗口宽高均 ≥ Medium）使用 48dp，而旁边的搜索、设置按钮是标准的 Material 3 `IconButton`（容器 40dp，图标 24dp），头像看起来明显比其他按钮大一圈。

## 修改

- `AniTopAppBar` 中桌面 / 平板档的头像推荐尺寸从 48dp 改为 40dp，与 `IconButton` 的 40dp 容器对齐。
- 手机端（Compact）保持 36dp 不变。
- 外层的 `minimumInteractiveComponentSize` 仍然保证 48dp 的点击区域，只是视觉尺寸变小。
- 首页和追番页共用这个推荐尺寸回调，两处一起生效。

## 修改前后对比

使用 Compose 桌面截图测试渲染 `AniTopAppBar`（1200×500dp 窗口，2x density，已登录状态），截取右上角区域：

<img width="640" alt="顶栏头像修改前 48dp 与修改后 40dp 对比" src="https://github.com/user-attachments/assets/b6fc8d23-1be1-4283-86e2-459a1529596d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
