### PR TITLE
fix(downloader): 流式下载 segment, 避免整个视频读入内存导致 OOM 崩溃

### DIFF
--- a/utils/http-downloader/src/commonMain/kotlin/KtorHttpDownloader.kt
+++ b/utils/http-downloader/src/commonMain/kotlin/KtorHttpDownloader.kt
@@ -865,18 +865,22 @@ open class KtorHttpDownloader(
         logger.info { "Downloading segment index=${segmentInfo.index}, range=(${segmentInfo.rangeStart}-${segmentInfo.rangeEnd})" }
 
         return httpGet(segmentInfo.url, finalOptions) { statement ->
-            val response = statement.execute()
-            val segmentPath = baseSaveDir.resolve(segmentInfo.relativeTempFilePath)
-            withContext(ioDispatcher) {
-                fileSystem.createDirectories(
-                    segmentPath.parent ?: error("Parent dir not found for segmentInfo: $segmentInfo"),
-                )
-            }
+            // 必须使用流式的 execute { }: 无参数的 execute() 会把整个 response body 读进一个
+            // ByteArray. 当服务器不支持 range 请求时 segment 没有大小上限, 一个几百 MB 的视频
+            // 会直接撑爆堆内存.
+            statement.execute { response ->
+                val segmentPath = baseSaveDir.resolve(segmentInfo.relativeTempFilePath)
+                withContext(ioDispatcher) {
+                    fileSystem.createDirectories(
+                        segmentPath.parent ?: error("Parent dir not found for segmentInfo: $segmentInfo"),
+                    )
+                }
 
-            val channel = response.bodyAsChannel()
-            val byteSize = copyChannelToFile(channel, segmentPath)
-            byteSize.also {
-                logger.info { "Segment index=${segmentInfo.index} downloaded, size=$it" }
+                val channel = response.bodyAsChannel()
+                val byteSize = copyChannelToFile(channel, segmentPath)
+                byteSize.also {
+                    logger.info { "Segment index=${segmentInfo.index} downloaded, size=$it" }
+                }
             }
         }
     }

--- a/utils/http-downloader/src/commonTest/kotlin/KtorHttpDownloaderTest.kt
+++ b/utils/http-downloader/src/commonTest/kotlin/KtorHttpDownloaderTest.kt
@@ -18,7 +18,10 @@ import io.ktor.client.request.HttpResponseData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.core.readAvailable
+import io.ktor.utils.io.writeByteArray
+import io.ktor.utils.io.writer
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -75,6 +78,7 @@ class KtorHttpDownloaderTest {
     private var lastFfmpegArgs: List<String>? = null
     private var lastInputPlaylistContent: String? = null
     private var forceFfmpegFailure = false
+    private var partFileBytesWhenBodySent = -1L
 
     // We use this to track how many times a given URL has been requested.
     // This allows us to simulate "fails first time, succeeds second time", etc.
@@ -100,6 +104,7 @@ class KtorHttpDownloaderTest {
         lastFfmpegArgs = null
         lastInputPlaylistContent = null
         forceFfmpegFailure = false
+        partFileBytesWhenBodySent = -1L
 
         // Create mock client with preset responses
         mockClient = HttpClient(MockEngine) {
@@ -218,6 +223,33 @@ class KtorHttpDownloaderTest {
                             )
                         }
 
+                        "https://example.com/streaming-no-range.mp4" -> {
+                            // A server that does not support range requests and streams its body
+                            // lazily, like a real video CDN. The downloader must consume the body
+                            // as a stream; it must not buffer the whole file in memory first.
+                            if (request.headers[HttpHeaders.Range] != null) {
+                                // Range probe: answer 200 so that range support is not detected,
+                                // which makes the downloader create one single unbounded segment.
+                                respond(
+                                    content = ByteArray(1),
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(
+                                        HttpHeaders.ContentType to listOf("video/mp4"),
+                                        HttpHeaders.ContentLength to listOf("$STREAMING_FILE_SIZE"),
+                                    ),
+                                )
+                            } else {
+                                respond(
+                                    content = lazilyProducedBody(),
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(
+                                        HttpHeaders.ContentType to listOf("video/mp4"),
+                                        HttpHeaders.ContentLength to listOf("$STREAMING_FILE_SIZE"),
+                                    ),
+                                )
+                            }
+                        }
+
                         "https://example.com/unstable-playlist1.m3u8" -> {
                             // Fails the first time (attempt==1 => 500), succeeds second time => return a valid playlist
                             if (currentAttempt == 0) {
@@ -334,6 +366,27 @@ class KtorHttpDownloaderTest {
                 return FFmpegResult(exitCode = 0)
             }
         }
+    }
+
+    /**
+     * Produces [STREAMING_FILE_SIZE] bytes chunk by chunk, and records in
+     * [partFileBytesWhenBodySent] how many bytes the downloader had already flushed to its
+     * `.part` file by the time the whole body had been handed to the client.
+     *
+     * A streaming consumer writes to disk while the body is still arriving, so the recorded value
+     * is > 0. A consumer that buffers the whole response in memory first has not even created the
+     * `.part` file at that point, so the recorded value stays 0.
+     */
+    private fun lazilyProducedBody(): ByteReadChannel {
+        val chunk = ByteArray(STREAMING_CHUNK_SIZE) { it.toByte() }
+        return CoroutineScope(testDispatcher + SupervisorJob()).writer {
+            repeat((STREAMING_FILE_SIZE / STREAMING_CHUNK_SIZE).toInt()) {
+                channel.writeByteArray(chunk)
+                channel.flush()
+            }
+            partFileBytesWhenBodySent =
+                fileSystem.metadataOrNull(Path("$tempDir/segments_streaming-no-range/0.part"))?.size ?: 0L
+        }.channel
     }
 
     // Helper to handle MP4 partial or full
@@ -994,6 +1047,29 @@ class KtorHttpDownloaderTest {
     }
 
     @Test
+    fun `download - segment body is streamed to disk instead of buffered in memory`() = testScope.runTest {
+        val downloadId = downloader.downloadWithId(
+            url = "https://example.com/streaming-no-range.mp4",
+            downloadId = DownloadId("streaming-no-range"),
+        )?.downloadId
+        assertNotNull(downloadId)
+        downloader.joinDownload(downloadId)
+
+        assertEquals(DownloadStatus.COMPLETED, downloader.getState(downloadId)?.status)
+        assertEquals(
+            STREAMING_FILE_SIZE,
+            fileSystem.metadata(Path("$tempDir/streaming-no-range.mp4")).size,
+        )
+
+        assertNotEquals(-1L, partFileBytesWhenBodySent, "The streaming body was never produced.")
+        assertTrue(
+            partFileBytesWhenBodySent > 0,
+            "The whole response body was buffered in memory before anything was written to disk. " +
+                    "A single allocation of the full file size OOMs on large videos.",
+        )
+    }
+
+    @Test
     fun `download - should create multiple segments for mp4 file`() = testScope.runTest {
         // Set a small max concurrent segments value to ensure multiple segments are created
         val options = DownloadOptions(maxConcurrentSegments = 3)
@@ -1406,6 +1482,10 @@ class KtorHttpDownloaderTest {
         // File sizes for testing regular media files
         private const val MP4_FILE_SIZE = 10 * 1024 * 1024L // 10MB
         private const val MKV_FILE_SIZE = 15 * 1024 * 1024L // 15MB
+
+        // A body streamed chunk by chunk, used to assert that responses are not fully buffered.
+        private const val STREAMING_CHUNK_SIZE = 64 * 1024 // 64KB
+        private const val STREAMING_FILE_SIZE = 4 * 1024 * 1024L // 4MB
     }
 
     private class TestClock(private val scheduler: TestCoroutineScheduler) : Clock {


### PR DESCRIPTION
## 问题

Android 上缓存视频时会频繁 OOM 崩溃, 崩溃后重启会自动恢复缓存任务, 形成崩溃循环.

`KtorHttpDownloader.downloadSingleSegment` 使用了 Ktor 无参数的 `HttpStatement.execute()`:

```kotlin
val response = statement.execute()
...
val channel = response.bodyAsChannel()
val byteSize = copyChannelToFile(channel, segmentPath)
```

看起来是流式写盘, 实际不是. Ktor 3.1.1 中这个重载会走 `fetchResponse()` → `HttpClientCall.save()`, 而 `save()` 是 `response.rawContent.readRemaining().readByteArray()` —— **整个 response body 被读进一个 ByteArray**. 后面的 `bodyAsChannel()` 只是在这份已经完全驻留内存的副本上再读一遍, `copyChannelToFile` 的流式写盘没有起到任何作用.

放大这个问题的是 segment 的切分策略: `createSegments` 只有在服务器**支持 range 请求**时才按 5MB 切块; 当 range 探测失败或返回 200 时 (`KtorHttpDownloader.kt:754`), 会生成一个 `rangeStart` / `rangeEnd` 均为 null 的**无上限 segment**, 于是整个视频文件被一次性分配.

Android 堆上限 512MB, 一个 440MB 的 mp4 直接触发:

```
INFO  u.h.KtorHttpDownloader  Downloading 1 segments for <cacheId> with concurrency=3
INFO  u.h.KtorHttpDownloader  Downloading segment index=0, range=(null-null)
INFO  u.h.KtorHttpDownloader  Segment download failed on attempt 1/100: Failed to allocate a
      462077112 byte allocation with 5688672 free bytes and 5555KB until OOM,
      target footprint 536870912, growth limit 536870912. Retrying after 1000ms...
```

462077112 字节正好是该文件的大小, 一次性分配.

真正导致崩溃的是**放大效应**: `withRetry` catch 的是 `Throwable` (因此连 `OutOfMemoryError` 一起重试), `maxRetriesPerSegment` 默认 100. 堆被长期顶在 OOM 边缘, 最终由一个**无关线程上的 32 字节分配**失败引爆:

```
ERROR a.AniApplication  !!!ANI FATAL EXCEPTION!!! (java.lang.OutOfMemoryError:
      Failed to allocate a 32 byte allocation with 2612544 free bytes ...)
  at kotlinx.coroutines.CancellableContinuationImpl.resumedState
  at kotlinx.coroutines.EventLoopImplBase$DelayedResumeTask.run
  at kotlinx.coroutines.DefaultExecutor.run
```

重启后 `Restored 3 downloads from DataStore` 恢复缓存任务, 同样的 462MB 分配再次出现 —— 崩溃循环.

## 复现

从**不支持 range 请求**的媒体源缓存一集较大的单文件 mp4, 下载开始后不久 App 即 OOM 崩溃, 且每次重启都会再次崩溃.

## 修改

改用流式的 `execute { }` 重载, 响应体边下载边写入 `.part` 文件, 内存占用回到 `DEFAULT_BUFFER_SIZE` 级别. 全仓库仅此一处使用无参数 `execute()`.

## 测试

新增回归测试 `download - segment body is streamed to disk instead of buffered in memory`: mock 服务器对 range 探测返回 200 (不支持 range), 随后按 64KB 分块吐出 4MB body, 并在 body 发送完毕的时刻记录 `.part` 文件已写入的字节数.

- 流式实现: body 还在传输时就已经在写盘, 记录值 > 0 —— 通过
- 缓冲整个响应的实现: 此时连 `.part` 文件都还没创建, 记录值为 0 —— 失败, 报 `The whole response body was buffered in memory before anything was written to disk.`

修改前该测试失败, 修改后 `desktopTest` 与 `testAndroidHostTest` 均 35/35 通过.

## 备注

`withRetry` (`KtorHttpDownloader.kt:1159`) catch `Throwable` 会把 `Error` 也一起重试, 从而把一次失败放大成持续的崩溃循环. 本 PR 未改动这里, 如有需要可另开 PR 收窄为 `Exception`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
