### PR TITLE
refactor(selector): optimize search content negotiation

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorHttpHeaders.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorHttpHeaders.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.web
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.accept
+import io.ktor.http.ContentType
+import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatId
+import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatJsonPathIndexed
+
+internal fun HttpRequestBuilder.acceptSelectorSearch(subjectFormatId: SelectorFormatId) {
+    if (subjectFormatId == SelectorSubjectFormatJsonPathIndexed.id) {
+        accept(ContentType.Application.Json)
+        // JSON 搜索接口也可能返回 HTML 验证页, 交给现有验证码流程处理.
+        accept(ContentType.Text.Html.withParameter("q", "0.9"))
+    } else {
+        accept(ContentType.Text.Html)
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/SelectorMediaSourceEngine.kt
@@ -37,7 +37,9 @@ import me.him188.ani.app.domain.mediasource.asCandidate
 import me.him188.ani.app.domain.mediasource.web.format.SelectedChannelEpisodes
 import me.him188.ani.app.domain.mediasource.web.format.SelectorChannelFormat
 import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatConfig
+import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatId
 import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormat
+import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatA
 import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.Media
@@ -110,6 +112,7 @@ abstract class SelectorMediaSourceEngine {
 
     /**
      * 根据给定信息搜索条目列表.
+     * @param subjectFormatId 搜索结果格式, 用于请求相应的响应类型.
      */
     @Throws(RepositoryException::class, CancellationException::class)
     suspend fun searchSubjects(
@@ -117,6 +120,7 @@ abstract class SelectorMediaSourceEngine {
         subjectName: String,
         useOnlyFirstWord: Boolean,
         removeSpecial: Boolean,
+        subjectFormatId: SelectorFormatId = SelectorSubjectFormatA.id,
     ): SearchSubjectResult {
         val encodedUrl = MediaSourceEngineHelpers.encodeUrlSegment(
             MediaSourceEngineHelpers.getSearchKeyword(subjectName, removeSpecial, useOnlyFirstWord),
@@ -126,7 +130,7 @@ abstract class SelectorMediaSourceEngine {
             searchUrl.replace("{keyword}", encodedUrl),
         )
 
-        return searchImpl(finalUrl)
+        return searchImpl(finalUrl, subjectFormatId)
     }
 
     fun parseSearchResult(
@@ -154,6 +158,7 @@ abstract class SelectorMediaSourceEngine {
     @Throws(RepositoryException::class, CancellationException::class)
     protected abstract suspend fun searchImpl(
         finalUrl: Url,
+        subjectFormatId: SelectorFormatId,
     ): SearchSubjectResult
 
     /**
@@ -404,11 +409,12 @@ class DefaultSelectorMediaSourceEngine(
 ) : SelectorMediaSourceEngine() {
     override suspend fun searchImpl(
         finalUrl: Url,
+        subjectFormatId: SelectorFormatId,
     ): SearchSubjectResult = withContext(ioDispatcher) {
         try {
             client.use {
                 prepareGet(finalUrl) {
-                    accept(ContentType.Text.Html)
+                    acceptSelectorSearch(subjectFormatId)
                 }.execute { response ->
                     when (response.status) {
                         HttpStatusCode.NotFound -> SearchSubjectResult(

--- a/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/captcha/WebSessionManager.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/mediasource/web/captcha/WebSessionManager.kt
@@ -47,6 +47,7 @@ import me.him188.ani.app.domain.mediasource.web.PageEvaluator
 import me.him188.ani.app.domain.mediasource.web.PageExpectation
 import me.him188.ani.app.domain.mediasource.web.PageVerdict
 import me.him188.ani.app.domain.mediasource.web.SolveRequest
+import me.him188.ani.app.domain.mediasource.web.acceptSelectorSearch
 import me.him188.ani.app.domain.mediasource.web.normalizedSessionHost
 import me.him188.ani.app.domain.mediasource.web.normalizedStorageOrigin
 import me.him188.ani.utils.coroutines.IO_
@@ -213,7 +214,7 @@ class WebSessionManager(
             }
         }
 
-        val page = httpFetch(url)
+        val page = httpFetch(url, expectation)
         val verdict = evaluator.evaluate(page, expectation)
         if (verdict !is PageVerdict.Blocked || verdict.reason !is BlockReason.Captcha || host == null) {
             return verdict
@@ -321,11 +322,15 @@ class WebSessionManager(
         return pageHost == host || pageHost.endsWith(".$host") || host.endsWith(".$pageHost")
     }
 
-    private suspend fun httpFetch(url: String): LoadedPage = withContext(ioContext) {
+    private suspend fun httpFetch(url: String, expectation: PageExpectation<*>): LoadedPage = withContext(ioContext) {
         try {
             client.use {
                 prepareGet(url) {
-                    accept(ContentType.Text.Html)
+                    if (expectation is PageExpectation.SearchResults) {
+                        acceptSelectorSearch(expectation.config.subjectFormatId)
+                    } else {
+                        accept(ContentType.Text.Html)
+                    }
                 }.execute { response ->
                     response.toLoadedPage()
                 }

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/DefaultSelectorMediaSourceEngineContentNegotiationTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/DefaultSelectorMediaSourceEngineContentNegotiationTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.mediasource.web
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.domain.mediasource.web.format.SelectorChannelFormatNoChannel
+import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatA
+import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatJsonPathIndexed
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DefaultSelectorMediaSourceEngineContentNegotiationTest {
+    private val jsonConfig = SelectorSearchConfig(
+        searchUrl = "https://example.com/search?keyword={keyword}",
+        rawBaseUrl = "https://example.com/subjects/",
+        subjectFormatId = SelectorSubjectFormatJsonPathIndexed.id,
+        selectorSubjectFormatJsonPathIndexed = SelectorSubjectFormatJsonPathIndexed.Config(
+            selectNames = "$[*].title",
+            selectLinks = "$[*].id",
+        ),
+        selectorChannelFormatNoChannel = SelectorChannelFormatNoChannel.Config(selectEpisodes = ".episodes a"),
+    )
+
+    private fun createEngine(handler: MockRequestHandler): DefaultSelectorMediaSourceEngine {
+        val client = HttpClient(MockEngine(handler)) {
+            expectSuccess = true
+        }
+        return DefaultSelectorMediaSourceEngine(client.asScopedHttpClient(), EmptyCoroutineContext)
+    }
+
+    @Test
+    fun `json search negotiates JSON and resolves numeric subject ids`() = runTest {
+        val engine = createEngine { request ->
+            val acceptsJson = request.headers.getAll(HttpHeaders.Accept).orEmpty()
+                .flatMap { it.split(',') }
+                .any { ContentType.parse(it).withoutParameters() == ContentType.Application.Json }
+            if (acceptsJson) {
+                respond(
+                    """[{"id":123,"title":"Example Subject"}]""",
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            } else {
+                respond("JSON response required", HttpStatusCode.NotAcceptable)
+            }
+        }
+
+        val result = engine.searchSubjects(
+            searchUrl = jsonConfig.searchUrl,
+            subjectName = "Example Subject",
+            useOnlyFirstWord = false,
+            removeSpecial = false,
+            subjectFormatId = jsonConfig.subjectFormatId,
+        )
+        val subject = assertNotNull(engine.selectSubjects(assertNotNull(result.document), jsonConfig)).single()
+
+        assertNull(result.captchaKind)
+        assertEquals("Example Subject", subject.name)
+        assertEquals("123", subject.internalId)
+        assertEquals("https://example.com/subjects/123", subject.fullUrl)
+    }
+
+    @Test
+    fun `json search still accepts and detects HTML captcha pages`() = runTest {
+        val engine = createEngine { request ->
+            assertEquals(
+                listOf("application/json", "text/html; q=0.9"),
+                request.headers.getAll(HttpHeaders.Accept),
+            )
+            respond(
+                "<html><body><div class=\"cf-turnstile\"></div></body></html>",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()),
+            )
+        }
+
+        val result = engine.searchSubjects(
+            searchUrl = jsonConfig.searchUrl,
+            subjectName = "test",
+            useOnlyFirstWord = false,
+            removeSpecial = false,
+            subjectFormatId = jsonConfig.subjectFormatId,
+        )
+
+        assertEquals(WebCaptchaKind.CloudflareTurnstile, result.captchaKind)
+        assertNull(result.document)
+    }
+
+    @Test
+    fun `default search keeps HTML accept and parses subjects`() = runTest {
+        val engine = createEngine { request ->
+            assertEquals(listOf("text/html"), request.headers.getAll(HttpHeaders.Accept))
+            respond(
+                """<html><body><a class="subject" href="/subjects/123">Example Subject</a></body></html>""",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()),
+            )
+        }
+        val config = SelectorSearchConfig(
+            searchUrl = jsonConfig.searchUrl,
+            selectorSubjectFormatA = SelectorSubjectFormatA.Config(selectLists = "a.subject"),
+        )
+
+        val result = engine.searchSubjects(config.searchUrl, "test", useOnlyFirstWord = false, removeSpecial = false)
+        val subject = assertNotNull(engine.selectSubjects(assertNotNull(result.document), config)).single()
+
+        assertEquals("Example Subject", subject.name)
+        assertEquals("https://example.com/subjects/123", subject.fullUrl)
+    }
+
+    @Test
+    fun `subject details keep HTML accept with JSON search config`() = runTest {
+        val engine = createEngine { request ->
+            assertEquals(listOf("text/html"), request.headers.getAll(HttpHeaders.Accept))
+            respond(
+                """<html><body><div class="episodes"><a href="/play/123/1">第1集</a></div></body></html>""",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()),
+            )
+        }
+        val subjectUrl = "https://example.com/subjects/123"
+
+        val document = assertNotNull(engine.searchEpisodes(subjectUrl))
+        val episode = assertNotNull(engine.selectEpisodes(document, subjectUrl, jsonConfig)).episodes.single()
+
+        assertEquals(EpisodeSort(1), episode.episodeSortOrEp)
+        assertEquals("https://example.com/play/123/1", episode.playUrl)
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/captcha/WebSessionManagerTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/mediasource/web/captcha/WebSessionManagerTest.kt
@@ -15,6 +15,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
@@ -40,7 +42,12 @@ import me.him188.ani.app.domain.mediasource.web.PageVerdict
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.SolveRequest
 import me.him188.ani.app.domain.mediasource.web.WebCaptchaKind
+import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
+import me.him188.ani.app.domain.mediasource.web.format.SelectedChannelEpisodes
+import me.him188.ani.app.domain.mediasource.web.format.SelectorChannelFormatNoChannel
 import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatIndexed
+import me.him188.ani.app.domain.mediasource.web.format.SelectorSubjectFormatJsonPathIndexed
+import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.utils.ktor.asScopedHttpClient
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
@@ -79,18 +86,19 @@ class WebSessionManagerTest {
     private class Fixture(
         scope: TestScope,
         solvers: List<CaptchaSolver> = emptyList(),
-        var httpResponder: (url: String) -> Pair<String, HttpStatusCode> = { "" to HttpStatusCode.OK },
+        contentType: ContentType = ContentType.Text.Html,
+        var httpResponder: (HttpRequestData) -> Pair<String, HttpStatusCode> = { "" to HttpStatusCode.OK },
     ) {
         val factory = FakeCaptchaBrowserFactory()
         val cookieJar = WebSourceCookieJar()
         val identityRegistry = WebSourceIdentityRegistry()
         val client = HttpClient(
             MockEngine { request ->
-                val (content, status) = httpResponder(request.url.toString())
+                val (content, status) = httpResponder(request)
                 respond(
                     content = content,
                     status = status,
-                    headers = headersOf(HttpHeaders.ContentType, "text/html; charset=utf-8"),
+                    headers = headersOf(HttpHeaders.ContentType, "$contentType; charset=utf-8"),
                 )
             },
         ) {
@@ -353,12 +361,81 @@ class WebSessionManagerTest {
     // 直连正常时不碰浏览器
     @Test
     fun `direct http ok does not touch browser`() = runTestExt {
-        val fixture = Fixture(this) { _ -> parseableHtml to HttpStatusCode.OK }
+        val fixture = Fixture(this) { request ->
+            assertEquals(listOf("text/html"), request.headers.getAll(HttpHeaders.Accept))
+            parseableHtml to HttpStatusCode.OK
+        }
 
         val verdict = fixture.manager.fetchPage(searchUrl, expectation)
 
         assertIs<PageVerdict.Ok<*>>(verdict)
         assertEquals(0, fixture.factory.createCount)
+    }
+
+    @Test
+    fun `JSON search negotiates JSON and resolves numeric subject ids without browser`() = runTestExt {
+        val fixture = Fixture(this, contentType = ContentType.Application.Json) { request ->
+            val acceptsJson = request.headers.getAll(HttpHeaders.Accept).orEmpty()
+                .flatMap { it.split(',') }
+                .any { ContentType.parse(it).withoutParameters() == ContentType.Application.Json }
+            if (acceptsJson) {
+                """[{"id":123,"title":"Example Subject"}]""" to HttpStatusCode.OK
+            } else {
+                "JSON response required" to HttpStatusCode.NotAcceptable
+            }
+        }
+        val config = searchConfig.copy(
+            rawBaseUrl = "https://example.com/subjects/",
+            subjectFormatId = SelectorSubjectFormatJsonPathIndexed.id,
+            selectorSubjectFormatJsonPathIndexed = SelectorSubjectFormatJsonPathIndexed.Config(
+                selectNames = "$[*].title",
+                selectLinks = "$[*].id",
+            ),
+        )
+
+        val verdict = fixture.manager.fetchPage(searchUrl, PageExpectation.SearchResults(config))
+        val subject = assertIs<PageVerdict.Ok<List<WebSearchSubjectInfo>>>(verdict).value.single()
+
+        assertEquals("Example Subject", subject.name)
+        assertEquals("123", subject.internalId)
+        assertEquals("https://example.com/subjects/123", subject.fullUrl)
+        assertEquals(0, fixture.factory.createCount)
+    }
+
+    @Test
+    fun `JSON search still accepts and detects HTML captcha pages`() = runTestExt {
+        val fixture = Fixture(this) { request ->
+            assertEquals(
+                listOf("application/json", "text/html; q=0.9"),
+                request.headers.getAll(HttpHeaders.Accept),
+            )
+            challengeHtml to HttpStatusCode.Forbidden
+        }
+        val config = searchConfig.copy(subjectFormatId = SelectorSubjectFormatJsonPathIndexed.id)
+
+        val verdict = fixture.manager.fetchPage(searchUrl, PageExpectation.SearchResults(config))
+
+        assertEquals(BlockReason.Captcha(WebCaptchaKind.Cloudflare), assertIs<PageVerdict.Blocked>(verdict).reason)
+    }
+
+    @Test
+    fun `subject details keep HTML accept with JSON search config`() = runTestExt {
+        val fixture = Fixture(this) { request ->
+            assertEquals(listOf("text/html"), request.headers.getAll(HttpHeaders.Accept))
+            """<html><body><div class="episodes"><a href="/play/123/1">第1集</a></div></body></html>""" to
+                    HttpStatusCode.OK
+        }
+        val config = searchConfig.copy(
+            subjectFormatId = SelectorSubjectFormatJsonPathIndexed.id,
+            selectorChannelFormatNoChannel = SelectorChannelFormatNoChannel.Config(selectEpisodes = ".episodes a"),
+        )
+        val subjectUrl = "https://example.com/subjects/123"
+
+        val verdict = fixture.manager.fetchPage(subjectUrl, PageExpectation.SubjectDetails(config, subjectUrl))
+        val episode = assertIs<PageVerdict.Ok<SelectedChannelEpisodes>>(verdict).value.episodes.single()
+
+        assertEquals(EpisodeSort(1), episode.episodeSortOrEp)
+        assertEquals("https://example.com/play/123/1", episode.playUrl)
     }
 
     // 手动确认 (✓): 以当前页面判决为准

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/mediasource/selector/test/SelectorTestPane.kt
@@ -67,6 +67,7 @@ import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
 import me.him188.ani.app.domain.mediasource.web.SolveRequest
 import me.him188.ani.app.domain.mediasource.web.WebSearchSubjectInfo
+import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatId
 import me.him188.ani.app.domain.mediasource.web.displayName
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.animation.LocalAniMotionScheme
@@ -364,7 +365,8 @@ fun PreviewSelectorTestPane() = ProvideCompositionLocalsForPreview {
 @TestOnly
 class TestSelectorMediaSourceEngine : SelectorMediaSourceEngine() {
     override suspend fun searchImpl(
-        finalUrl: Url
+        finalUrl: Url,
+        subjectFormatId: SelectorFormatId,
     ): SearchSubjectResult {
         return SearchSubjectResult(
             Url("https://example.com"),

--- a/tools/datasource-test-mcp/src/test/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorWebVideoMatcherTest.kt
+++ b/tools/datasource-test-mcp/src/test/kotlin/me/him188/ani/tools/datasourcetestmcp/selector/SelectorWebVideoMatcherTest.kt
@@ -12,6 +12,7 @@ package me.him188.ani.tools.datasourcetestmcp.selector
 import io.ktor.http.Url
 import me.him188.ani.app.domain.mediasource.web.SelectorMediaSourceEngine
 import me.him188.ani.app.domain.mediasource.web.SelectorSearchConfig
+import me.him188.ani.app.domain.mediasource.web.format.SelectorFormatId
 import me.him188.ani.datasources.api.matcher.WebViewConfig
 import me.him188.ani.utils.xml.Document
 import kotlin.test.Test
@@ -23,7 +24,7 @@ import kotlin.test.assertEquals
  */
 class SelectorWebVideoMatcherTest {
     private val engine = object : SelectorMediaSourceEngine() {
-        override suspend fun searchImpl(finalUrl: Url): SearchSubjectResult =
+        override suspend fun searchImpl(finalUrl: Url, subjectFormatId: SelectorFormatId): SearchSubjectResult =
             throw UnsupportedOperationException()
 
         override suspend fun doHttpGet(uri: String): Document =


### PR DESCRIPTION
Choose the search request's `Accept` header from the configured selector format. JSONPath searches prefer `application/json` and also accept HTML challenge pages; HTML searches and detail requests keep their existing headers. The direct engine and `WebSessionManager` share the same policy.

Regression coverage includes JSON content negotiation, numeric subject IDs, HTML challenge handling, and existing HTML search/detail parsing.

Validation:

- `:app:shared:app-data:desktopTest`: 1,144 passed, 5 skipped.
- `:tools:datasource-test-mcp:test`: 57 passed.
- `:app:shared:ui-settings:compileKotlinDesktop`: passed.