### PR TITLE
fix(subject): recreate subject details state on reload

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/state/SubjectDetailsStateLoader.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/state/SubjectDetailsStateLoader.kt
@@ -63,6 +63,7 @@ class SubjectDetailsStateLoader(
 
     fun clear() {
         tasker.cancel()
+        _state.value = null
     }
 
     fun reload(

--- a/app/shared/ui-subject/src/commonTest/kotlin/ui/subject/details/state/SubjectDetailsStateLoaderTest.kt
+++ b/app/shared/ui-subject/src/commonTest/kotlin/ui/subject/details/state/SubjectDetailsStateLoaderTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.ui.subject.details.state
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
+import me.him188.ani.app.data.models.subject.SubjectInfo
+import me.him188.ani.app.ui.subject.details.SubjectDetailsUIState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+
+class SubjectDetailsStateLoaderTest {
+    @Test
+    fun `state should be refreshed after reload`() = runTest {
+        val createdScopes = mutableListOf<CoroutineScope>()
+        val factory = object : SubjectDetailsStateFactory {
+            override fun create(subjectInfoFlow: Flow<SubjectInfo>): Flow<SubjectDetailsState> {
+                error("Not used")
+            }
+
+            override fun create(subjectInfo: SubjectInfo): Flow<SubjectDetailsState> {
+                error("Not used")
+            }
+
+            override fun create(
+                subjectId: Int,
+                placeholder: SubjectInfo?,
+            ): Flow<SubjectDetailsState> = flow {
+                // 和 DefaultSubjectDetailsStateFactory.create 结构保持一致
+                coroutineScope {
+                    createdScopes += this
+                    emit(createTestSubjectDetailsState(this))
+                    awaitCancellation()
+                }
+            }
+
+            override fun create(
+                subjectCollectionInfo: SubjectCollectionInfo,
+                scope: CoroutineScope,
+            ): SubjectDetailsState {
+                error("Not used")
+            }
+        }
+        val loader = createTestSubjectDetailsLoader(backgroundScope, factory)
+
+        loader.load(0)
+        runCurrent()
+
+        val oldValue = assertIs<SubjectDetailsUIState.Ok>(loader.state.value).value
+        val oldScope = createdScopes.single()
+        assertTrue(oldScope.isActive)
+
+        loader.reload(0)
+        runCurrent()
+
+        val newValue = assertIs<SubjectDetailsUIState.Ok>(loader.state.value).value
+        val newScope = createdScopes.last()
+        assertEquals(2, createdScopes.size)
+        assertNotSame(oldValue, newValue)
+        assertFalse(oldScope.isActive)
+        assertTrue(newScope.isActive)
+        assertTrue(backgroundScope.isActive)
+    }
+}


### PR DESCRIPTION
Closes #2766

## Summary

修复重新进入条目详情页后，收藏状态无法修改的问题。

`SubjectDetailsStateLoader` 会根据页面的`SubjectDetailsState`是否存在来决定是否启动收集`SubjectDetailsState`的任务，该任务包含收藏状态修改、评分、评论和各类 Flow 收集等；此前 `SubjectDetailsStateLoader.reload()` 会取消旧的加载任务及其 scope，但仍保留旧的 UI state，导致后续加载同一条目时命中缓存判断，继续使用 scope 已被取消的旧 State。

## Changes

- 在 `SubjectDetailsStateLoader.clear()` 中同时清除当前 UI state。
- 确保 `reload()` 创建新的 `SubjectDetailsState` 及其关联 scope。
- 添加 `SubjectDetailsStateLoaderTest` 回归测试，验证 reload 后：
  - 旧 State 的 scope 已取消；
  - 创建了新的 State 和 scope；
  - 新 scope 与 Loader 的外层 scope 保持 active。

## Testing

### Automated test

```text
./gradlew :app:shared:ui-subject:testAndroidHostTest \
  --tests "me.him188.ani.app.ui.subject.details.state.SubjectDetailsStateLoaderTest"

BUILD SUCCESSFUL
```

### Manual verification

修改收藏状态出现的场景有以下3处，均做了回归验证：

- 普通独立番剧详情页
  - 修改收藏状态正常。
  - 进入播放页面后返回，修改收藏状态正常。

- 搜索页番剧详情侧栏
  - 点击番剧 A，状态显示及修改正常。
  - 重复点击番剧 A，状态刷新正常。
  - 点击番剧 B 后重新点击番剧 A，状态刷新正常。

- 播放页标题 Bottom Sheet
  - 状态显示及修改正常。
  - 多次关闭并重新打开 Bottom Sheet，状态显示及修改正常。
